### PR TITLE
Point fulfillment pop-ups to explorer instead of etherscan

### DIFF
--- a/src/custom/state/orders/middleware.ts
+++ b/src/custom/state/orders/middleware.ts
@@ -44,10 +44,9 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
       // Pending Order Popup
       popup = setPopupData(OrderTxTypes.METATXN, { summary, status: 'submitted', id })
     } else if (isFulfillOrderAction(action)) {
-      const { transactionHash: hash } = action.payload
-
-      popup = setPopupData(OrderTxTypes.TXN, {
-        hash,
+      // it's an OrderTxTypes.TXN, yes, but we still want to point to the explorer
+      // because it's nicer there
+      popup = setPopupData(OrderTxTypes.METATXN, {
         summary,
         id,
         status: OrderActions.OrderStatus.FULFILLED,
@@ -80,9 +79,11 @@ export const popupMiddleware: Middleware<{}, AppState> = store => next => action
 
     if (isBatchFulfillOrderAction(action)) {
       // construct Fulfilled Order Popups for each Order
-      idsAndPopups = action.payload.ordersData.map(({ id, transactionHash, summary }) => {
-        const popup = setPopupData(OrderTxTypes.TXN, {
-          hash: transactionHash,
+
+      idsAndPopups = action.payload.ordersData.map(({ id, summary }) => {
+        // it's an OrderTxTypes.TXN, yes, but we still want to point to the explorer
+        // because it's nicer there
+        const popup = setPopupData(OrderTxTypes.METATXN, {
           summary,
           id,
           status: OrderActions.OrderStatus.FULFILLED,


### PR DESCRIPTION
# Summary

Fulfillment notification pop-ups say they pointing to etherscan, but in fact the link goes to explorer.
![screenshot_2021-03-10_10-28-34](https://user-images.githubusercontent.com/43217/110696923-891c0f00-81a0-11eb-999c-bb046aff471f.png)
Which in the ends doesn't work, because it uses the tx hash as order id.

This change makes the pop-up have the correct wording and use the order id instead of tx hash.
![screenshot_2021-03-10_12-52-51](https://user-images.githubusercontent.com/43217/110696914-85888800-81a0-11eb-8094-01993d2f3efc.png)

# Testing

1. Place an order between liquid pairs (on Rinkeby I had all orders settled between WETH <-> UNI)
2. Wait a few minutes for the trade notification

- [ ] Pop-up should say `View on Explorer`
- [ ] Link should lead to the order details on the Explorer

