### PR TITLE
[165::Bug fix] - Delay querying backend for fulfilled order data

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -38,3 +38,4 @@ export const BUY_ETHER_TOKEN: { [chainId in ChainId]: Token } = {
 }
 
 export const ORDER_ID_SHORT_LENGTH = 8
+export const DEFAULT_ORDER_DELAY = 20000 // 20s

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -193,6 +193,7 @@ export function EventUpdater(): null {
           // We've found the orderId in the Trade event
           // But the backend may not be completely updated yet, e.g
           // the frontend is ahead of the backend in regards to data freshness
+          // TODO: temporary! change to a better solution
           const orderFromApi = await delay(DEFAULT_ORDER_DELAY, getOrder(chainId, id))
 
           // using order from store and api compute summary

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -14,14 +14,13 @@ import {
 import { buildBlock2DateMap } from 'utils/blocks'
 import { delay, registerOnWindow } from 'utils/misc'
 import { getOrder, OrderMetaData } from 'utils/operator'
-import { GP_SETTLEMENT_CONTRACT_ADDRESS, SHORT_PRECISION } from 'constants/index'
+import { DEFAULT_ORDER_DELAY, GP_SETTLEMENT_CONTRACT_ADDRESS, SHORT_PRECISION } from 'constants/index'
 import { GP_V2_SETTLEMENT_INTERFACE } from 'constants/GPv2Settlement'
 import { stringToCurrency } from '../swap/extension'
 
 type OrderLogPopupMixData = OrderFulfillmentData & Pick<Log, 'transactionHash'> & Partial<Pick<Order, 'summary'>>
 
 const TradeEvent = GP_V2_SETTLEMENT_INTERFACE.getEvent('Trade')
-const DEFAULT_ORDER_DELAY = 20000 // 20 seconds
 
 interface TradeEventParams {
   owner: string // address


### PR DESCRIPTION
Branched off of #192 

Potentially closes #165 

Delays the querying of the backend for a detected fulfilled order (20 second delay)

Difficulty: how to test this is actually working and now still just a race condition?