### PR TITLE
Prevent job failure on step failure

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,18 +27,24 @@ jobs:
           node-version: 12
 
       # Install deps only
-      - name: Cypress install deps
+      - name: Cypress install dependencies
+        id: cypress-deps
         uses: cypress-io/github-action@v2
         with:
           runTests: false
 
       - name: Install Cypress binary
+        id: cypress-bin
+        # Only run if previous step failed
         if: failure()
         run: npx cypress install
 
       # Actually run tests, building repo
       - name: Cypress run
         uses: cypress-io/github-action@v2
+        # Run when one of the previous 2 jobs succeeds
+        # Without this conditional, it won't run in case there's a failure, even if expected
+        if: steps.cypress-deps.conclusion == 'success' || steps.cypress-bin.conclusion == 'success'
         with:
           build: yarn build
           start: yarn serve

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,21 +30,21 @@ jobs:
       - name: Cypress install dependencies
         id: cypress-deps
         uses: cypress-io/github-action@v2
+        # Do not consider failure a failure. Well, sort of.
+        # See https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context
+        continue-on-error: true
         with:
           runTests: false
 
       - name: Install Cypress binary
         id: cypress-bin
         # Only run if previous step failed
-        if: failure()
+        if: steps.cypress-deps.outcome == 'failure'
         run: npx cypress install
 
       # Actually run tests, building repo
       - name: Cypress run
         uses: cypress-io/github-action@v2
-        # Run when one of the previous 2 jobs succeeds
-        # Without this conditional, it won't run in case there's a failure, even if expected
-        if: steps.cypress-deps.conclusion == 'success' || steps.cypress-bin.conclusion == 'success'
         with:
           build: yarn build
           start: yarn serve

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,6 +28,9 @@ jobs:
 
       # Install deps only
       - name: Cypress install deps
+        # Prevents job failure when in case step fails.
+        # Next step takes care of it
+        continue-on-error: true
         uses: cypress-io/github-action@v2
         with:
           runTests: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,9 +28,6 @@ jobs:
 
       # Install deps only
       - name: Cypress install deps
-        # Prevents job failure when in case step fails.
-        # Next step takes care of it
-        continue-on-error: true
         uses: cypress-io/github-action@v2
         with:
           runTests: false


### PR DESCRIPTION
# The problem

Integration tests worked as I expected. Mostly. https://github.com/gnosis/gp-swap-ui/runs/1785968007?check_suite_focus=true

1. Tried to install deps (step 4)
2. Failed because cypress bin was not on the cache (no idea why)
3. Optional step to install cypress bin ran and installed it! (step 5)

And this is what I didn't predict

4. Actual cypress tests did not run because step 4 failed.
Hopefully should be an easy fix (famous last words)

![screenshot_2021-01-28_13-04-18](https://user-images.githubusercontent.com/43217/106201301-1e24f480-616d-11eb-9bb1-aceec4a56da3.png)

# The fix

This PR fiddles with the conditionals to make it succeed. https://github.com/gnosis/gp-swap-ui/pull/122/checks?check_run_id=1787487498

Now the step that can fail is marked with [`continue-on-error`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)

The job doesn't fail straight away, and the next step checks whether it has to execute or not based on [step outcome instead of step conclusion](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context)