### PR TITLE
[xdai] Hack Uniswap SDK + include xDAI

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.10"
+    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.10",
+    "@uniswap/sdk-original": "./node_modules/@uniswap/sdk"
   }
 }

--- a/package.json
+++ b/package.json
@@ -124,6 +124,6 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.10",
-    "@uniswap/sdk-original": "./node_modules/@uniswap/sdk"
+    "@uniswap/sdk-original": "npm:@uniswap/sdk"
   }
 }

--- a/src/custom/@uniswap/sdk/declarations.d.ts
+++ b/src/custom/@uniswap/sdk/declarations.d.ts
@@ -1,0 +1,212 @@
+import {
+  Currency,
+  CurrencyAmount,
+  BigintIsh,
+  Price,
+  TradeType,
+  Percent,
+  BestTradeOptions,
+  TradeOptions,
+  TradeOptionsDeadline,
+  SwapParameters
+} from '@uniswap/sdk-original'
+import { ChainId } from './'
+
+declare module 'uniswap/sdk' {
+  export class Token extends Currency {
+    readonly chainId: ChainId
+    readonly address: string
+    constructor(chainId: ChainId, address: string, decimals: number, symbol?: string, name?: string)
+    /**
+     * Returns true if the two tokens are equivalent, i.e. have the same chainId and address.
+     * @param other other token to compare
+     */
+    equals(other: Token): boolean
+    /**
+     * Returns true if the address of this token sorts before the address of the other token
+     * @param other other token to compare
+     * @throws if the tokens have the same address
+     * @throws if the tokens are on different chains
+     */
+    sortsBefore(other: Token): boolean
+  }
+
+  export class TokenAmount extends CurrencyAmount {
+    readonly token: Token
+    constructor(token: Token, amount: BigintIsh)
+    add(other: TokenAmount): TokenAmount
+    subtract(other: TokenAmount): TokenAmount
+  }
+
+  export class Pair {
+    readonly liquidityToken: Token
+    private readonly tokenAmounts
+    static getAddress(tokenA: Token, tokenB: Token): string
+    constructor(tokenAmountA: TokenAmount, tokenAmountB: TokenAmount)
+    /**
+     * Returns true if the token is either token0 or token1
+     * @param token to check
+     */
+    involvesToken(token: Token): boolean
+    /**
+     * Returns the current mid price of the pair in terms of token0, i.e. the ratio of reserve1 to reserve0
+     */
+    get token0Price(): Price
+    /**
+     * Returns the current mid price of the pair in terms of token1, i.e. the ratio of reserve0 to reserve1
+     */
+    get token1Price(): Price
+    /**
+     * Return the price of the given token in terms of the other token in the pair.
+     * @param token token to return price of
+     */
+    priceOf(token: Token): Price
+    /**
+     * Returns the chain ID of the tokens in the pair.
+     */
+    get chainId(): ChainId
+    get token0(): Token
+    get token1(): Token
+    get reserve0(): TokenAmount
+    get reserve1(): TokenAmount
+    reserveOf(token: Token): TokenAmount
+    getOutputAmount(inputAmount: TokenAmount): [TokenAmount, Pair]
+    getInputAmount(outputAmount: TokenAmount): [TokenAmount, Pair]
+    getLiquidityMinted(totalSupply: TokenAmount, tokenAmountA: TokenAmount, tokenAmountB: TokenAmount): TokenAmount
+    getLiquidityValue(
+      token: Token,
+      totalSupply: TokenAmount,
+      liquidity: TokenAmount,
+      feeOn?: boolean,
+      kLast?: BigintIsh
+    ): TokenAmount
+  }
+
+  export class Route {
+    readonly pairs: Pair[]
+    readonly path: Token[]
+    readonly input: Currency
+    readonly output: Currency
+    readonly midPrice: Price
+    constructor(pairs: Pair[], input: Currency, output?: Currency)
+    get chainId(): ChainId
+  }
+
+  /**
+   * Represents a trade executed against a list of pairs.
+   * Does not account for slippage, i.e. trades that front run this trade and move the price.
+   */
+  export class Trade {
+    /**
+     * The route of the trade, i.e. which pairs the trade goes through.
+     */
+    readonly route: Route
+    /**
+     * The type of the trade, either exact in or exact out.
+     */
+    readonly tradeType: TradeType
+    /**
+     * The input amount for the trade assuming no slippage.
+     */
+    readonly inputAmount: CurrencyAmount
+    /**
+     * The output amount for the trade assuming no slippage.
+     */
+    readonly outputAmount: CurrencyAmount
+    /**
+     * The price expressed in terms of output amount/input amount.
+     */
+    readonly executionPrice: Price
+    /**
+     * The mid price after the trade executes assuming no slippage.
+     */
+    readonly nextMidPrice: Price
+    /**
+     * The percent difference between the mid price before the trade and the trade execution price.
+     */
+    readonly priceImpact: Percent
+    /**
+     * Constructs an exact in trade with the given amount in and route
+     * @param route route of the exact in trade
+     * @param amountIn the amount being passed in
+     */
+    static exactIn(route: Route, amountIn: CurrencyAmount): Trade
+    /**
+     * Constructs an exact out trade with the given amount out and route
+     * @param route route of the exact out trade
+     * @param amountOut the amount returned by the trade
+     */
+    static exactOut(route: Route, amountOut: CurrencyAmount): Trade
+    constructor(route: Route, amount: CurrencyAmount, tradeType: TradeType)
+    /**
+     * Get the minimum amount that must be received from this trade for the given slippage tolerance
+     * @param slippageTolerance tolerance of unfavorable slippage from the execution price of this trade
+     */
+    minimumAmountOut(slippageTolerance: Percent): CurrencyAmount
+    /**
+     * Get the maximum amount in that can be spent via this trade for the given slippage tolerance
+     * @param slippageTolerance tolerance of unfavorable slippage from the execution price of this trade
+     */
+    maximumAmountIn(slippageTolerance: Percent): CurrencyAmount
+    /**
+     * Given a list of pairs, and a fixed amount in, returns the top `maxNumResults` trades that go from an input token
+     * amount to an output token, making at most `maxHops` hops.
+     * Note this does not consider aggregation, as routes are linear. It's possible a better route exists by splitting
+     * the amount in among multiple routes.
+     * @param pairs the pairs to consider in finding the best trade
+     * @param currencyAmountIn exact amount of input currency to spend
+     * @param currencyOut the desired currency out
+     * @param maxNumResults maximum number of results to return
+     * @param maxHops maximum number of hops a returned trade can make, e.g. 1 hop goes through a single pair
+     * @param currentPairs used in recursion; the current list of pairs
+     * @param originalAmountIn used in recursion; the original value of the currencyAmountIn parameter
+     * @param bestTrades used in recursion; the current list of best trades
+     */
+    static bestTradeExactIn(
+      pairs: Pair[],
+      currencyAmountIn: CurrencyAmount,
+      currencyOut: Currency,
+      { maxNumResults, maxHops }?: BestTradeOptions,
+      currentPairs?: Pair[],
+      originalAmountIn?: CurrencyAmount,
+      bestTrades?: Trade[]
+    ): Trade[]
+    /**
+     * similar to the above method but instead targets a fixed output amount
+     * given a list of pairs, and a fixed amount out, returns the top `maxNumResults` trades that go from an input token
+     * to an output token amount, making at most `maxHops` hops
+     * note this does not consider aggregation, as routes are linear. it's possible a better route exists by splitting
+     * the amount in among multiple routes.
+     * @param pairs the pairs to consider in finding the best trade
+     * @param currencyIn the currency to spend
+     * @param currencyAmountOut the exact amount of currency out
+     * @param maxNumResults maximum number of results to return
+     * @param maxHops maximum number of hops a returned trade can make, e.g. 1 hop goes through a single pair
+     * @param currentPairs used in recursion; the current list of pairs
+     * @param originalAmountOut used in recursion; the original value of the currencyAmountOut parameter
+     * @param bestTrades used in recursion; the current list of best trades
+     */
+    static bestTradeExactOut(
+      pairs: Pair[],
+      currencyIn: Currency,
+      currencyAmountOut: CurrencyAmount,
+      { maxNumResults, maxHops }?: BestTradeOptions,
+      currentPairs?: Pair[],
+      originalAmountOut?: CurrencyAmount,
+      bestTrades?: Trade[]
+    ): Trade[]
+  }
+
+  export abstract class Router {
+    /**
+     * Cannot be constructed.
+     */
+    private constructor()
+    /**
+     * Produces the on-chain method name to call and the hex encoded parameters to pass as arguments for a given trade.
+     * @param trade to produce call parameters for
+     * @param options options for the call parameters
+     */
+    static swapCallParameters(trade: Trade, options: TradeOptions | TradeOptionsDeadline): SwapParameters
+  }
+}

--- a/src/custom/@uniswap/sdk/index.ts
+++ b/src/custom/@uniswap/sdk/index.ts
@@ -1,0 +1,100 @@
+// this file essentially provides all the overrides employed in uniswap-xdai-sdk fork
+import { pack, keccak256 } from '@ethersproject/solidity'
+import { getCreate2Address } from '@ethersproject/address'
+import { Token, Pair, WETH as WETH_UNISWAP /*, Currency*/ } from '@uniswap/sdk-original'
+export {
+  Currency,
+  CurrencyAmount,
+  ETHER,
+  Fraction,
+  JSBI,
+  Pair,
+  Token,
+  Percent,
+  Price,
+  Route,
+  Router,
+  TokenAmount,
+  Trade,
+  TradeType,
+  Fetcher,
+  currencyEquals
+} from '@uniswap/sdk-original'
+
+// extended ChainId
+export enum ChainId {
+  MAINNET = 1,
+  ROPSTEN = 3,
+  RINKEBY = 4,
+  GÖRLI = 5,
+  KOVAN = 42,
+  XDAI = 100
+}
+
+// TODO: make chainId-dependant
+// xDAI
+export const FACTORY_ADDRESS = '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7'
+// TODO: make chainId-dependant
+// xDAI
+export const INIT_CODE_HASH = '0x3f88503e8580ab941773b59034fb4b2a63e86dbc031b3633a925533ad3ed2b93'
+
+// copy-pasta from the lib
+let PAIR_ADDRESS_CACHE: { [token0Address: string]: { [token1Address: string]: string } } = {}
+
+// overrides actual function to use xDAI specific FACTORY_ADDRESS and INIT_CODE_HASH
+// copy-pasta from the lib
+// TODO: make chainId-dependant
+Pair.getAddress = function getAddress(tokenA: Token, tokenB: Token): string {
+  const tokens = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA] // does safety checks
+
+  if (PAIR_ADDRESS_CACHE?.[tokens[0].address]?.[tokens[1].address] === undefined) {
+    PAIR_ADDRESS_CACHE = {
+      ...PAIR_ADDRESS_CACHE,
+      [tokens[0].address]: {
+        ...PAIR_ADDRESS_CACHE?.[tokens[0].address],
+        [tokens[1].address]: getCreate2Address(
+          FACTORY_ADDRESS,
+          keccak256(['bytes'], [pack(['address', 'address'], [tokens[0].address, tokens[1].address])]),
+          INIT_CODE_HASH
+        )
+      }
+    }
+  }
+
+  return PAIR_ADDRESS_CACHE[tokens[0].address][tokens[1].address]
+}
+
+// // This may not be necessary
+// // or even useless,because it's exported as
+// // const ETHER = Currency.ETHER; export {ETHER}
+// // in the lib
+// //// @ts-expect-error
+// // Currency.ETHER = new Currency(18, 'XDAI', 'xDai')
+
+// export const HONEY_XDAI = new Token(ChainId.XDAI, '0x71850b7e9ee3f13ab46d67167341e4bdc905eef9', 18, 'HNY', 'Honey')
+
+// export const USDC_XDAI = new Token(100, '0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83', 6, 'USDC', 'USDC on xDai')
+
+// export const WETH_XDAI = new Token(
+//   ChainId.XDAI,
+//   '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1',
+//   18,
+//   'WETH',
+//   'Wrapped Ether on xDai'
+// )
+// export const STAKE = new Token(
+//   ChainId.XDAI,
+//   '0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e',
+//   18,
+//   'STAKE',
+//   'Stake Token on xDai'
+// )
+
+export const WXDAI = new Token(100, '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d', 18, 'WXDAI', 'Wrapped XDAI')
+// export const WXDAI = new Token(100, '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d', 18, 'WXDAI', 'Wrapped XDAI')
+
+// // extends WETH to be used in Token Pairs logic
+export const WETH = {
+  ...WETH_UNISWAP,
+  [ChainId.XDAI]: WXDAI
+}

--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -1,4 +1,4 @@
-import { ChainId } from '@uniswap/sdk'
+import { ChainId } from '@uniswap/sdk/index'
 import React, { useState } from 'react'
 import { Text } from 'rebass'
 import { NavLink } from 'react-router-dom'
@@ -262,7 +262,8 @@ const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.RINKEBY]: 'Rinkeby',
   [ChainId.ROPSTEN]: 'Ropsten',
   [ChainId.GÖRLI]: 'Görli',
-  [ChainId.KOVAN]: 'Kovan'
+  [ChainId.KOVAN]: 'Kovan',
+  [ChainId.XDAI]: 'xDAI'
 }
 
 export default function HeaderMod(props: WithClassName) {

--- a/src/custom/tsconfig-paths.json
+++ b/src/custom/tsconfig-paths.json
@@ -1,8 +1,16 @@
 {
   "compilerOptions": {
     "paths": {
-      "@src/*": ["*"],
-      "*": ["custom/*", "*"]
+      "@uniswap/sdk": [
+        "src/custom/@uniswap/sdk/index.ts"
+      ],
+      "@src/*": [
+        "*"
+      ],
+      "*": [
+        "custom/*",
+        "*"
+      ]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,18 +2729,7 @@
   resolved "https://registry.yarnpkg.com/@uniswap/merkle-distributor/-/merkle-distributor-1.0.1.tgz#dc3d911f65a860fc3f0cae074bdcd08ed6a27a4d"
   integrity sha512-5gDiTI5hrXIh5UWTrxKYjw30QQDnpl8ckDSpefldNenDlYO1RKkdUYMYpvrqGi2r7YzLYTlO6+TDlNs6O7hDRw==
 
-"@uniswap/sdk-original@./node_modules/@uniswap/sdk":
-  version "3.0.3"
-  dependencies:
-    "@uniswap/v2-core" "^1.0.0"
-    big.js "^5.2.2"
-    decimal.js-light "^2.5.0"
-    jsbi "^3.1.1"
-    tiny-invariant "^1.1.0"
-    tiny-warning "^1.0.3"
-    toformat "^2.0.0"
-
-"@uniswap/sdk@3.0.3":
+"@uniswap/sdk-original@npm:@uniswap/sdk", "@uniswap/sdk@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@uniswap/sdk/-/sdk-3.0.3.tgz#8201c7c72215d0030cb99acc7e661eff895c18a9"
   integrity sha512-t4s8bvzaCFSiqD2qfXIm3rWhbdnXp+QjD3/mRaeVDHK7zWevs6RGEb1ohMiNgOCTZANvBayb4j8p+XFdnMBadQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,6 +2729,17 @@
   resolved "https://registry.yarnpkg.com/@uniswap/merkle-distributor/-/merkle-distributor-1.0.1.tgz#dc3d911f65a860fc3f0cae074bdcd08ed6a27a4d"
   integrity sha512-5gDiTI5hrXIh5UWTrxKYjw30QQDnpl8ckDSpefldNenDlYO1RKkdUYMYpvrqGi2r7YzLYTlO6+TDlNs6O7hDRw==
 
+"@uniswap/sdk-original@./node_modules/@uniswap/sdk":
+  version "3.0.3"
+  dependencies:
+    "@uniswap/v2-core" "^1.0.0"
+    big.js "^5.2.2"
+    decimal.js-light "^2.5.0"
+    jsbi "^3.1.1"
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
+    toformat "^2.0.0"
+
 "@uniswap/sdk@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@uniswap/sdk/-/sdk-3.0.3.tgz#8201c7c72215d0030cb99acc7e661eff895c18a9"


### PR DESCRIPTION
**edit 19/01**: I re-visit this PR. Dima was right in his comment, my solution of defining a package.json dependency using relative path doesn't work on a clean install. So I applied his solution and that fixed the issue. 

For some reason, now it was taking precendence of the original SDK to the hacked one. This is why I had to add something to the tsconfig override. 

With this, it's working. 


**What is not included in this PR**: xdai doesn't work yet, cause this PR is all about hacking their SDK without actually using a different package or rewriting all the files from the original Uniswap. 

Expect very soon a new PR on top of this one to add xDAI support


----

This PR is an attempt to make a less intrusive hack than #92 or #90 to include xDAI in the SDK chainId

I make use of the the work of #90 for redeclaring the conflicting types.
To avoid modifying the files, I declare everything in `src/custom/@uniswap/sdk`, then I include an alias for the original uniswap SDK, `@uniswap/sdk-original`, see `package.json`

I still want to explore another option, but it looks like this is working and allow us to control the pieces we hack from the SDK.
Anyways We should make an issue to uniswap asking them to include xDAI network in their list