### PR TITLE
Explorer link: Hack etherscan links

### DIFF
--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@uniswap/sdk'
+import { getExplorerOrderLink } from './explorer'
 
 export {
   basisPointsToPercent,
@@ -73,7 +74,11 @@ function getBlockscoutUrl(chainId: ChainId, data: string, type: BlockExplorerLin
 }
 
 export function getEtherscanLink(chainId: ChainId, data: string, type: BlockExplorerLinkType): string {
-  if (chainId === ChainId.XDAI) {
+  // TODO: do nicer!
+  if (data.length === 114) {
+    // id!
+    return getExplorerOrderLink(chainId, data)
+  } else if (chainId === ChainId.XDAI) {
     return getBlockscoutUrl(chainId, data, type)
   } else {
     return getEtherscanUrl(chainId, data, type)

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -1,6 +1,8 @@
 import { ChainId } from '@uniswap/sdk'
 import { getExplorerOrderLink } from './explorer'
 
+const GP_ORDER_ID_LENGTH = 114 // 112 (56 bytes in hex) + 2 (it's prefixed with "0x")
+
 export {
   basisPointsToPercent,
   calculateGasMargin,
@@ -74,13 +76,15 @@ function getBlockscoutUrl(chainId: ChainId, data: string, type: BlockExplorerLin
 }
 
 export function getEtherscanLink(chainId: ChainId, data: string, type: BlockExplorerLinkType): string {
-  // TODO: do nicer!
-  if (data.length === 114) {
-    // id!
+  if (type === 'transaction' && data.length === GP_ORDER_ID_LENGTH) {
+    // Explorer for GP orders:
+    //    If a transaction has the size of the GP orderId, then it's a meta-tx
     return getExplorerOrderLink(chainId, data)
   } else if (chainId === ChainId.XDAI) {
+    // Blockscout in xDAI
     return getBlockscoutUrl(chainId, data, type)
   } else {
+    // Etherscan in xDAI
     return getEtherscanUrl(chainId, data, type)
   }
 }


### PR DESCRIPTION
This pr makes this link to work (also any other where the tx is shown):
![image](https://user-images.githubusercontent.com/2352112/107788142-5a04b000-6d50-11eb-9bac-eae68fc54b76.png)


## not included
we still need to add it here:
![image](https://user-images.githubusercontent.com/2352112/107788209-71439d80-6d50-11eb-9fa4-e24d36399d4a.png)

Also, we should improve the labels and not says etherscan always, just write a more generic message or be specific: GP Explorer / Blockscout / Etherscan