### PR TITLE
Infer event types

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "serve": "^11.3.0",
     "start-server-and-test": "^1.11.0",
     "styled-components": "^4.2.0",
-    "typescript": "^3.8.3",
+    "typescript": "4.1.2",
     "use-count-up": "^2.2.5",
     "wcag-contrast": "^3.0.0"
   },

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -98,7 +98,7 @@ export default function Modal({
     leave: { opacity: 0 }
   })
 
-  const [{ y }, set] = useSpring(() => ({ y: 0, config: { mass: 1, tension: 210, friction: 20 } }))
+  const [{ y }, set] = useSpring<{ y: number }>(() => ({ y: 0, config: { mass: 1, tension: 210, friction: 20 } }))
   const bind = useGesture({
     onDrag: state => {
       set({
@@ -120,7 +120,7 @@ export default function Modal({
                 {...(isMobile
                   ? {
                       ...bind(),
-                      style: { transform: y.interpolate(y => `translateY(${y > 0 ? y : 0}px)`) }
+                      style: { transform: y.interpolate<string>((y: number) => `translateY(${y > 0 ? y : 0}px)`) }
                     }
                   : {})}
                 aria-label="dialog content"

--- a/src/connectors/Fortmatic.ts
+++ b/src/connectors/Fortmatic.ts
@@ -27,7 +27,7 @@ export class FortmaticConnector extends FortmaticConnectorCore {
 
     const provider = this.fortmatic.getProvider()
 
-    const pollForOverlayReady = new Promise(resolve => {
+    const pollForOverlayReady = new Promise<void>(resolve => {
       const interval = setInterval(() => {
         if (provider.overlayReady) {
           clearInterval(interval)

--- a/src/custom/state/orders/updater.tsx
+++ b/src/custom/state/orders/updater.tsx
@@ -6,6 +6,7 @@ import { AppDispatch, AppState } from 'state'
 import { removeOrder } from './actions'
 import { utils } from 'ethers'
 import { Log } from '@ethersproject/abstract-provider'
+import { EventObject } from 'types'
 
 // first iteration -- checking on each block
 // ideally we would check agains backend orders from last session, only once, on page load
@@ -66,8 +67,14 @@ const TransferEvent = ERC20Interface.getEvent('Transfer')
 
 const TransferEventTopics = ERC20Interface.encodeFilterTopics(TransferEvent, [])
 
-const decodeTransferEvent = (transferEventLog: Log) => {
-  return ERC20Interface.decodeEventLog(TransferEvent, transferEventLog.data, transferEventLog.topics)
+type TransferEventParams = EventObject<typeof transferEventAbi>['params']
+
+const decodeTransferEvent = (transferEventLog: Log): TransferEventParams => {
+  return (ERC20Interface.decodeEventLog(
+    TransferEvent,
+    transferEventLog.data,
+    transferEventLog.topics
+  ) as unknown) as TransferEventParams
 }
 
 export function EventUpdater(): null {

--- a/src/custom/types.ts
+++ b/src/custom/types.ts
@@ -1,3 +1,44 @@
+import { BigNumber } from '@ethersproject/bignumber'
+
 export interface WithClassName {
   className?: string
 }
+
+export type Split<S extends string, D extends string> =
+    string extends S ? string[] :
+    S extends '' ? [] :
+    S extends `${infer T}${D}${infer U}` ? [T, ...Split<U, D>] :
+    [S];
+
+
+export type SimpleSolidityTypes = 'address' | 'string' | 'byte' | `bytes${number}` | `uint${number}` | 'uint' | 'bool'
+
+export type SolidityTypeToJS<T extends SimpleSolidityTypes> =
+    T extends 'address' | 'string' | 'byte' | `bytes${number}` ? string :
+    T extends `uint${number}` | 'uint' ? BigNumber :
+    T extends 'bool' ? boolean : never
+
+export type PossibleAbiTypeSignatures = `${SimpleSolidityTypes} indexed ${string}` | `${SimpleSolidityTypes} ${string}`
+
+type NoLessThan2Words = `${string} ${string}`
+
+export type ParamsSignature2Obj<T extends string> =
+    T extends `${infer Type} indexed ${infer Name}` ?
+    Name extends NoLessThan2Words ? never :
+    Type extends SimpleSolidityTypes ? {type: SolidityTypeToJS<Type>; indexed: true; name: Name} : never :
+    T extends `${infer Type} ${infer Name}` ?
+    Name extends NoLessThan2Words ? never :
+    Type extends SimpleSolidityTypes ? {type: SolidityTypeToJS<Type>; name: Name} : never
+    : never
+
+export type EventSignature2Objects<T extends string> = ParamsSignature2Obj<Split<T, ', '>[number]>
+
+
+export type EventParameters<T extends string> = {
+    [
+        K in EventSignature2Objects<T>
+        as K['name']
+    ]: K['type']
+}
+
+export type EventObject<T extends `event ${string}(${PossibleAbiTypeSignatures})`> = T extends `event ${infer Name}(${infer K})` ? {event: Name, params: EventParameters<K>} : never

--- a/yarn.lock
+++ b/yarn.lock
@@ -14912,10 +14912,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 ua-parser-js@^0.7.21:
   version "0.7.21"


### PR DESCRIPTION
With Typescript 4.1 it's possible to infer types from  string template

So given abi string `'event Transfer(address indexed from, address indexed to, uint amount)'` we can automatically infer 
```ts
interface TransferParams {
  from: string
  to: string
  amount: BigNumber
}
```

This PR

-  updates TS to latest
- fixes broken types (due to update)
- adds type inference from events (for simple types, not structs,nor arrays)