### PR TITLE
Order toast message and showing correct amounts

### DIFF
--- a/src/custom/hooks/useSwapCallback.ts
+++ b/src/custom/hooks/useSwapCallback.ts
@@ -83,7 +83,8 @@ export function useSwapCallback(
             1. Original Input = ${inputAmount.toExact()}
             2. Fee = ${fee?.feeAsCurrency?.toExact() || '0'}
             3. Input Adjusted for Fee = ${inputAmountWithFee.toExact()}
-            4. Output = ${outputAmount.toExact()}
+            4. Expected Output = ${expectedOutputAmount.toExact()}
+            4b. Output with SLIPPAGE = ${outputAmount.toExact()}
             5. Price = ${executionPrice.toFixed()} 
             6. Details: `,
           {

--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -1,7 +1,7 @@
 import { createAction } from '@reduxjs/toolkit'
 import { OrderID } from 'utils/operator'
 import { OrderCreation } from 'utils/signatures'
-import { ChainId } from '@uniswap/sdk'
+import { ChainId, Currency } from '@uniswap/sdk'
 export { OrderKind } from '@gnosis.pm/gp-v2-contracts'
 
 export enum OrderStatus {
@@ -19,6 +19,8 @@ export interface Order extends OrderCreation {
   fulfilledTransactionHash?: string // hash of transaction when Order was fulfilled
   creationTime: string // Creation time of the order. Encoded as ISO 8601 UTC
   summary: string // for dapp use only, readable by user
+  inputCurrency: Pick<Currency, 'decimals' | 'symbol'> // for dapp use only, readable by user
+  outputCurrency: Pick<Currency, 'decimals' | 'symbol'> // for dapp use only, readable by user
 }
 
 // gotten from querying /api/v1/orders
@@ -47,6 +49,7 @@ export interface OrderFulfillmentData {
   id: OrderID
   fulfillmentTime: string
   transactionHash: string
+  summary?: string
 }
 
 export interface FulfillOrdersBatchParams {

--- a/src/custom/state/orders/helpers.ts
+++ b/src/custom/state/orders/helpers.ts
@@ -46,7 +46,7 @@ type MetaPopupContent = GPPopupContent<OrderTxTypes.METATXN>
 type TxnPopupContent = GPPopupContent<OrderTxTypes.TXN>
 
 function setOrderSummary({ id, summary, status, descriptor }: SetOrderSummaryParams) {
-  return summary ? `${summary} ${status}` : `Order ${formatOrderId(id)} ${descriptor || status}`
+  return summary ? `${summary} ${descriptor || status}` : `Order ${formatOrderId(id)} ${descriptor || status}`
 }
 
 // Metatxn popup

--- a/src/custom/state/orders/hooks.ts
+++ b/src/custom/state/orders/hooks.ts
@@ -170,6 +170,7 @@ export const useAddPendingOrder = (): AddOrderCallback => {
   return useCallback((addOrderParams: AddPendingOrderParams) => dispatch(addPendingOrder(addOrderParams)), [dispatch])
 }
 
+// unused except in mock
 export const useFulfillOrder = (): FulfillOrderCallback => {
   const dispatch = useDispatch<AppDispatch>()
   return useCallback((fulfillOrderParams: FulfillOrderParams) => dispatch(fulfillOrder(fulfillOrderParams)), [dispatch])

--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -80,10 +80,7 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
 
     if (isBatchFulfillOrderAction(action)) {
       // construct Fulfilled Order Popups for each Order
-      idsAndPopups = action.payload.ordersData.map(({ id, transactionHash }) => {
-        const orderObject = pending?.[id] || fulfilled?.[id] || expired?.[id]
-        const summary = orderObject?.order.summary
-
+      idsAndPopups = action.payload.ordersData.map(({ id, transactionHash, summary }) => {
         const popup = setPopupData(OrderTxTypes.TXN, {
           hash: transactionHash,
           summary,

--- a/src/custom/state/orders/mocks.ts
+++ b/src/custom/state/orders/mocks.ts
@@ -64,6 +64,8 @@ const generateOrder = ({ owner, sellToken, buyToken }: GenerateOrderParams): Ord
     status: OrderStatus.PENDING,
     creationTime: new Date().toISOString(),
     summary, // for dapp use only, readable by user
+    inputCurrency: sellToken,
+    outputCurrency: buyToken,
     sellToken: sellToken.address.replace('0x', ''), // address, without '0x' prefix
     buyToken: buyToken.address.replace('0x', ''), // address, without '0x' prefix
     sellAmount: sellAmount.toString(RADIX_DECIMAL), // in atoms

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -13,8 +13,10 @@ import {
 } from './hooks'
 import { buildBlock2DateMap } from 'utils/blocks'
 import { registerOnWindow } from 'utils/misc'
-import { GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
-import { GP_V2_SETTLEMENT_INTERFACE } from '@src/custom/constants/GPv2Settlement'
+import { getOrder, OrderMetaData } from 'utils/operator'
+import { GP_SETTLEMENT_CONTRACT_ADDRESS, SHORT_PRECISION } from 'constants/index'
+import { GP_V2_SETTLEMENT_INTERFACE } from 'constants/GPv2Settlement'
+import { stringToCurrency } from '../swap/extension'
 
 type OrderLogPopupMixData = OrderFulfillmentData & Pick<Log, 'transactionHash'> & Partial<Pick<Order, 'summary'>>
 
@@ -24,6 +26,37 @@ interface TradeEventParams {
   owner: string // address
   // maybe enable when orderUid is indexed
   // id?: string | string[] // to filter by id
+}
+
+function _computeFulfilledSummary({
+  orderFromStore,
+  orderFromApi
+}: {
+  orderFromStore?: Order
+  orderFromApi: OrderMetaData | null
+}) {
+  // Default to store's current order summary
+  let summary: string | undefined = orderFromStore?.summary
+
+  // if we can find the order from the API
+  // and our specific order exists in our state, let's use that
+  if (orderFromApi) {
+    const { buyToken, sellToken, executedBuyAmount, executedSellAmount } = orderFromApi
+
+    if (orderFromStore) {
+      const { inputCurrency, outputCurrency } = orderFromStore
+      // don't show amounts in atoms
+      const inputAmount = stringToCurrency(executedSellAmount, inputCurrency).toSignificant(SHORT_PRECISION)
+      const outputAmount = stringToCurrency(executedBuyAmount, outputCurrency).toSignificant(SHORT_PRECISION)
+
+      summary = `Swap ${inputAmount} ${inputCurrency.symbol} for ${outputAmount} ${outputCurrency.symbol}`
+    } else {
+      // We only have the API order info, let's at least use that
+      summary = `Swap ${sellToken} for ${buyToken}`
+    }
+  }
+
+  return summary
 }
 
 const generateTradeEventTopics = ({ owner /*, id */ }: TradeEventParams) => {
@@ -145,20 +178,28 @@ export function EventUpdater(): null {
 
       const block2DateMap = await buildBlock2DateMap(library, logs)
 
-      const ordersBatchData: OrderLogPopupMixData[] = logs.map(log => {
-        const { orderUid: id } = decodeTradeEvent(log)
+      const ordersBatchData: OrderLogPopupMixData[] = await Promise.all(
+        logs.map(async log => {
+          const { orderUid: id } = decodeTradeEvent(log)
 
-        console.log(`EventUpdater::Detected Trade event for order ${id} of token in block`, log.blockNumber)
+          console.log(`EventUpdater::Detected Trade event for order ${id} of token in block`, log.blockNumber)
 
-        const orderFromStore = findOrderById(id)
+          // Get order from our store
+          // and from the backened API
+          const orderFromStore = findOrderById(id)
+          const orderFromApi = await getOrder(chainId, id)
 
-        return {
-          id,
-          fulfillmentTime: block2DateMap[log.blockHash].toISOString(),
-          transactionHash: log.transactionHash,
-          summary: orderFromStore?.summary // only if that order was previously in store
-        }
-      })
+          // using order from store and api compute summary
+          const summary = _computeFulfilledSummary({ orderFromApi, orderFromStore })
+
+          return {
+            id,
+            fulfillmentTime: block2DateMap[log.blockHash].toISOString(),
+            transactionHash: log.transactionHash,
+            summary
+          }
+        })
+      )
 
       // SET lastCheckedBlock = lastBlockNumber
       // AND fulfill orders

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -74,7 +74,7 @@ interface TradeParams {
   feeInformation?: Omit<FeeInformation, 'expirationDate'>
 }
 
-const stringToCurrency = (amount: string, currency: Currency) =>
+export const stringToCurrency = (amount: string, currency: Currency) =>
   currency instanceof Token ? new TokenAmount(currency, JSBI.BigInt(amount)) : CurrencyAmount.ether(JSBI.BigInt(amount))
 
 /**

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -35,6 +35,28 @@ export interface FeeInformation {
   feeRatio: number
 }
 
+export interface OrderMetaData {
+  creationDate: string
+  owner: string
+  uid: OrderID
+  availableBalance: string
+  executedBuyAmount: string
+  executedSellAmount: string
+  executedSellAmountBeforeFees: string
+  executedFeeAmount: string
+  invalidated: false
+  sellToken: string
+  buyToken: string
+  sellAmount: string
+  buyAmount: string
+  validTo: number
+  appData: number
+  feeAmount: string
+  kind: string
+  partiallyFillable: false
+  signature: string
+}
+
 function _getApiBaseUrl(chainId: ChainId): string {
   const baseUrl = API_BASE_URL[chainId]
 
@@ -154,11 +176,7 @@ function checkIfEther(tokenAddress: string, chainId: ChainId) {
 
 export async function getFeeQuote(chainId: ChainId, tokenAddress: string): Promise<FeeInformation> {
   const checkedAddress = checkIfEther(tokenAddress, chainId)
-  // TODO: I commented out the implementation because the API is not yet implemented. Review the code in the comment below
   console.log('[util:operator] Get fee for ', chainId, checkedAddress)
-
-  // TODO: Let see if we can incorporate the PRs from the Fee, where they cache stuff and keep it in sync using redux.
-  // if that part is delayed or need more review, we can easily add the cache in this file (we check expiration and cache here)
 
   let response: Response | undefined
   try {
@@ -175,5 +193,24 @@ export async function getFeeQuote(chainId: ChainId, tokenAddress: string): Promi
   }
 }
 
+export async function getOrder(chainId: ChainId, orderId: string): Promise<OrderMetaData | null> {
+  console.log('[util:operator] Get order for ', chainId, orderId)
+
+  let response: Response | undefined
+  try {
+    const responseMaybeOk = await _get(chainId, `/orders/${orderId}`)
+    response = responseMaybeOk.ok ? responseMaybeOk : undefined
+  } catch (error) {
+    // do nothing
+  }
+
+  if (!response) {
+    // return null on error or non-ok status
+    return null
+  } else {
+    return response.json()
+  }
+}
+
 // Register some globals for convenience
-registerOnWindow({ operator: { getFeeQuote, postSignedOrder, apiGet: _get, apiPost: _post } })
+registerOnWindow({ operator: { getFeeQuote, getOrder, postSignedOrder, apiGet: _get, apiPost: _post } })


### PR DESCRIPTION
Waterfalls in #161 

Shows the proper `executedSellAmount` in the toast notifications on `fulfilledOrders`

Refer to #161 for the breakdown of numbers and what we want to show

In a nutshell: when orders are `fulfilled` `orders/updater` calls `/api/orders/{uuid}` and computes final toast order summary using the redux order summary and the new info: `executedSellAmount` / `executedBuyAmount` to show the proper numbers in the notification

**Assuming:** (contrived)
Slippage: 0.5%
Sell: 0.5 DAI for WETH
To (estimated): `0.005 WETH`
Min. received: `0.005 * 1 - 0.005(slippage)` = `0.004975 WETH`

**before**
`Swap 0.5 DAI for 0.004975 WETH was traded`
Wrong as it was showing the `Min. Received` instead of the actual `executedBuyAmount` from the API

**now**
(assuming API for this order returns: `executedBuyAmount: 0.004986`
`Swap 0.5 DAI for 0.004986 WETH was traded`
Correct as it is now showing the actual executed trade amount