### PR TITLE
[145] Sluggish app - default middleware = culprit

### DIFF
--- a/src/custom/state/index.ts
+++ b/src/custom/state/index.ts
@@ -1,4 +1,4 @@
-import { configureStore, getDefaultMiddleware, StateFromReducersMapObject } from '@reduxjs/toolkit'
+import { configureStore, StateFromReducersMapObject } from '@reduxjs/toolkit'
 import { save, load } from 'redux-localstorage-simple'
 
 // UNI REDUCERS
@@ -39,7 +39,7 @@ const PERSISTED_KEYS: string[] = ['user', 'transactions', 'lists', 'orders', 'fe
 
 const store = configureStore({
   reducer: reducers,
-  middleware: [...getDefaultMiddleware({ thunk: false }), save({ states: PERSISTED_KEYS }), popupMiddleware],
+  middleware: [save({ states: PERSISTED_KEYS }), popupMiddleware],
   preloadedState: load({ states: PERSISTED_KEYS })
 })
 


### PR DESCRIPTION
Closes #145 

Removes `getDefaultMiddleware` as we're not using any of them, here is the docu: https://redux-toolkit.js.org/api/getDefaultMiddleware

Essentially the 2 slugg-ifying middlewares are:
1. `Immutability check middleware`: checks state mutation 
2. `Serializability check middleware`: checks state tree for non serialisable values