### PR TITLE
[141] Fix whitescreen invariant crash

### DIFF
--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -56,12 +56,12 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
   })
 
   const bestTradeExactIn = useTradeExactInWithFee({
-    parsedAmount,
+    parsedAmount: isExactIn ? parsedAmount : undefined,
     outputCurrency,
     feeInformation
   })
   const bestTradeExactOut = useTradeExactOutWithFee({
-    parsedAmount,
+    parsedAmount: isExactIn ? undefined : parsedAmount,
     inputCurrency,
     feeInformation
   })


### PR DESCRIPTION
Closes #141 

Was a problem with the `parsedAmount` used in the `exactOut` trade when running an `exactIn` trade - should have passed `undefined` for `parsedAmount` as it wanted the token and the `sdk` `invariant` was throwing.

Can be tested as specified in #141 to see it works