### PR TITLE
[e2e] Add command and change test

### DIFF
--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -28,10 +28,9 @@ describe('Fetch and persist fee', () => {
     const NETWORK = ChainId.RINKEBY.toString()
 
     // GIVEN: There's no fee quoted for the token
-    window.localStorage.setItem(FEE_QUOTES_LOCAL_STORAGE_KEY, '{"4": {}}')
+    cy.clearLocalStorage()
 
     // WHEN: When the user select this token
-    // TODO: Select token
     cy.swapSelectInput('0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735')
 
     cy.window()
@@ -44,6 +43,7 @@ describe('Fetch and persist fee', () => {
       })
       .its(NETWORK)
       .its(TOKEN)
+      // .its(NETWORK + '.' + TOKEN)
       .then(feeQuote => {
         // THEN: Theres a stored quote for the network/token
         expect(feeQuote).to.exist

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -23,7 +23,7 @@ describe('Fetch and persist fee', () => {
     cy.visit('/swap')
   })
 
-  it.only('Persisted when selecting a token', () => {
+  it('Persisted when selecting a token', () => {
     const DAI = '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735'
     const Rinkeby = ChainId.RINKEBY.toString()
 

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -37,16 +37,13 @@ describe('Fetch and persist fee', () => {
     // WHEN: Select DAI token
     cy.swapSelectInput(DAI)
 
-    // THEN: The fee for DAI is fetched
+    // THEN: The fee for DAI is persisted in the Local Storage
     cy.window()
       .then(window => window.localStorage)
       .its(FEE_QUOTES_LOCAL_STORAGE_KEY)
       .should(feeQuotesStorage => {
-        // THEN: The fee information in the local storage
-        if (!feeQuotesStorage) assert.fail('No fee in local storage')
-        const feeQuoteData = JSON.parse(feeQuotesStorage)
-
         // THEN: There is fee information for Rinkeby and DAI token
+        const feeQuoteData = JSON.parse(feeQuotesStorage)
         expect(feeQuoteData).to.exist
         expect(feeQuoteData).to.have.property(Rinkeby)
         expect(feeQuoteData[Rinkeby]).to.have.property(DAI)
@@ -77,6 +74,7 @@ describe('Fetch and persist fee', () => {
     })
     // GIVEN: A fee is present in the local storage
     // Set expiring fee in localStorage
+    cy.wrap(this.localStorage)
     cy.get<Storage>('@localStorage')
       .then($storage => {
         // set time in the past

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -93,8 +93,8 @@ describe('Fetch and persist fee', () => {
       })
       // WHEN: When the fee quote expires, we refetch the fee
       // better imo than using cy.wait - clear fee storage
-      .then(() => cy.get<Storage>('@localStorage').then($storage => $storage.removeItem(KEY)))
-      .its(KEY)
+      .then(() => cy.get<Storage>('@localStorage').then($storage => $storage.removeItem(FEE_QUOTES_LOCAL_STORAGE_KEY)))
+      .its(FEE_QUOTES_LOCAL_STORAGE_KEY)
       // THEN: We get another quote
       .should($feeStorage => {
         const feeStorage = JSON.parse($feeStorage)

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -21,6 +21,10 @@ describe('Fee endpoint', () => {
 describe('Fetch and persist fee', () => {
   beforeEach(() => {
     cy.visit('/swap')
+
+    cy.window()
+      .then(window => window.localStorage)
+      .as('localStorage')
   })
 
   it('Persisted when selecting a token', () => {

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -24,31 +24,31 @@ describe('Fetch and persist fee', () => {
   })
 
   it.only('Persisted when selecting a token', () => {
-    const TOKEN = '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735'
-    const NETWORK = ChainId.RINKEBY.toString()
+    const DAI = '0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735'
+    const Rinkeby = ChainId.RINKEBY.toString()
 
-    // GIVEN: There's no fee quoted for the token
+    // GIVEN: Clean local storage
     cy.clearLocalStorage()
 
-    // WHEN: When the user select this token
-    cy.swapSelectInput('0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735')
+    // WHEN: Select DAI token
+    cy.swapSelectInput(DAI)
 
+    // THEN: The fee for DAI is fetched
     cy.window()
       .then(window => window.localStorage)
       .its(FEE_QUOTES_LOCAL_STORAGE_KEY)
       .should(feeQuotesStorage => {
-        // THEN: Theres fee quotes persisted in the local storage
+        // THEN: The fee information in the local storage
         if (!feeQuotesStorage) assert.fail('No fee in local storage')
         const feeQuoteData = JSON.parse(feeQuotesStorage)
 
-        // THEN: Theres a stored quote for the network/token
+        // THEN: There is fee information for Rinkeby and DAI token
         expect(feeQuoteData).to.exist
-        expect(feeQuoteData).to.have.property(NETWORK)
-        expect(feeQuoteData[NETWORK]).to.have.property(TOKEN)
+        expect(feeQuoteData).to.have.property(Rinkeby)
+        expect(feeQuoteData[Rinkeby]).to.have.property(DAI)
 
-        // THEN: The quote has the expected shape
-        console.log(feeQuoteData[NETWORK][TOKEN])
-        const fee = feeQuoteData[NETWORK][TOKEN].fee
+        // THEN: The quote has the expected information
+        const fee = feeQuoteData[Rinkeby][DAI].fee
         expect(fee).to.have.property('minimalFee')
         expect(fee).to.have.property('feeRatio')
         expect(fee).to.have.property('expirationDate')

--- a/cypress-custom/integration/fee.test.ts
+++ b/cypress-custom/integration/fee.test.ts
@@ -36,20 +36,19 @@ describe('Fetch and persist fee', () => {
     cy.window()
       .then(window => window.localStorage)
       .its(FEE_QUOTES_LOCAL_STORAGE_KEY)
-      .then(feeQuotesStorage => {
+      .should(feeQuotesStorage => {
         // THEN: Theres fee quotes persisted in the local storage
         if (!feeQuotesStorage) assert.fail('No fee in local storage')
-        return JSON.parse(feeQuotesStorage)
-      })
-      .its(NETWORK)
-      .its(TOKEN)
-      // .its(NETWORK + '.' + TOKEN)
-      .then(feeQuote => {
+        const feeQuoteData = JSON.parse(feeQuotesStorage)
+
         // THEN: Theres a stored quote for the network/token
-        expect(feeQuote).to.exist
+        expect(feeQuoteData).to.exist
+        expect(feeQuoteData).to.have.property(NETWORK)
+        expect(feeQuoteData[NETWORK]).to.have.property(TOKEN)
 
         // THEN: The quote has the expected shape
-        const fee = feeQuote.fee
+        console.log(feeQuoteData[NETWORK][TOKEN])
+        const fee = feeQuoteData[NETWORK][TOKEN].fee
         expect(fee).to.have.property('minimalFee')
         expect(fee).to.have.property('feeRatio')
         expect(fee).to.have.property('expirationDate')

--- a/cypress-custom/support/commands.d.ts
+++ b/cypress-custom/support/commands.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="cypress" />
+
+declare namespace Cypress {
+  interface Chainable {
+    /**
+     * Select token input in the swap page
+     *
+     * @example cy.selectTokens()
+     */
+    swapSelectInput(tokenAddress: string): Chainable<Element>
+  }
+}

--- a/cypress-custom/support/commands.js
+++ b/cypress-custom/support/commands.js
@@ -1,0 +1,5 @@
+Cypress.Commands.add('swapSelectInput', tokenAddress => {
+  cy.get('#swap-currency-input .open-currency-select-button').click()
+  cy.get('.token-item-' + tokenAddress).should('be.visible')
+  cy.get('.token-item-' + tokenAddress).click({ force: true })
+})


### PR DESCRIPTION
This PR adds convenient commands that would simplify how we define tests.

In this case, I created `swapSelectInput` which allows to select a token in the input. 

I used this to rework the test of the local storage.

I tried to:
- `WHEN`: Setup a known state for the local storage. Probably is not even needed if we do `cy.clearLocalStorage()`, and maybe even that is not needed synce cypress do it for u
`THEN`: Does a `cy.swapSelectInput('0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735')` wich will hopefully detect we need to get a new quote and store it in the local storage
- `THEN`: Checks the quote has the expected shape

edit: ~Right now is failing, I think it's because Cypress returns first a version of the local storage that does not contain the quote. Then it timesout waiting for the token...~
~I'm pretty sure it will work if I add a delay, but I don't want to do that. Any idea of a better approach?~
Thanks David for the tip with using `should` to re-evaluate


![image](https://user-images.githubusercontent.com/2352112/106258599-533d4f80-621e-11eb-95f6-03d718eafe89.png)

## Future PR
#123 will refactor this further and add some new test!