### PR TITLE
[148] Fix undefined order toast

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -36,3 +36,5 @@ export const BUY_ETHER_TOKEN: { [chainId in ChainId]: Token } = {
   [ChainId.KOVAN]: new Token(ChainId.KOVAN, BUY_ETHER_ADDRESS, 18, 'ETH', 'Ether'),
   [ChainId.XDAI]: new Token(ChainId.XDAI, BUY_ETHER_ADDRESS, 18, 'xDAI', 'xDAI')
 }
+
+export const ORDER_ID_SHORT_LENGTH = 8

--- a/src/custom/state/orders/helpers.ts
+++ b/src/custom/state/orders/helpers.ts
@@ -1,4 +1,4 @@
-import { shortenOrderId } from 'utils'
+import { formatOrderId } from 'utils'
 import { OrderID } from 'utils/operator'
 import { addPopup } from 'state/application/actions'
 import { OrderStatus } from './actions'
@@ -46,7 +46,7 @@ type MetaPopupContent = GPPopupContent<OrderTxTypes.METATXN>
 type TxnPopupContent = GPPopupContent<OrderTxTypes.TXN>
 
 function setOrderSummary({ id, summary, status, descriptor }: SetOrderSummaryParams) {
-  return summary ? `${summary} ${status}` : `Order ${shortenOrderId(id)} ${descriptor || status}`
+  return summary ? `${summary} ${status}` : `Order ${formatOrderId(id)} ${descriptor || status}`
 }
 
 // Metatxn popup

--- a/src/custom/state/orders/helpers.ts
+++ b/src/custom/state/orders/helpers.ts
@@ -1,0 +1,94 @@
+import { shortenOrderId } from 'utils'
+import { OrderID } from 'utils/operator'
+import { addPopup } from 'state/application/actions'
+import { OrderStatus } from './actions'
+
+type OrderStatusExtended = OrderStatus | 'submitted'
+
+interface SetOrderSummaryParams {
+  id: string
+  status: OrderStatusExtended
+  summary?: string
+  descriptor?: string
+}
+
+// what is passed to addPopup action
+export type PopupPayload = Parameters<typeof addPopup>[0]
+export interface OrderIDWithPopup {
+  id: OrderID
+  popup: PopupPayload
+}
+
+export enum OrderTxTypes {
+  METATXN = 'metatxn',
+  TXN = 'txn'
+}
+
+enum OrderIdType {
+  ID = 'id',
+  HASH = 'hash'
+}
+
+interface BasePopupContent {
+  success: boolean
+  summary: string
+}
+
+type IdOrHash<K extends OrderIdType, T extends OrderTxTypes> = {
+  [identifier in K]: T extends OrderTxTypes.METATXN ? OrderTxTypes.METATXN : OrderTxTypes.TXN
+}
+
+type GPPopupContent<T extends OrderTxTypes> = {
+  [type in T]: IdOrHash<T extends OrderTxTypes.METATXN ? OrderIdType.ID : OrderIdType.HASH, T> & BasePopupContent
+}
+
+type MetaPopupContent = GPPopupContent<OrderTxTypes.METATXN>
+type TxnPopupContent = GPPopupContent<OrderTxTypes.TXN>
+
+function setOrderSummary({ id, summary, status, descriptor }: SetOrderSummaryParams) {
+  return summary ? `${summary} ${status}` : `Order ${shortenOrderId(id)} ${descriptor || status}`
+}
+
+// Metatxn popup
+export function setPopupData(
+  type: OrderTxTypes.METATXN,
+  { success, id, summary, status, descriptor }: SetOrderSummaryParams & { success?: boolean }
+): { key?: string; content: MetaPopupContent }
+// Txn popup
+export function setPopupData(
+  type: OrderTxTypes.TXN,
+  { success, id, summary, status, descriptor }: SetOrderSummaryParams & { hash: string; success?: boolean }
+): { key?: string; content: TxnPopupContent }
+export function setPopupData(
+  type: OrderTxTypes,
+  { hash, success = true, id, summary, status, descriptor }: any
+): { key?: string; content: TxnPopupContent | MetaPopupContent } {
+  const key = id + '_' + status
+  const baseContent = {
+    success,
+    summary: setOrderSummary({
+      summary,
+      id,
+      status,
+      descriptor
+    })
+  }
+  let content: TxnPopupContent | MetaPopupContent
+  if (type === OrderTxTypes.TXN) {
+    content = {
+      txn: {
+        hash,
+        ...baseContent
+      }
+    }
+  } else {
+    content = {
+      metatxn: {
+        id,
+        ...baseContent
+      }
+    }
+  }
+
+  return { key, content }
+}

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -63,7 +63,6 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
       // Pending Order Popup
       popup = { key, content }
     } else if (isFulfillOrderAction(action)) {
-      console.debug('[MIDDLEWARE] isFulfillOrderAction', action)
       const { transactionHash } = action.payload
 
       const key = id + '_fulfilled'
@@ -105,7 +104,6 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
     const { pending, fulfilled, expired } = orders
 
     if (isBatchFulfillOrderAction(action)) {
-      console.debug('[MIDDLEWARE] isBatchFulfillOrderAction', action)
       // construct Fulfilled Order Popups for each Order
       idsAndPopups = action.payload.ordersData.map(({ id, transactionHash }) => {
         const orderObject = pending?.[id] || fulfilled?.[id] || expired?.[id]

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -1,31 +1,21 @@
 import { Middleware, isAnyOf } from '@reduxjs/toolkit'
 
-import * as OrderActions from './actions'
-import { OrderID } from 'utils/operator'
 import { addPopup } from 'state/application/actions'
 import { AppState } from 'state'
-import { shortenOrderId } from 'utils'
+import * as OrderActions from './actions'
 
+import { OrderIDWithPopup, OrderTxTypes, PopupPayload, setPopupData } from './helpers'
+
+// action syntactic sugar
 const isSingleOrderChangeAction = isAnyOf(
   OrderActions.addPendingOrder,
   OrderActions.expireOrder,
   OrderActions.fulfillOrder
 )
-
 const isPendingOrderAction = isAnyOf(OrderActions.addPendingOrder)
-
 const isFulfillOrderAction = isAnyOf(OrderActions.fulfillOrder)
-
 const isBatchOrderAction = isAnyOf(OrderActions.fulfillOrdersBatch, OrderActions.expireOrdersBatch)
-
 const isBatchFulfillOrderAction = isAnyOf(OrderActions.fulfillOrdersBatch)
-
-// what is passed to addPopup action
-type PopupPayload = Parameters<typeof addPopup>[0]
-interface OrderIDWithPopup {
-  id: OrderID
-  popup: PopupPayload
-}
 
 // on each Pending, Expired, Fulfilled order action
 // a corresponsing Popup action is dispatched
@@ -50,43 +40,28 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
     const summary = orderObject?.order.summary
 
     let popup: PopupPayload
-
     if (isPendingOrderAction(action)) {
-      const key = id + '_pending'
-      const content = {
-        metatxn: {
-          id,
-          success: true,
-          summary: summary ? summary + ' submitted' : `Order ${shortenOrderId(id)} submitted`
-        }
-      }
       // Pending Order Popup
-      popup = { key, content }
+      popup = setPopupData(OrderTxTypes.METATXN, { summary, status: 'submitted', id })
     } else if (isFulfillOrderAction(action)) {
-      const { transactionHash } = action.payload
+      const { transactionHash: hash } = action.payload
 
-      const key = id + '_fulfilled'
-      const content = {
-        txn: {
-          hash: transactionHash,
-          success: true,
-          summary: summary ? summary + ' fulfilled' : `Order ${shortenOrderId(id)} was traded`
-        }
-      }
-      // Fulfilled Order Popup
-      popup = { key, content }
+      popup = setPopupData(OrderTxTypes.TXN, {
+        hash,
+        summary,
+        id,
+        status: OrderActions.OrderStatus.FULFILLED,
+        descriptor: 'was traded'
+      })
     } else {
       // action is order/expireOrder
-      const key = id + '_expired'
-      const content = {
-        metatxn: {
-          id: id,
-          success: false,
-          summary: summary ? summary + ' expired' : `Order ${shortenOrderId(id)} expired`
-        }
-      }
       // Expired Order Popup
-      popup = { key, content }
+      popup = setPopupData(OrderTxTypes.METATXN, {
+        success: false,
+        summary,
+        id,
+        status: OrderActions.OrderStatus.EXPIRED
+      })
     }
 
     idsAndPopups.push({
@@ -107,18 +82,15 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
       // construct Fulfilled Order Popups for each Order
       idsAndPopups = action.payload.ordersData.map(({ id, transactionHash }) => {
         const orderObject = pending?.[id] || fulfilled?.[id] || expired?.[id]
-
         const summary = orderObject?.order.summary
-        const key = id + '_fulfilled'
-        const content = {
-          txn: {
-            hash: transactionHash,
-            success: true,
-            summary: summary ? summary + ' fulfilled' : `Order ${shortenOrderId(id)} was traded`
-          }
-        }
 
-        const popup = { key, content }
+        const popup = setPopupData(OrderTxTypes.TXN, {
+          hash: transactionHash,
+          summary,
+          id,
+          status: OrderActions.OrderStatus.FULFILLED,
+          descriptor: 'was traded'
+        })
 
         return { id, popup }
       })
@@ -128,16 +100,13 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
         const orderObject = pending?.[id] || fulfilled?.[id] || expired?.[id]
 
         const summary = orderObject?.order.summary
-        const key = id + '_expired'
-        const content = {
-          metatxn: {
-            id: id,
-            success: false,
-            summary: summary ? summary + ' expired' : `Order ${shortenOrderId(id)} expired`
-          }
-        }
 
-        const popup = { key, content }
+        const popup = setPopupData(OrderTxTypes.METATXN, {
+          success: false,
+          summary,
+          id,
+          status: OrderActions.OrderStatus.EXPIRED
+        })
 
         return { id, popup }
       })

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -4,6 +4,7 @@ import * as OrderActions from './actions'
 import { OrderID } from 'utils/operator'
 import { addPopup } from 'state/application/actions'
 import { AppState } from 'state'
+import { shortenOrderId } from 'utils'
 
 const isSingleOrderChangeAction = isAnyOf(
   OrderActions.addPendingOrder,
@@ -56,12 +57,13 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
         metatxn: {
           id,
           success: true,
-          summary: summary + ' submitted' || `Order ${id} submitted`
+          summary: summary ? summary + ' submitted' : `Order ${shortenOrderId(id)} submitted`
         }
       }
       // Pending Order Popup
       popup = { key, content }
     } else if (isFulfillOrderAction(action)) {
+      console.debug('[MIDDLEWARE] isFulfillOrderAction', action)
       const { transactionHash } = action.payload
 
       const key = id + '_fulfilled'
@@ -69,7 +71,7 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
         txn: {
           hash: transactionHash,
           success: true,
-          summary: summary + ' fulfilled' || `Order ${id} was traded`
+          summary: summary ? summary + ' fulfilled' : `Order ${shortenOrderId(id)} was traded`
         }
       }
       // Fulfilled Order Popup
@@ -81,7 +83,7 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
         metatxn: {
           id: id,
           success: false,
-          summary: summary + ' expired' || `Order ${id} expired`
+          summary: summary ? summary + ' expired' : `Order ${shortenOrderId(id)} expired`
         }
       }
       // Expired Order Popup
@@ -103,6 +105,7 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
     const { pending, fulfilled, expired } = orders
 
     if (isBatchFulfillOrderAction(action)) {
+      console.debug('[MIDDLEWARE] isBatchFulfillOrderAction', action)
       // construct Fulfilled Order Popups for each Order
       idsAndPopups = action.payload.ordersData.map(({ id, transactionHash }) => {
         const orderObject = pending?.[id] || fulfilled?.[id] || expired?.[id]
@@ -113,7 +116,7 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
           txn: {
             hash: transactionHash,
             success: true,
-            summary: summary + ' fulfilled' || `Order ${id} was traded`
+            summary: summary ? summary + ' fulfilled' : `Order ${shortenOrderId(id)} was traded`
           }
         }
 
@@ -132,7 +135,7 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
           metatxn: {
             id: id,
             success: false,
-            summary: summary + ' expired' || `Order ${id} expired`
+            summary: summary ? summary + ' expired' : `Order ${shortenOrderId(id)} expired`
           }
         }
 

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -89,6 +89,8 @@ export function getEtherscanLink(chainId: ChainId, data: string, type: BlockExpl
   }
 }
 
-export function shortenOrderId(orderId: string, chars = 4, length = 114): string {
-  return `${orderId.substring(2, chars + 2)}...${orderId.substring(length - chars)}`
+// Shortens OrderID (or any string really) removing initial 2 characters e.g 0x
+// and cutting string at 'chars' length, default = 8
+export function shortenOrderId(orderId: string, chars = 8): string {
+  return orderId.substring(2, chars)
 }

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -81,5 +81,5 @@ export function getEtherscanLink(chainId: ChainId, data: string, type: BlockExpl
 }
 
 export function shortenOrderId(orderId: string, chars = 4, length = 114): string {
-  return `${orderId.substring(0, chars + 2)}...${orderId.substring(length - chars)}`
+  return `${orderId.substring(2, chars + 2)}...${orderId.substring(length - chars)}`
 }

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@uniswap/sdk'
+import { ORDER_ID_SHORT_LENGTH } from '../constants'
 import { getExplorerOrderLink } from './explorer'
 
 const GP_ORDER_ID_LENGTH = 114 // 112 (56 bytes in hex) + 2 (it's prefixed with "0x")
@@ -91,6 +92,13 @@ export function getEtherscanLink(chainId: ChainId, data: string, type: BlockExpl
 
 // Shortens OrderID (or any string really) removing initial 2 characters e.g 0x
 // and cutting string at 'chars' length, default = 8
-export function shortenOrderId(orderId: string, chars = 8): string {
-  return orderId.substring(2, chars)
+export function shortenOrderId(orderId: string, start = 0, chars = ORDER_ID_SHORT_LENGTH): string {
+  return orderId.substring(start, chars + start)
+}
+
+export function formatOrderId(orderId: string): string {
+  const has0x = orderId.match('0x')
+
+  // 0x is at index 0 of orderId, shorten. Else return id as is
+  return has0x?.index === 0 ? shortenOrderId(orderId, 2, orderId.length) : orderId
 }

--- a/src/custom/utils/index.ts
+++ b/src/custom/utils/index.ts
@@ -79,3 +79,7 @@ export function getEtherscanLink(chainId: ChainId, data: string, type: BlockExpl
     return getEtherscanUrl(chainId, data, type)
   }
 }
+
+export function shortenOrderId(orderId: string, chars = 4, length = 114): string {
+  return `${orderId.substring(0, chars + 2)}...${orderId.substring(length - chars)}`
+}


### PR DESCRIPTION
Closes #148 

Creates `shortenOrderId` fn 
Checks computed `summary` var to make sure it isn't `falsy` then returns better data:

### Screenshot shows `0x` before order id but that is removed in last commit 

![Screenshot from 2021-02-15 09-28-42](https://user-images.githubusercontent.com/21335563/107928442-9dd9fe00-6f78-11eb-86a4-010160e81b11.png)
