### PR TITLE
[Part of fee] Show correct input amount in pending order toast

### DIFF
--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -16,7 +16,7 @@ import { useWrapEther } from 'hooks/useWrapEther'
 import { computeSlippageAdjustedAmounts } from 'utils/prices'
 import { postOrder } from 'utils/trade'
 import { OrderKind } from 'utils/signatures'
-import { TradeWithFee } from '../state/swap/extension'
+import { TradeWithFee } from 'state/swap/extension'
 
 const MAX_VALID_TO_EPOCH = BigNumber.from('0xFFFFFFFF').toNumber() // Max uint32 (Feb 07 2106 07:28:15 GMT+0100)
 
@@ -115,8 +115,10 @@ export function useSwapCallback(
           kind,
           account,
           chainId,
+          // unadjusted inputAmount
+          inputAmount: inputAmount,
           // pass inputAmount calculated with fee applied
-          inputAmount: inputAmountWithFee,
+          adjustedInputAmount: inputAmountWithFee,
           outputAmount,
           // pass Trade feeAmount as raw string or give 0
           feeAmount: fee?.feeAsCurrency?.raw.toString() || '0',

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -13,6 +13,7 @@ export interface PostOrderParams {
   signer: Signer
   kind: OrderKind
   inputAmount: CurrencyAmount
+  adjustedInputAmount: CurrencyAmount
   outputAmount: CurrencyAmount
   feeAmount: BigNumberish
   sellToken: Token
@@ -50,7 +51,7 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
     kind,
     addPendingOrder,
     chainId,
-    inputAmount,
+    adjustedInputAmount,
     outputAmount,
     sellToken,
     buyToken,
@@ -60,7 +61,7 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
     signer
   } = params
 
-  const sellAmount = inputAmount.raw.toString(RADIX_DECIMAL)
+  const sellAmount = adjustedInputAmount.raw.toString(RADIX_DECIMAL)
   const buyAmount = outputAmount.raw.toString(RADIX_DECIMAL)
 
   // Prepare order


### PR DESCRIPTION
Was showing the `adjustedInputAmount` - how shows the proper expected `inputAmount`

![Screenshot from 2021-02-25 17-55-12](https://user-images.githubusercontent.com/21335563/109195610-a1e4f780-7792-11eb-8c74-99ca0144a82c.png)
