### PR TITLE
Fix DAI logo in token list

### DIFF
--- a/src/custom/tokens/rinkeby-token-list.json
+++ b/src/custom/tokens/rinkeby-token-list.json
@@ -44,7 +44,7 @@
         "symbol": "DAI",
         "decimals": 18,
         "address": "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa",
-        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6b175474e89094c44da98b954eedeac495271d0f/logo.png"
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
       },
       {
         "name": "TUSD",


### PR DESCRIPTION
The logos URLs are case sensitive.

The current logo URL for DAI returns **Not Found** 