### PR TITLE
[xdai] Refactor and customize wrap

### DIFF
--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -1,0 +1,112 @@
+import { TransactionResponse } from '@ethersproject/providers'
+import { getChainCurrencySymbols } from '@src/custom/utils/xdai/hack'
+import { Currency, CurrencyAmount, currencyEquals, ETHER, WETH } from '@uniswap/sdk'
+import { Contract } from 'ethers'
+import { useMemo } from 'react'
+import { tryParseAmount } from 'state/swap/hooks'
+import { useTransactionAdder } from 'state/transactions/hooks'
+import { useCurrencyBalance } from 'state/wallet/hooks'
+import { useActiveWeb3React } from 'hooks/index'
+import { useWETHContract } from 'hooks/useContract'
+
+export enum WrapType {
+  NOT_APPLICABLE,
+  WRAP,
+  UNWRAP
+}
+
+interface WrapUnwrapCallback {
+  wrapType: WrapType
+  execute?: undefined | (() => Promise<void>)
+  inputError?: string
+}
+
+type TransactionAdder = ReturnType<typeof useTransactionAdder>
+
+interface GetWrapUnwrapCallback {
+  isWrap: boolean
+  balance?: CurrencyAmount
+  inputAmount?: CurrencyAmount
+  addTransaction: TransactionAdder
+  wethContract: Contract
+}
+
+const NOT_APPLICABLE = { wrapType: WrapType.NOT_APPLICABLE }
+
+function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallback {
+  const { native, wrapped } = getChainCurrencySymbols()
+  const { isWrap, balance, inputAmount, addTransaction, wethContract } = params
+  const symbol = isWrap ? native : wrapped
+
+  // Check if user has enough balance for wrap/unwrap
+  const sufficientBalance = (inputAmount && balance && !balance.lessThan(inputAmount)) || false
+
+  // Create wrap/unwrap callback if sufficient balance
+  let wrapUnwrapCallback: (() => Promise<void>) | undefined
+  if (sufficientBalance && inputAmount) {
+    let wrapUnwrap: () => TransactionResponse
+    let summary: string, symbol: string
+
+    if (isWrap) {
+      wrapUnwrap = () => wethContract.deposit({ value: `0x${inputAmount.raw.toString(16)}` })
+      summary = `Wrap ${inputAmount.toSignificant(6)} ${native} to ${wrapped}`
+    } else {
+      wrapUnwrap = () => wethContract.withdraw(`0x${inputAmount.raw.toString(16)}`)
+      summary = `Unwrap ${inputAmount.toSignificant(6)} ${wrapped} to ${native}`
+    }
+
+    wrapUnwrapCallback = async () => {
+      try {
+        const txReceipt = await wrapUnwrap()
+        addTransaction(txReceipt, { summary })
+      } catch (error) {
+        const actionName = WrapType.WRAP ? 'wrapping' : 'unwrapping'
+        console.error(`Error ${actionName} ${symbol}`, error)
+      }
+    }
+  }
+
+  return {
+    wrapType: isWrap ? WrapType.WRAP : WrapType.UNWRAP,
+    execute: wrapUnwrapCallback,
+    inputError: sufficientBalance ? undefined : `Insufficient ${symbol} balance`
+  }
+}
+
+/**
+ * Given the selected input and output currency, return a wrap callback
+ * @param inputCurrency the selected input currency
+ * @param outputCurrency the selected output currency
+ * @param typedValue the user input value
+ */
+export default function useWrapCallback(
+  inputCurrency: Currency | undefined,
+  outputCurrency: Currency | undefined,
+  typedValue: string | undefined
+): WrapUnwrapCallback {
+  const { chainId, account } = useActiveWeb3React()
+  const wethContract = useWETHContract()
+  const balance = useCurrencyBalance(account ?? undefined, inputCurrency)
+  // we can always parse the amount typed as the input currency, since wrapping is 1:1
+  const inputAmount = useMemo(() => tryParseAmount(typedValue, inputCurrency), [inputCurrency, typedValue])
+  const addTransaction = useTransactionAdder()
+
+  return useMemo(() => {
+    if (!wethContract || !chainId || !inputCurrency || !outputCurrency) return NOT_APPLICABLE
+
+    const isWrappingEther = inputCurrency === ETHER && currencyEquals(WETH[chainId], outputCurrency)
+    const isUnwrappingWeth = currencyEquals(WETH[chainId], inputCurrency) && outputCurrency === ETHER
+
+    if (!isWrappingEther && !isUnwrappingWeth) {
+      return NOT_APPLICABLE
+    } else {
+      return _getWrapUnwrapCallback({
+        isWrap: isWrappingEther,
+        balance,
+        inputAmount,
+        addTransaction,
+        wethContract
+      })
+    }
+  }, [wethContract, chainId, inputCurrency, outputCurrency, inputAmount, balance, addTransaction])
+}

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -45,7 +45,7 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
   let wrapUnwrapCallback: (() => Promise<void>) | undefined
   if (sufficientBalance && inputAmount) {
     let wrapUnwrap: () => TransactionResponse
-    let summary: string, symbol: string
+    let summary: string
 
     if (isWrap) {
       wrapUnwrap = () => wethContract.deposit({ value: `0x${inputAmount.raw.toString(16)}` })

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -39,7 +39,7 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
   const symbol = isWrap ? native : wrapped
 
   // Check if user has enough balance for wrap/unwrap
-  const sufficientBalance = (inputAmount && balance && !balance.lessThan(inputAmount)) || false
+  const sufficientBalance = !!(inputAmount && balance && !balance.lessThan(inputAmount))
 
   // Create wrap/unwrap callback if sufficient balance
   let wrapUnwrapCallback: (() => Promise<void>) | undefined

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -17,7 +17,7 @@ export enum WrapType {
 
 interface WrapUnwrapCallback {
   wrapType: WrapType
-  execute?: undefined | (() => Promise<void>)
+  execute?: () => Promise<void>
   inputError?: string
 }
 

--- a/src/hooks/useWrapCallback.ts
+++ b/src/hooks/useWrapCallback.ts
@@ -1,4 +1,3 @@
-import { getChainCurrencySymbols } from '@src/custom/utils/xdai/hack'
 import { Currency, currencyEquals, ETHER, WETH } from '@uniswap/sdk'
 import { useMemo } from 'react'
 import { tryParseAmount } from '../state/swap/hooks'
@@ -38,7 +37,6 @@ export default function useWrapCallback(
     const sufficientBalance = inputAmount && balance && !balance.lessThan(inputAmount)
 
     if (inputCurrency === ETHER && currencyEquals(WETH[chainId], outputCurrency)) {
-      const { native, wrapped } = getChainCurrencySymbols()
       return {
         wrapType: WrapType.WRAP,
         execute:
@@ -46,10 +44,7 @@ export default function useWrapCallback(
             ? async () => {
                 try {
                   const txReceipt = await wethContract.deposit({ value: `0x${inputAmount.raw.toString(16)}` })
-
-                  addTransaction(txReceipt, {
-                    summary: `Wrap ${inputAmount.toSignificant(6)} ${native} to ${wrapped}`
-                  })
+                  addTransaction(txReceipt, { summary: `Wrap ${inputAmount.toSignificant(6)} ETH to WETH` })
                 } catch (error) {
                   console.error('Could not deposit', error)
                 }
@@ -58,7 +53,6 @@ export default function useWrapCallback(
         inputError: sufficientBalance ? undefined : 'Insufficient ETH balance'
       }
     } else if (currencyEquals(WETH[chainId], inputCurrency) && outputCurrency === ETHER) {
-      const { native, wrapped } = getChainCurrencySymbols()
       return {
         wrapType: WrapType.UNWRAP,
         execute:
@@ -66,9 +60,7 @@ export default function useWrapCallback(
             ? async () => {
                 try {
                   const txReceipt = await wethContract.withdraw(`0x${inputAmount.raw.toString(16)}`)
-                  addTransaction(txReceipt, {
-                    summary: `Unwrap ${inputAmount.toSignificant(6)} ${wrapped} to ${native}`
-                  })
+                  addTransaction(txReceipt, { summary: `Unwrap ${inputAmount.toSignificant(6)} WETH to ETH` })
                 } catch (error) {
                   console.error('Could not withdraw', error)
                 }


### PR DESCRIPTION
> It should be merged into #105 

This PR does 2 things:
- Amend an error in #110 where I modified an original hook. Here I restore the original
- Refactor the original hook

## Why a refactor?
@W3stside pointed out I was duplicating the call to get the native/wrapped token name for the wrap/unwrap logic. I saw the root cause is because it had a lot of duplication in the first place.

This was the dreadful original code:
![image](https://user-images.githubusercontent.com/2352112/106164606-75858d80-618a-11eb-9759-22e0bf456380.png)

The main hook is now smaller and easier to follow, it delegates to a private function which handles both wrap and unwrap:
![image](https://user-images.githubusercontent.com/2352112/106164866-bda4b000-618a-11eb-9eb0-512f2986c364.png)


`_getWrapUnwrapCallback` Does 3 things:
- Check if balance is enough
- Creates the `wrapUnwrapCallback` which executes the wrap/unwrap logic
- return the result


