### PR TITLE
[189 pt.2] - Confirmation Modal // Tooltip text

### DIFF
--- a/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
@@ -8,6 +8,7 @@ import { RowBetween, RowFixed } from 'components/Row'
 import { ParseCustomSlippageFn } from './index'
 
 import { darken } from 'polished'
+import { INPUT_OUTPUT_EXPLANATION } from 'constants/index'
 
 enum SlippageError {
   InvalidInput = 'InvalidInput',
@@ -160,7 +161,12 @@ export default function SlippageTabs({
           <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
             Slippage tolerance
           </TYPE.black>
-          <QuestionHelper text="Your transaction will expire if the price changes unfavorably by more than this percentage." />
+          <QuestionHelper
+            text={
+              'Your swap will expire if the price changes unfavourably by more than your selected percentage. ' +
+              INPUT_OUTPUT_EXPLANATION
+            }
+          />
         </RowFixed>
         <RowBetween>
           <Option
@@ -237,7 +243,12 @@ export default function SlippageTabs({
           <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
             Transaction deadline
           </TYPE.black>
-          <QuestionHelper text="Your transaction will expire if it is pending for more than this long." />
+          <QuestionHelper
+            text={
+              'Your swap will expire if it is pending for longer than your selected duration. ' +
+              INPUT_OUTPUT_EXPLANATION
+            }
+          />
         </RowFixed>
         <RowFixed>
           <OptionCustom style={{ width: '80px' }} tabIndex={-1}>

--- a/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
@@ -163,7 +163,7 @@ export default function SlippageTabs({
           </TYPE.black>
           <QuestionHelper
             text={
-              'Your swap will expire if the price changes unfavourably by more than your selected percentage. ' +
+              'Your swap expires and will not execute if the price changes unfavourably by more than the selected percentage. ' +
               INPUT_OUTPUT_EXPLANATION
             }
           />
@@ -245,7 +245,7 @@ export default function SlippageTabs({
           </TYPE.black>
           <QuestionHelper
             text={
-              'Your swap will expire if it is pending for longer than your selected duration. ' +
+              'Your swap expires and will not execute if it is pending for longer than the selected duration. ' +
               INPUT_OUTPUT_EXPLANATION
             }
           />

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -13,6 +13,7 @@ import CurrencyLogo from 'components/CurrencyLogo'
 import { RowBetween, RowFixed } from 'components/Row'
 import { TruncatedText, SwapShowAcceptChanges } from 'components/swap/styleds'
 import { TradeWithFee } from 'state/swap/extension'
+import { INPUT_OUTPUT_EXPLANATION } from 'constants/index'
 
 export interface SwapModalHeaderProps {
   trade: TradeWithFee
@@ -109,7 +110,7 @@ export default function SwapModalHeader({
               {slippageAdjustedAmounts[Field.OUTPUT]?.toSignificant(6)} {trade.outputAmount.currency.symbol}
             </b>
             {/* {' or the transaction will revert.'} */}
-            {' or the transaction will expire.'}
+            {'or the swap will not execute. ' + INPUT_OUTPUT_EXPLANATION}
           </TYPE.italic>
         ) : (
           <TYPE.italic textAlign="left" style={{ width: '100%' }}>
@@ -118,7 +119,7 @@ export default function SwapModalHeader({
               {slippageAdjustedAmounts[Field.INPUT]?.toSignificant(6)} {trade.inputAmount.currency.symbol}
             </b>
             {/* {' or the transaction will revert.'} */}
-            {' or the transaction will expire.'}
+            {'or the swap will not execute. ' + INPUT_OUTPUT_EXPLANATION}
           </TYPE.italic>
         )}
       </AutoColumn>

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -110,7 +110,7 @@ export default function SwapModalHeader({
               {slippageAdjustedAmounts[Field.OUTPUT]?.toSignificant(6)} {trade.outputAmount.currency.symbol}
             </b>
             {/* {' or the transaction will revert.'} */}
-            {'or the swap will not execute. ' + INPUT_OUTPUT_EXPLANATION}
+            {' or the swap will not execute. ' + INPUT_OUTPUT_EXPLANATION}
           </TYPE.italic>
         ) : (
           <TYPE.italic textAlign="left" style={{ width: '100%' }}>

--- a/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
+++ b/src/custom/components/swap/SwapModalHeader/SwapModalHeaderMod.tsx
@@ -119,7 +119,7 @@ export default function SwapModalHeader({
               {slippageAdjustedAmounts[Field.INPUT]?.toSignificant(6)} {trade.inputAmount.currency.symbol}
             </b>
             {/* {' or the transaction will revert.'} */}
-            {'or the swap will not execute. ' + INPUT_OUTPUT_EXPLANATION}
+            {' or the swap will not execute. ' + INPUT_OUTPUT_EXPLANATION}
           </TYPE.italic>
         )}
       </AutoColumn>

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -38,3 +38,5 @@ export const BUY_ETHER_TOKEN: { [chainId in ChainId]: Token } = {
 }
 
 export const ORDER_ID_SHORT_LENGTH = 8
+
+export const INPUT_OUTPUT_EXPLANATION = 'Non-executed swaps do not incur any fees.'

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -39,4 +39,4 @@ export const BUY_ETHER_TOKEN: { [chainId in ChainId]: Token } = {
 
 export const ORDER_ID_SHORT_LENGTH = 8
 
-export const INPUT_OUTPUT_EXPLANATION = 'Non-executed swaps do not incur any fees.'
+export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'


### PR DESCRIPTION
Branched off #161

Closes #189 

Fixes wording in Confirmation modal and tooltips as laid out in #189 

![Screenshot from 2021-03-08 14-53-30](https://user-images.githubusercontent.com/21335563/110338132-94473180-801e-11eb-880f-75123ca04b75.png)
![Screenshot from 2021-03-08 14-53-12](https://user-images.githubusercontent.com/21335563/110338134-94dfc800-801e-11eb-9883-7492a9bda948.png)
![Screenshot from 2021-03-08 14-53-07](https://user-images.githubusercontent.com/21335563/110338137-95785e80-801e-11eb-9405-771df6f09115.png)

