### PR TITLE
[e2e] Check localStorage for proper `fee` data

### DIFF
--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -20,17 +20,17 @@ describe('Fee endpoint', () => {
 describe('Fetch and persist fee', () => {
   beforeEach(() => {
     cy.visit('/swap')
+
+    // Alias localStorage
+    cy.window()
+      .then(window => window.localStorage)
+      .as('localStorage')
   })
 
   it('Persisted when selecting a token', () => {
     const TOKEN = 'ETH'
     // GIVEN: A fee for a token is not in the local storage
     // WHEN: When the user select this token
-
-    // Alias localStorage
-    cy.window()
-      .then(window => window.localStorage)
-      .as('localStorage')
 
     // Clear localStorage
     cy.get<Storage>('@localStorage').then(storage => storage.clear())

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -43,7 +43,8 @@ describe('Fetch and persist fee', () => {
         // we need to parse JSON
         const feeStorage = JSON.parse($feeStorage)
         const feeQuote = feeStorage[NETWORK][TOKEN]
-
+        expect(feeStorage).to.have.property(NETWORK)
+        expect(feeStorage[NETWORK]).to.have.property(TOKEN)
         expect(feeQuote.token).to.equal(TOKEN)
         expect(feeQuote.fee).to.have.property('minimalFee')
         expect(feeQuote.fee).to.have.property('feeRatio')

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -23,9 +23,32 @@ describe('Fetch and persist fee', () => {
   })
 
   it('Persisted when selecting a token', () => {
+    const TOKEN = 'ETH'
     // GIVEN: A fee for a token is not in the local storage
     // WHEN: When the user select this token
+
+    // Alias localStorage
+    cy.window()
+      .then(window => window.localStorage)
+      .as('localStorage')
+
+    // Clear localStorage
+    cy.get<Storage>('@localStorage').then(storage => storage.clear())
+
     // THEN: The fee is persisted in the local storage (redux_localstorage_simple_fee)
+    cy.get<Storage>('@localStorage')
+      .its('redux_localstorage_simple_fee')
+      .should($feeStorage => {
+        // we need to parse JSON
+        const feeStorage = JSON.parse($feeStorage)
+        expect(feeStorage).to.have.property('4')
+        expect(feeStorage[4]).to.have.property(TOKEN)
+        expect(feeStorage[4][TOKEN]).to.have.property('token')
+        expect(feeStorage[4][TOKEN]).to.have.property('fee')
+        expect(feeStorage[4][TOKEN].fee).to.have.property('minimalFee')
+        expect(feeStorage[4][TOKEN].fee).to.have.property('feeRatio')
+        expect(feeStorage[4][TOKEN].fee).to.have.property('expirationDate')
+      })
   })
 
   // TODO: not sure if it's easy to test this

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -1,4 +1,4 @@
-import { WETH } from '@uniswap/sdk'
+import { ChainId, WETH } from '@uniswap/sdk'
 
 const FEE_QUERY = `https://protocol-rinkeby.dev.gnosisdev.com/api/v1/tokens/${WETH[4].address}/fee`
 
@@ -29,6 +29,7 @@ describe('Fetch and persist fee', () => {
 
   it('Persisted when selecting a token', () => {
     const TOKEN = 'ETH'
+    const NETWORK = ChainId.RINKEBY.toString()
     // GIVEN: A fee for a token is not in the local storage
     // WHEN: When the user select this token
 
@@ -41,13 +42,12 @@ describe('Fetch and persist fee', () => {
       .should($feeStorage => {
         // we need to parse JSON
         const feeStorage = JSON.parse($feeStorage)
-        expect(feeStorage).to.have.property('4')
-        expect(feeStorage[4]).to.have.property(TOKEN)
-        expect(feeStorage[4][TOKEN]).to.have.property('token')
-        expect(feeStorage[4][TOKEN]).to.have.property('fee')
-        expect(feeStorage[4][TOKEN].fee).to.have.property('minimalFee')
-        expect(feeStorage[4][TOKEN].fee).to.have.property('feeRatio')
-        expect(feeStorage[4][TOKEN].fee).to.have.property('expirationDate')
+        const feeQuote = feeStorage[NETWORK][TOKEN]
+
+        expect(feeQuote.token).to.equal(TOKEN)
+        expect(feeQuote.fee).to.have.property('minimalFee')
+        expect(feeQuote.fee).to.have.property('feeRatio')
+        expect(feeQuote.fee).to.have.property('expirationDate')
       })
   })
 


### PR DESCRIPTION
Adds second `it` test for `e2e` on fees

Checks `localStorage` is properly populated under the `redux_localstorage_simple_fee` key