### PR TITLE
[135] - fix incorrect input amount when fee applicable

### DIFF
--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
-import { ETHER, Percent, Trade, TradeType } from '@uniswap/sdk'
+import { ETHER, Percent, TradeType } from '@uniswap/sdk'
 import { BigNumber } from 'ethers'
 
 import { BIPS_BASE, BUY_ETHER_TOKEN, INITIAL_ALLOWED_SLIPPAGE, RADIX_DECIMAL } from 'constants/index'
 
 import { useAddPendingOrder } from 'state/orders/hooks'
+import { TradeWithFee } from 'state/swap/extension'
 
 import { SwapCallbackState } from '@src/hooks/useSwapCallback'
 import useTransactionDeadline from '@src/hooks/useTransactionDeadline'
@@ -22,7 +23,7 @@ const MAX_VALID_TO_EPOCH = BigNumber.from('0xFFFFFFFF').toNumber() // Max uint32
 // returns a function that will execute a swap, if the parameters are all valid
 // and the user has approved the slippage adjusted input amount for the trade
 export function useSwapCallback(
-  trade: Trade | undefined, // trade to execute, required
+  trade: TradeWithFee | undefined, // trade to execute, required
   allowedSlippage: number = INITIAL_ALLOWED_SLIPPAGE, // in bips
   recipientAddressOrName: string | null // the ENS name or address of the recipient of the trade, or null if swap should be returned to sender
 ): { state: SwapCallbackState; callback: null | (() => Promise<string>); error: string | null } {
@@ -60,7 +61,10 @@ export function useSwapCallback(
       callback: async function onSwap(): Promise<string> {
         const {
           executionPrice,
+          // non-fee amount
           inputAmount: expectedInputAmount,
+          // input amount with fee calculated
+          inputAmountWithFee,
           nextMidPrice,
           outputAmount: expectedOutputAmount,
           priceImpact,
@@ -76,7 +80,7 @@ export function useSwapCallback(
         const kind = trade.tradeType === TradeType.EXACT_INPUT ? OrderKind.SELL : OrderKind.BUY
 
         console.log(
-          `[useSwapCallback] Trading ${routeDescription}. Input = ${inputAmount.toExact()}, Output = ${outputAmount.toExact()}, Price = ${executionPrice.toFixed()}, Details: `,
+          `[useSwapCallback] Trading ${routeDescription}. Input = ${inputAmount.toExact()}, InputWithFee = ${inputAmountWithFee.toExact()}, Output = ${outputAmount.toExact()}, Price = ${executionPrice.toFixed()}, Details: `,
           {
             expectedInputAmount: expectedInputAmount.toExact(),
             expectedOutputAmount: expectedOutputAmount.toExact(),
@@ -106,7 +110,7 @@ export function useSwapCallback(
           kind,
           account,
           chainId,
-          inputAmount,
+          inputAmount: inputAmountWithFee,
           outputAmount,
           sellToken,
           buyToken,

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -10,22 +10,26 @@ interface ExtendedTradeParams {
   feeAsCurrency?: CurrencyAmount
 }
 
+export type TradeWithFee = Trade & { inputAmountWithFee: CurrencyAmount }
+
 /**
  * extendExactInTrade
  * @description takes a Uni ExactIn Trade object and returns a custom one with fee adjusted inputAmount
  */
-export function extendExactInTrade(params: Pick<ExtendedTradeParams, 'exactInTrade' | 'typedAmountAsCurrency'>) {
+export function extendExactInTrade(
+  params: Pick<ExtendedTradeParams, 'exactInTrade' | 'typedAmountAsCurrency'>
+): TradeWithFee | null {
   const { exactInTrade, typedAmountAsCurrency } = params
 
   if (!exactInTrade || !typedAmountAsCurrency) return null
 
-  // We need to iverride the Trade object to use different values as we are intercepting initial inputs
+  // We need to override the Trade object to use different values as we are intercepting initial inputs
   // and applying fee. For ExactIn orders, we leave outputAmount as is
   // and only change inputAmount to show the original entry before fee calculation
   return {
     ...exactInTrade,
     inputAmount: typedAmountAsCurrency,
-    inputAmountWithFees: exactInTrade.inputAmount,
+    inputAmountWithFee: exactInTrade.inputAmount,
     minimumAmountOut: exactInTrade.minimumAmountOut,
     maximumAmountIn: exactInTrade.maximumAmountIn
   }
@@ -35,7 +39,9 @@ export function extendExactInTrade(params: Pick<ExtendedTradeParams, 'exactInTra
  * extendExactOutTrade
  * @description takes a Uni ExactOut Trade object and returns a custom one with fee adjusted inputAmount
  */
-export function extendExactOutTrade(params: Pick<ExtendedTradeParams, 'exactOutTrade' | 'feeAsCurrency'>) {
+export function extendExactOutTrade(
+  params: Pick<ExtendedTradeParams, 'exactOutTrade' | 'feeAsCurrency'>
+): TradeWithFee | null {
   const { exactOutTrade, feeAsCurrency } = params
 
   if (!exactOutTrade || !feeAsCurrency) return null
@@ -47,6 +53,7 @@ export function extendExactOutTrade(params: Pick<ExtendedTradeParams, 'exactOutT
   return {
     ...exactOutTrade,
     inputAmount: inputAmountWithFee,
+    inputAmountWithFee,
     minimumAmountOut: exactOutTrade.minimumAmountOut,
     maximumAmountIn: exactOutTrade.maximumAmountIn
   }

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -28,6 +28,8 @@ export function extendExactInTrade(
   // and only change inputAmount to show the original entry before fee calculation
   return {
     ...exactInTrade,
+    // overriding inputAmount is a hack
+    // to allow us to not have to change Uni's pages/swap/index and use different method names
     inputAmount: typedAmountAsCurrency,
     inputAmountWithFee: exactInTrade.inputAmount,
     minimumAmountOut: exactInTrade.minimumAmountOut,
@@ -52,6 +54,8 @@ export function extendExactOutTrade(
   // and only change outputAm to show the original entry before fee calculation
   return {
     ...exactOutTrade,
+    // overriding inputAmount is a hack
+    // to allow us to not have to change Uni's pages/swap/index and use different method names
     inputAmount: inputAmountWithFee,
     inputAmountWithFee,
     minimumAmountOut: exactOutTrade.minimumAmountOut,

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -1,5 +1,5 @@
 import useENS from '@src/hooks/useENS'
-import { Currency, CurrencyAmount, Trade } from '@uniswap/sdk'
+import { Currency, CurrencyAmount } from '@uniswap/sdk'
 import { useActiveWeb3React } from '@src/hooks'
 import { useCurrency } from '@src/hooks/Tokens'
 import { isAddress } from '@src/utils'
@@ -10,7 +10,7 @@ import { computeSlippageAdjustedAmounts } from '@src/utils/prices'
 import { tryParseAmount, useSwapState } from '@src/state/swap/hooks'
 import { useFee } from '../fee/hooks'
 import { registerOnWindow } from 'utils/misc'
-import { useTradeExactInWithFee, useTradeExactOutWithFee } from './extension'
+import { TradeWithFee, useTradeExactInWithFee, useTradeExactOutWithFee } from './extension'
 
 export * from '@src/state/swap/hooks'
 
@@ -18,7 +18,7 @@ interface DerivedSwapInfo {
   currencies: { [field in Field]?: Currency }
   currencyBalances: { [field in Field]?: CurrencyAmount }
   parsedAmount: CurrencyAmount | undefined
-  v2Trade: Trade | undefined
+  v2Trade: TradeWithFee | undefined
   // TODO: review this - we don't use a v1 trade but changing all code
   // or extending whole swap comp for only removing v1trade is a lot
   v1Trade: undefined


### PR DESCRIPTION
Closes #135 

Passes `inputAmountWithFee` to `useSwapCallback` to `POST` proper sell amount

Proof: when selling `0.04` ether with `0.02` ether fee, etherscan should show `0.04` sell, not `0.06` when order fulfilled:
![Screenshot from 2021-02-15 20-03-18](https://user-images.githubusercontent.com/21335563/107988903-461bb100-6fd1-11eb-82a3-487504d822f4.png)
