### PR TITLE
Hack negative slippage

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -18,7 +18,7 @@ import Modal from '../Modal'
 import QuestionHelper from '../QuestionHelper'
 import { RowBetween, RowFixed } from '../Row'
 import Toggle from '../Toggle'
-import TransactionSettings from '../TransactionSettings'
+import TransactionSettings from 'components/TransactionSettings'
 
 const StyledMenuIcon = styled(Settings)`
   height: 20px;

--- a/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
@@ -1,0 +1,261 @@
+import React, { useState, useRef, useContext } from 'react'
+import styled, { ThemeContext } from 'styled-components'
+
+import QuestionHelper from 'components/QuestionHelper'
+import { TYPE } from 'theme'
+import { AutoColumn } from 'components/Column'
+import { RowBetween, RowFixed } from 'components/Row'
+import { ParseCustomSlippageFn } from './index'
+
+import { darken } from 'polished'
+
+enum SlippageError {
+  InvalidInput = 'InvalidInput',
+  RiskyLow = 'RiskyLow',
+  RiskyHigh = 'RiskyHigh'
+}
+
+enum DeadlineError {
+  InvalidInput = 'InvalidInput'
+}
+
+const FancyButton = styled.button`
+  color: ${({ theme }) => theme.text1};
+  align-items: center;
+  height: 2rem;
+  border-radius: 36px;
+  font-size: 1rem;
+  width: auto;
+  min-width: 3.5rem;
+  border: 1px solid ${({ theme }) => theme.bg3};
+  outline: none;
+  background: ${({ theme }) => theme.bg1};
+  :hover {
+    border: 1px solid ${({ theme }) => theme.bg4};
+  }
+  :focus {
+    border: 1px solid ${({ theme }) => theme.primary1};
+  }
+`
+
+const Option = styled(FancyButton)<{ active: boolean }>`
+  margin-right: 8px;
+  :hover {
+    cursor: pointer;
+  }
+  background-color: ${({ active, theme }) => active && theme.primary1};
+  color: ${({ active, theme }) => (active ? theme.white : theme.text1)};
+`
+
+const Input = styled.input`
+  background: ${({ theme }) => theme.bg1};
+  font-size: 16px;
+  width: auto;
+  outline: none;
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+  }
+  color: ${({ theme, color }) => (color === 'red' ? theme.red1 : theme.text1)};
+  text-align: right;
+`
+
+const OptionCustom = styled(FancyButton)<{ active?: boolean; warning?: boolean }>`
+  height: 2rem;
+  position: relative;
+  padding: 0 0.75rem;
+  flex: 1;
+  border: ${({ theme, active, warning }) => active && `1px solid ${warning ? theme.red1 : theme.primary1}`};
+  :hover {
+    border: ${({ theme, active, warning }) =>
+      active && `1px solid ${warning ? darken(0.1, theme.red1) : darken(0.1, theme.primary1)}`};
+  }
+
+  input {
+    width: 100%;
+    height: 100%;
+    border: 0px;
+    border-radius: 2rem;
+  }
+`
+
+const SlippageEmojiContainer = styled.span`
+  color: #f3841e;
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    display: none;  
+  `}
+`
+
+export interface SlippageTabsProps {
+  rawSlippage: number
+  setRawSlippage: (rawSlippage: number) => void
+  deadline: number
+  setDeadline: (deadline: number) => void
+  parseCustomSlippageFn: ParseCustomSlippageFn
+}
+
+export default function SlippageTabs({
+  rawSlippage,
+  setRawSlippage,
+  deadline,
+  setDeadline,
+  parseCustomSlippageFn
+}: SlippageTabsProps) {
+  const theme = useContext(ThemeContext)
+
+  const inputRef = useRef<HTMLInputElement>()
+
+  const [slippageInput, setSlippageInput] = useState('')
+  const [deadlineInput, setDeadlineInput] = useState('')
+
+  const slippageInputIsValid =
+    slippageInput === '' || (rawSlippage / 100).toFixed(2) === Number.parseFloat(slippageInput).toFixed(2)
+  const deadlineInputIsValid = deadlineInput === '' || (deadline / 60).toString() === deadlineInput
+
+  let slippageError: SlippageError | undefined
+  if (slippageInput !== '' && !slippageInputIsValid) {
+    slippageError = SlippageError.InvalidInput
+  } else if (slippageInputIsValid && rawSlippage < 50) {
+    slippageError = SlippageError.RiskyLow
+  } else if (slippageInputIsValid && rawSlippage > 500) {
+    slippageError = SlippageError.RiskyHigh
+  } else {
+    slippageError = undefined
+  }
+
+  let deadlineError: DeadlineError | undefined
+  if (deadlineInput !== '' && !deadlineInputIsValid) {
+    deadlineError = DeadlineError.InvalidInput
+  } else {
+    deadlineError = undefined
+  }
+
+  // function parseCustomSlippage(value: string) {
+  //   setSlippageInput(value)
+
+  //   try {
+  //     const valueAsIntFromRoundedFloat = Number.parseInt((Number.parseFloat(value) * 100).toString())
+  //     if (!Number.isNaN(valueAsIntFromRoundedFloat) && valueAsIntFromRoundedFloat < 5000) {
+  //       setRawSlippage(valueAsIntFromRoundedFloat)
+  //     }
+  //   } catch {}
+  // }
+  const parseCustomSlippage = (value: string) => parseCustomSlippageFn(value, setRawSlippage, setSlippageInput)
+
+  function parseCustomDeadline(value: string) {
+    setDeadlineInput(value)
+
+    try {
+      const valueAsInt: number = Number.parseInt(value) * 60
+      if (!Number.isNaN(valueAsInt) && valueAsInt > 0) {
+        setDeadline(valueAsInt)
+      }
+    } catch {}
+  }
+
+  return (
+    <AutoColumn gap="md">
+      <AutoColumn gap="sm">
+        <RowFixed>
+          <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
+            Slippage tolerance
+          </TYPE.black>
+          <QuestionHelper text="Your transaction will revert if the price changes unfavorably by more than this percentage." />
+        </RowFixed>
+        <RowBetween>
+          <Option
+            onClick={() => {
+              setSlippageInput('')
+              setRawSlippage(10)
+            }}
+            active={rawSlippage === 10}
+          >
+            0.1%
+          </Option>
+          <Option
+            onClick={() => {
+              setSlippageInput('')
+              setRawSlippage(50)
+            }}
+            active={rawSlippage === 50}
+          >
+            0.5%
+          </Option>
+          <Option
+            onClick={() => {
+              setSlippageInput('')
+              setRawSlippage(100)
+            }}
+            active={rawSlippage === 100}
+          >
+            1%
+          </Option>
+          <OptionCustom active={![10, 50, 100].includes(rawSlippage)} warning={!slippageInputIsValid} tabIndex={-1}>
+            <RowBetween>
+              {!!slippageInput &&
+              (slippageError === SlippageError.RiskyLow || slippageError === SlippageError.RiskyHigh) ? (
+                <SlippageEmojiContainer>
+                  <span role="img" aria-label="warning">
+                    ⚠️
+                  </span>
+                </SlippageEmojiContainer>
+              ) : null}
+              {/* https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451 */}
+              <Input
+                ref={inputRef as any}
+                placeholder={(rawSlippage / 100).toFixed(2)}
+                value={slippageInput}
+                onBlur={() => {
+                  parseCustomSlippage((rawSlippage / 100).toFixed(2))
+                }}
+                onChange={e => parseCustomSlippage(e.target.value)}
+                color={!slippageInputIsValid ? 'red' : ''}
+              />
+              %
+            </RowBetween>
+          </OptionCustom>
+        </RowBetween>
+        {!!slippageError && (
+          <RowBetween
+            style={{
+              fontSize: '14px',
+              paddingTop: '7px',
+              color: slippageError === SlippageError.InvalidInput ? 'red' : '#F3841E'
+            }}
+          >
+            {slippageError === SlippageError.InvalidInput
+              ? 'Enter a valid slippage percentage'
+              : slippageError === SlippageError.RiskyLow
+              ? 'Your transaction may fail'
+              : 'Your transaction may be frontrun'}
+          </RowBetween>
+        )}
+      </AutoColumn>
+
+      <AutoColumn gap="sm">
+        <RowFixed>
+          <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+            Transaction deadline
+          </TYPE.black>
+          <QuestionHelper text="Your transaction will revert if it is pending for more than this long." />
+        </RowFixed>
+        <RowFixed>
+          <OptionCustom style={{ width: '80px' }} tabIndex={-1}>
+            <Input
+              color={!!deadlineError ? 'red' : undefined}
+              onBlur={() => {
+                parseCustomDeadline((deadline / 60).toString())
+              }}
+              placeholder={(deadline / 60).toString()}
+              value={deadlineInput}
+              onChange={e => parseCustomDeadline(e.target.value)}
+            />
+          </OptionCustom>
+          <TYPE.body style={{ paddingLeft: '8px' }} fontSize={14}>
+            minutes
+          </TYPE.body>
+        </RowFixed>
+      </AutoColumn>
+    </AutoColumn>
+  )
+}

--- a/src/custom/components/TransactionSettings/index.tsx
+++ b/src/custom/components/TransactionSettings/index.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import SlippageTabsMod, { SlippageTabsProps as SlippageTabsPropsMod } from './TransactionSetttingsMod'
+
+import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
+
+type SetRawSlippage = (rawSlippage: number) => void
+type SetSlippageInput = (value: React.SetStateAction<string>) => void
+
+function parseCustomSlippage(value: string, setRawSlippage: SetRawSlippage, setSlippageInput: SetSlippageInput): void {
+  // we don't allow negative slippage to be input
+  if (isNaN(Number(value)) || Number(value) < 0) {
+    return batchedUpdates(() => {
+      setSlippageInput('0')
+      setRawSlippage(0)
+    })
+  }
+
+  setSlippageInput(value)
+
+  try {
+    const valueAsIntFromRoundedFloat = Number.parseInt((Number.parseFloat(value) * 100).toString())
+    if (!Number.isNaN(valueAsIntFromRoundedFloat) && valueAsIntFromRoundedFloat < 5000) {
+      setRawSlippage(valueAsIntFromRoundedFloat)
+    }
+  } catch {}
+}
+
+export type ParseCustomSlippageFn = typeof parseCustomSlippage
+export type SlippageTabsProps = Omit<SlippageTabsPropsMod, 'parseCustomSlippageFn'>
+
+export default function SlippageTabs(params: SlippageTabsProps) {
+  return <SlippageTabsMod {...params} parseCustomSlippageFn={parseCustomSlippage} />
+}


### PR DESCRIPTION
Supersedes https://github.com/gnosis/gp-swap-ui/pull/157 

I created this PR to show that sometimes we can hack only the part we need to change. One way is using composition, and injecting the new logic. 

In this approach, all the new logic is in our `index.tsx`, the `Mod` has only some commented lines, a new parameter, and the call to the logic. 

I would consider in this case it was maybe overkilling inject the logic, since the logic was 4 lines. Although I find this approach very declarative in terms of what's our code. So an alternative would be to add those 4 lines in the Mod file. But I kind of like to have the hacks in the `index.ts`

So the point is, now the original function receives a function with the hack, so watching  this small file 33 lines should be enough to tell why we hacked and what we hacked:

```ts
export default function SlippageTabs(params: SlippageTabsProps) {
  return <SlippageTabsMod {...params} parseCustomSlippageFn={parseCustomSlippage} />
}
```

The mod file, still compares line to line. Only a few lines are commented (nothing was deleted as in #143 ), so it should be easy to keep track of the new features.
