### PR TITLE
[e2e] Check fee endpoint + add stubbing to config file

### DIFF
--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -1,12 +1,19 @@
+import { WETH } from '@uniswap/sdk'
+
+const FEE_QUERY = `https://protocol-rinkeby.dev.gnosisdev.com/api/v1/tokens/${WETH[4].address}/fee`
+
 describe('Fee endpoint', () => {
   it('Returns the expected info', () => {
     // GIVEN:-
     // WHEN: Call fee API
-    // cy.request('/users/1')
-    //   .its('body')
-    //   .should('deep.eq', { name: 'Jane' })
-    //
-    // THEN: The response has the expected information
+    cy.request(FEE_QUERY)
+      .its('body')
+      // THEN: response is as expected
+      .should(body => {
+        expect(body).to.have.property('minimalFee')
+        expect(body).to.have.property('feeRatio')
+        expect(body).to.have.property('expirationDate')
+      })
   })
 })
 

--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,6 @@
   "downloadsFolder": "cypress-custom/downloads",
   "video": false,
   "fixturesFolder": false,
-  "pluginsFile": false
+  "pluginsFile": false,
+  "experimentalNetworkStubbing": true
 }


### PR DESCRIPTION
Simple fee endpoint test

also adds `"experimentalNetworkStubbing": true` to `cypress.json`

@anxolin here is the stubbing format if you need it (not included in this PR):
```ts
// EXAMPLE STUBBING

const expectedExpirationDate = new Date(Date.now() + 30000).toISOString()

cy.visit('/swap')
     // GIVEN:-

     // WHEN: Call fee API
     // We tell cypress to listen to requests matching below
     cy.route2('**/api/v1/tokens/**', req => {
       req.reply(res => {
         // Stub the res.body
         res.body = {
           minimalFee: '999',
           feeRatio: 1000,
           expirationDate: expectedExpirationDate
         }
       })
     }).as('fee')

     cy.wait('@fee')
       .its('response')
       // THEN: response is as expected
       .should(({ body }) => {
         expect(body).to.have.property('minimalFee', '999')
         expect(body).to.have.property('feeRatio', 1000)
         expect(body).to.have.property('expirationDate', expectedExpirationDate)
       })
 })
```