### PR TITLE
xDAI hack-around/chain switch

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,8 +5,11 @@ import { AbstractConnector } from '@web3-react/abstract-connector'
 import { fortmatic, injected, portis, walletconnect, walletlink } from '../connectors'
 
 // TODO: make chainId-dependant
-// export const ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
-export const ROUTER_ADDRESS = '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77'
+export const ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+export const ROUTER_ADDRESS_XDAI = '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77'
+export const getRouterAddress = (chainId?: ChainId) => {
+  return chainId === ChainId.XDAI ? ROUTER_ADDRESS_XDAI : ROUTER_ADDRESS
+}
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 

--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -1,10 +1,11 @@
 // the Uniswap Default token list lives here
 // TODO: make chainId-dependent
-// export const DEFAULT_TOKEN_LIST_URL = 'tokens.uniswap.eth'
-export const DEFAULT_TOKEN_LIST_URL = 'https://tokens.honeyswap.org'
+export const DEFAULT_TOKEN_LIST_URL = 'tokens.uniswap.eth'
+export const DEFAULT_TOKEN_LIST_URL_XDAI = 'https://tokens.honeyswap.org'
 
 export const DEFAULT_LIST_OF_LISTS: string[] = [
   DEFAULT_TOKEN_LIST_URL,
+  DEFAULT_TOKEN_LIST_URL_XDAI,
   't2crtokens.eth', // kleros
   'tokens.1inch.eth', // 1inch
   'synths.snx.eth',

--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -262,7 +262,8 @@ const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
   [ChainId.ROPSTEN]: 'Ropsten',
   [ChainId.GÖRLI]: 'Görli',
-  [ChainId.KOVAN]: 'Kovan'
+  [ChainId.KOVAN]: 'Kovan',
+  [ChainId.XDAI]: 'xDAI'
 }
 
 export default function HeaderMod(props: WithClassName) {

--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -266,6 +266,10 @@ const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.XDAI]: 'xDAI'
 }
 
+const CHAIN_CURRENCY_LABELS: { [chainId in ChainId]?: string } = {
+  [ChainId.XDAI]: 'XDAI'
+}
+
 export default function HeaderMod(props: WithClassName) {
   const { account, chainId } = useActiveWeb3React()
   const { t } = useTranslation()
@@ -377,7 +381,7 @@ export default function HeaderMod(props: WithClassName) {
           <AccountElement active={!!account} style={{ pointerEvents: 'auto' }}>
             {account && userEthBalance ? (
               <BalanceText style={{ flexShrink: 0 }} pl="0.75rem" pr="0.5rem" fontWeight={500}>
-                {userEthBalance?.toSignificant(4)} ETH
+                {userEthBalance?.toSignificant(4)} {chainId && (CHAIN_CURRENCY_LABELS[chainId] || 'ETH')}
               </BalanceText>
             ) : null}
             <Web3Status />

--- a/src/custom/xdai/index.ts
+++ b/src/custom/xdai/index.ts
@@ -102,23 +102,6 @@ Pair.getAddress = function getAddress(tokenA: Token, tokenB: Token): string {
 // used as UNI token
 export const HONEY_XDAI = new Token(ChainId.XDAI, '0x71850b7e9ee3f13ab46d67167341e4bdc905eef9', 18, 'HNY', 'Honey')
 
-export const USDC_XDAI = new Token(100, '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83', 6, 'USDC', 'USDC on xDai')
-
-export const WETH_XDAI = new Token(
-  ChainId.XDAI,
-  '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
-  18,
-  'WETH',
-  'Wrapped Ether on xDai'
-)
-export const STAKE = new Token(
-  ChainId.XDAI,
-  '0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e',
-  18,
-  'STAKE',
-  'Stake Token on xDai'
-)
-
 export const WXDAI = new Token(ChainId.XDAI, '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d', 18, 'WXDAI', 'Wrapped XDAI')
 
 // extends WETH to be used in Token Pairs logic

--- a/src/custom/xdai/index.ts
+++ b/src/custom/xdai/index.ts
@@ -5,7 +5,8 @@ import {
   Token,
   Pair,
   FACTORY_ADDRESS as FACTORY_ADDRESS_UNISWAP,
-  INIT_CODE_HASH as INIT_CODE_HASH_UNISWAP
+  INIT_CODE_HASH as INIT_CODE_HASH_UNISWAP,
+  ETHER
 } from '@uniswap/sdk'
 import { pack, keccak256 } from '@ethersproject/solidity'
 import { getCreate2Address } from '@ethersproject/address'
@@ -33,17 +34,34 @@ let currentChainId: ChainId | undefined
 // this is rather hacky but Pair.getAddress is used in new Pair(constructor)
 // so it happens rather often with no obvious place to pass in dynamic chainId
 export const switchXDAIparams = (chainId?: ChainId) => {
+  if (currentChainId === chainId) return
+
+  console.log('Changing library internal parameters for chainId', chainId)
+
   currentChainId = chainId
 
   if (chainId === ChainId.XDAI) {
     FACTORY_ADDRESS = FACTORY_ADDRESS_XDAI
     INIT_CODE_HASH = INIT_CODE_HASH_XDAI
 
+    // ETHER is used in a bunch of places
+    // Including internaly by the lib
+    // easier to change name+symbol
+    // @ts-expect-error
+    ETHER.name = 'xDai'
+    // @ts-expect-error
+    ETHER.symbol = 'XDAI'
+
     return
   }
 
   FACTORY_ADDRESS = FACTORY_ADDRESS_UNISWAP
   INIT_CODE_HASH = INIT_CODE_HASH_UNISWAP
+
+  // @ts-expect-error
+  ETHER.name = 'Ether'
+  // @ts-expect-error
+  ETHER.symbol = 'ETH'
 }
 
 // copy-pasta from the lib

--- a/src/custom/xdai/index.ts
+++ b/src/custom/xdai/index.ts
@@ -109,3 +109,9 @@ export const WETH = {
   ...WETH_UNISWAP,
   [ChainId.XDAI]: WXDAI
 }
+
+// library internally accesses its WETH mapping at ChainId passed from outside
+// breaks in Pair.involvesToken(WETH[chainId] == undefined)
+// so it can get ChainId.XDAI and would fail if not extended
+// @ts-expect-error
+WETH_UNISWAP[ChainId.XDAI] = WXDAI

--- a/src/custom/xdai/index.ts
+++ b/src/custom/xdai/index.ts
@@ -47,6 +47,7 @@ export const switchXDAIparams = (chainId?: ChainId) => {
     // ETHER is used in a bunch of places
     // Including internaly by the lib
     // easier to change name+symbol
+    // this way you seeXDAI in Token selector when on xDAI
     // @ts-expect-error
     ETHER.name = 'xDai'
     // @ts-expect-error
@@ -98,13 +99,7 @@ Pair.getAddress = function getAddress(tokenA: Token, tokenB: Token): string {
   return pairAddressCache[tokens[0].address][tokens[1].address]
 }
 
-// This may not be necessary
-// or even useless,because it's exported as
-// const ETHER = Currency.ETHER; export {ETHER}
-// in the lib
-//// @ts-expect-error
-// Currency.ETHER = new Currency(18, 'XDAI', 'xDai')
-
+// used as UNI token
 export const HONEY_XDAI = new Token(ChainId.XDAI, '0x71850b7e9ee3f13ab46d67167341e4bdc905eef9', 18, 'HNY', 'Honey')
 
 export const USDC_XDAI = new Token(100, '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83', 6, 'USDC', 'USDC on xDai')

--- a/src/custom/xdai/updater.ts
+++ b/src/custom/xdai/updater.ts
@@ -1,0 +1,11 @@
+import { useActiveWeb3React } from 'hooks'
+import { switchXDAIparams } from '.'
+
+export default function Updater(): null {
+  const { chainId } = useActiveWeb3React()
+
+  // sync update to not rely on useEffect timing
+  switchXDAIparams(chainId)
+
+  return null
+}

--- a/src/hooks/useApproveCallback.ts
+++ b/src/hooks/useApproveCallback.ts
@@ -2,7 +2,7 @@ import { MaxUint256 } from '@ethersproject/constants'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Trade, TokenAmount, CurrencyAmount, ETHER } from '@uniswap/sdk'
 import { useCallback, useMemo } from 'react'
-import { ROUTER_ADDRESS } from 'constants/index'
+import { getRouterAddress } from 'constants/index'
 import { useTokenAllowance } from '../data/Allowances'
 import { getTradeVersion, useV1TradeExchangeAddress } from '../data/V1'
 import { Field } from '../state/swap/actions'
@@ -101,11 +101,13 @@ export function useApproveCallback(
 
 // wraps useApproveCallback in the context of a swap
 export function useApproveCallbackFromTrade(trade?: Trade, allowedSlippage = 0) {
+  const { chainId } = useActiveWeb3React()
+
   const amountToApprove = useMemo(
     () => (trade ? computeSlippageAdjustedAmounts(trade, allowedSlippage)[Field.INPUT] : undefined),
     [trade, allowedSlippage]
   )
   const tradeIsV1 = getTradeVersion(trade) === Version.v1
   const v1ExchangeAddress = useV1TradeExchangeAddress(trade)
-  return useApproveCallback(amountToApprove, tradeIsV1 ? v1ExchangeAddress : ROUTER_ADDRESS)
+  return useApproveCallback(amountToApprove, tradeIsV1 ? v1ExchangeAddress : getRouterAddress(chainId))
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import { NetworkContextName } from './constants'
 import './i18n'
 import App from './pages/App'
 import store from 'state'
+import XDAIoverrideUpdater from 'xdai/updater'
 import ApplicationUpdater from './state/application/updater'
 import ListsUpdater from './state/lists/updater'
 import MulticallUpdater from './state/multicall/updater'
@@ -47,6 +48,8 @@ window.addEventListener('error', error => {
 function Updaters() {
   return (
     <>
+      {/* xDAI goes first to propagate updates first */}
+      <XDAIoverrideUpdater />
       <ListsUpdater />
       <UserUpdater />
       <ApplicationUpdater />

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -18,7 +18,7 @@ import { AddRemoveTabs } from '../../components/NavigationTabs'
 import { MinimalPositionCard } from '../../components/PositionCard'
 import Row, { RowBetween, RowFlat } from '../../components/Row'
 
-import { ROUTER_ADDRESS } from 'constants/index'
+import { getRouterAddress } from 'constants/index'
 import { PairState } from '../../data/Reserves'
 import { useActiveWeb3React } from '../../hooks'
 import { useCurrency } from '../../hooks/Tokens'
@@ -117,9 +117,11 @@ export default function AddLiquidity({
     {}
   )
 
+  const routerAddress = getRouterAddress(chainId)
+
   // check whether the user has approved the router on the tokens
-  const [approvalA, approveACallback] = useApproveCallback(parsedAmounts[Field.CURRENCY_A], ROUTER_ADDRESS)
-  const [approvalB, approveBCallback] = useApproveCallback(parsedAmounts[Field.CURRENCY_B], ROUTER_ADDRESS)
+  const [approvalA, approveACallback] = useApproveCallback(parsedAmounts[Field.CURRENCY_A], routerAddress)
+  const [approvalB, approveBCallback] = useApproveCallback(parsedAmounts[Field.CURRENCY_B], routerAddress)
 
   const addTransaction = useTransactionAdder()
 

--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -21,7 +21,7 @@ import Row, { RowBetween, RowFixed } from '../../components/Row'
 
 import Slider from '../../components/Slider'
 import CurrencyLogo from '../../components/CurrencyLogo'
-import { ROUTER_ADDRESS } from '../../constants'
+import { getRouterAddress } from '../../constants'
 import { useActiveWeb3React } from '../../hooks'
 import { useCurrency } from '../../hooks/Tokens'
 import { usePairContract } from '../../hooks/useContract'
@@ -99,9 +99,11 @@ export default function RemoveLiquidity({
   // pair contract
   const pairContract: Contract | null = usePairContract(pair?.liquidityToken?.address)
 
+  const routerAddress = getRouterAddress(chainId)
+
   // allowance handling
   const [signatureData, setSignatureData] = useState<{ v: number; r: string; s: string; deadline: number } | null>(null)
-  const [approval, approveCallback] = useApproveCallback(parsedAmounts[Field.LIQUIDITY], ROUTER_ADDRESS)
+  const [approval, approveCallback] = useApproveCallback(parsedAmounts[Field.LIQUIDITY], routerAddress)
 
   const isArgentWallet = useIsArgentWallet()
 
@@ -138,7 +140,7 @@ export default function RemoveLiquidity({
     ]
     const message = {
       owner: account,
-      spender: ROUTER_ADDRESS,
+      spender: routerAddress,
       value: liquidityAmount.raw.toString(),
       nonce: nonce.toHexString(),
       deadline: deadline.toNumber()

--- a/src/state/lists/reducer.test.ts
+++ b/src/state/lists/reducer.test.ts
@@ -320,7 +320,7 @@ describe('list reducer', () => {
       store.dispatch(removeList('fake-url'))
       expect(store.getState()).toEqual({
         byUrl: {},
-        selectedListUrl: 'https://tokens.honeyswap.org'
+        selectedListUrl: 'tokens.uniswap.eth'
       })
     })
   })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,7 +4,7 @@ import { AddressZero } from '@ethersproject/constants'
 import { JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
 import { BigNumber } from '@ethersproject/bignumber'
 import { abi as IUniswapV2Router02ABI } from '@uniswap/v2-periphery/build/IUniswapV2Router02.json'
-import { ROUTER_ADDRESS } from '../constants'
+import { getRouterAddress } from '../constants'
 import { JSBI, Percent, Token, CurrencyAmount, Currency, ETHER } from '@uniswap/sdk'
 import { ChainId } from 'xdai'
 import { TokenAddressMap } from '../state/lists/hooks'
@@ -100,8 +100,8 @@ export function getContract(address: string, ABI: any, library: Web3Provider, ac
 }
 
 // account is optional
-export function getRouterContract(_: number, library: Web3Provider, account?: string): Contract {
-  return getContract(ROUTER_ADDRESS, IUniswapV2Router02ABI, library, account)
+export function getRouterContract(chainId: number, library: Web3Provider, account?: string): Contract {
+  return getContract(getRouterAddress(chainId), IUniswapV2Router02ABI, library, account)
 }
 
 export function escapeRegExp(string: string): string {


### PR DESCRIPTION
- On `chainId` change from/to xDAI changes some hardcoded addresses, which is ugly, but works
- For now when changing chains need to explicitly change token lists to/from `https://tokens.honeyswap.org`, or you won't see any tokens

What's left:

- Automatic switch between `tokenLists` if there's one that supports current chain

This now works for any supported chain, but needs much more testing.
Also would be a nice thing to move more files to `custom/` override.
There will likely need to be more changes made for wrapping XDAI in #87 