### PR TITLE
163/Fix wrong wallet name

### DIFF
--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -128,7 +128,7 @@ export default function AccountDetails({
           <YourAccount>
             <InfoCard>
               <AccountGroupingRow>
-                {formatConnectorName()}
+                {formatConnectorName(connector)}
                 <div>
                   {connector !== injected && connector !== walletlink && (
                     <WalletAction


### PR DESCRIPTION
# Summary

Closes #163

Fix wrong wallet name
![screenshot_2021-03-10_13-30-39](https://user-images.githubusercontent.com/43217/110700511-e3b76a00-81a4-11eb-95da-daee835cba3b.png)

Probably during a refactor the function was moved out of the component but the argument was not added to where it's called.

# Testing

1. Open the app
2. Connect a wallet (MM for example)
3. Click on your account address to bring up the accounts details modal
- [ ] Should have the correct wallet name