### PR TITLE
Tokens-by-Network logic update

### DIFF
--- a/src/custom/state/lists/helpers.ts
+++ b/src/custom/state/lists/helpers.ts
@@ -86,11 +86,12 @@ export function _updateState({
 }: {
   storageKey: string
   state: ListsState
-  dispatch: React.Dispatch<any>
+  dispatch?: React.Dispatch<any>
 }) {
   return batchedUpdates(() => {
     // save chain aware tokens to localStorage and redux
-    dispatch(initialiseTokenLists(state))
+    // if dispatch is falsy, skip initialising the lists
+    dispatch && dispatch(initialiseTokenLists(state))
     localStorage.setItem(storageKey, JSON.stringify(state))
   })
 }

--- a/src/custom/state/lists/hooks/hooksMod.ts
+++ b/src/custom/state/lists/hooks/hooksMod.ts
@@ -1,0 +1,6 @@
+import { useSelector } from 'react-redux'
+import { AppState } from '../..'
+
+export function useFullLists() {
+  return useSelector<AppState, AppState['lists']>(state => state.lists)
+}

--- a/src/custom/state/lists/hooks/index.ts
+++ b/src/custom/state/lists/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './hooksMod'
+export * from '@src/state/lists/hooks'


### PR DESCRIPTION
This PR waterfalls into #107 

Adds a `useEffect` block in the existing `NetworkListsUpdater` to check a change in chainId and save the `previousChainTokenLists` to `localStorage`

Also adds a helper hook for grabbing all list state