### PR TITLE
xDAI hack-around/token list switch

### DIFF
--- a/src/custom/xdai/updater.ts
+++ b/src/custom/xdai/updater.ts
@@ -1,11 +1,70 @@
 import { useActiveWeb3React } from 'hooks'
 import { switchXDAIparams } from '.'
+import { useSelectedListUrl } from 'state/lists/hooks'
+import { selectList } from 'state/lists/actions'
+import { useEffect, useRef } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { AppState, AppDispatch } from 'state'
 
 export default function Updater(): null {
   const { chainId } = useActiveWeb3React()
 
   // sync update to not rely on useEffect timing
   switchXDAIparams(chainId)
+
+  return null
+}
+
+export function TokenListUpdater(): null {
+  const { chainId } = useActiveWeb3React()
+
+  const dispatch = useDispatch<AppDispatch>()
+
+  const listsByUrl = useSelector<AppState, AppState['lists']['byUrl']>(state => state.lists.byUrl)
+  const listsByUrlRef = useRef(listsByUrl)
+  listsByUrlRef.current = listsByUrl
+
+  const currentListUrl = useSelectedListUrl()
+
+  const currentList = currentListUrl ? listsByUrl[currentListUrl] : undefined
+
+  // ref, so we don'tdepend on currentList in useEffect
+  const currentListRef = useRef(currentList?.current)
+  currentListRef.current = currentList?.current
+
+  useEffect(() => {
+    if (!chainId || !currentListRef.current) return
+
+    // chainId changed
+    // currentList may not have tokens for the new chainId
+    const listHasTokens = currentListRef.current.tokens.some(token => token.chainId === chainId)
+
+    // current list has valid tokens -- good
+    if (listHasTokens) return
+
+    // no tokens for chainId in the current list
+    // try to switch to the first list that has valid tokens
+
+    const listUrlWithValidTokens = Object.keys(listsByUrlRef.current).find(url => {
+      const list = listsByUrlRef.current[url]
+      // look for lists without errors
+      if (list.error) return false
+      // that have tokens for the current chainId
+      return list.current?.tokens.some(token => token.chainId === chainId)
+    })
+
+    if (listUrlWithValidTokens) {
+      // just switch to a new list
+      // e.g. when MAINNET -> XDAI
+      // will do Uniswap list -> Honeyswap list
+      dispatch(selectList(listUrlWithValidTokens))
+
+      // can make a popup to inform the user
+      // extend ListUpdatePopup?
+
+      // can aternatively ask the user what to do in a Modal
+    }
+  }, [chainId, dispatch])
 
   return null
 }

--- a/src/custom/xdai/updater.ts
+++ b/src/custom/xdai/updater.ts
@@ -6,7 +6,7 @@ import { useEffect, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { AppState, AppDispatch } from 'state'
 
-export default function Updater(): null {
+export function XDAIoverrideUpdater(): null {
   const { chainId } = useActiveWeb3React()
 
   // sync update to not rely on useEffect timing

--- a/src/custom/xdai/updater.ts
+++ b/src/custom/xdai/updater.ts
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { AppState, AppDispatch } from 'state'
 
+// enables hackarounds to override internal data for @uniswap/sdk
 export function XDAIoverrideUpdater(): null {
   const { chainId } = useActiveWeb3React()
 
@@ -15,6 +16,9 @@ export function XDAIoverrideUpdater(): null {
   return null
 }
 
+// watches when chainId changes and the current token list
+// doesn't have tokens for that chainId
+// tries to switch to a different token list
 export function TokenListUpdater(): null {
   const { chainId } = useActiveWeb3React()
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import { NetworkContextName } from './constants'
 import './i18n'
 import App from './pages/App'
 import store from 'state'
-import XDAIoverrideUpdater from 'xdai/updater'
+import { XDAIoverrideUpdater, TokenListUpdater } from 'xdai/updater'
 import ApplicationUpdater from './state/application/updater'
 import ListsUpdater from './state/lists/updater'
 import MulticallUpdater from './state/multicall/updater'
@@ -50,6 +50,7 @@ function Updaters() {
     <>
       {/* xDAI goes first to propagate updates first */}
       <XDAIoverrideUpdater />
+      <TokenListUpdater />
       <ListsUpdater />
       <UserUpdater />
       <ApplicationUpdater />


### PR DESCRIPTION
Adds `<TokenListUpdater/>` that would switch to a list that has tokens for the current `chainId` if the current token list has none.
In practice would switch `Uniswap list -> Honeyswap list when MAINNET -> XDAI `and back.

You may want to makeit more explicit with a user notification/prompt.