### PR TITLE
[237 ]Fix toast message/urls

### DIFF
--- a/src/custom/components/Popups/TransactionPopupMod.tsx
+++ b/src/custom/components/Popups/TransactionPopupMod.tsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react'
+import React, { useContext, useMemo } from 'react'
 import { AlertCircle, CheckCircle } from 'react-feather'
 import styled, { ThemeContext } from 'styled-components'
 import { useActiveWeb3React } from 'hooks'
-import { TYPE } from 'theme'
-// import { ExternalLink } from 'theme'
-// import { getEtherscanLink } from 'utils'
+import { TYPE, ExternalLink } from 'theme'
 import { AutoColumn } from 'components/Column'
 import { AutoRow } from 'components/Row'
-import { ExplorerLink } from '../ExplorerLink'
+import { getEtherscanLink, getExplorerLabel } from 'utils'
 
 const RowNoFlex = styled(AutoRow)`
   flex-wrap: nowrap;
@@ -26,17 +24,23 @@ export default function TransactionPopup({
 
   const theme = useContext(ThemeContext)
 
+  const [transactionUrl, hashToDisplay, transactionLabel] = useMemo(
+    () => [
+      chainId && getEtherscanLink(chainId, hash, 'transaction'),
+      hash.slice(0, 8) + '...' + hash.slice(58, 65),
+      chainId && getExplorerLabel(chainId, hash, 'transaction')
+    ],
+    [chainId, hash]
+  )
+
   return (
     <RowNoFlex>
       <div style={{ paddingRight: 16 }}>
         {success ? <CheckCircle color={theme.green1} size={24} /> : <AlertCircle color={theme.red1} size={24} />}
       </div>
       <AutoColumn gap="8px">
-        <TYPE.body fontWeight={500}>{summary ?? 'Hash: ' + hash.slice(0, 8) + '...' + hash.slice(58, 65)}</TYPE.body>
-        {chainId && (
-          // <ExternalLink href={getEtherscanLink(chainId, hash, 'transaction')}>View on Etherscan</ExternalLink>
-          <ExplorerLink id={hash} />
-        )}
+        <TYPE.body fontWeight={500}>{summary ?? 'Hash: ' + hashToDisplay}</TYPE.body>
+        {transactionUrl && <ExternalLink href={transactionUrl}>{transactionLabel}</ExternalLink>}
       </AutoColumn>
     </RowNoFlex>
   )

--- a/src/custom/state/orders/mocks.ts
+++ b/src/custom/state/orders/mocks.ts
@@ -42,8 +42,8 @@ interface GenerateOrderParams extends Pick<Order, 'owner'> {
 
 // increment for OrderId
 let orderN = 1
-const generateOrderId = (ind: number) => {
-  return `OrderId_${ind}_`.padEnd(56 * 2, 'X')
+const generateOrderId = () => {
+  return '0x'.padEnd(57 * 2, Math.floor(Math.random() * 10).toString())
 }
 
 const generateOrder = ({ owner, sellToken, buyToken }: GenerateOrderParams): Order => {
@@ -57,7 +57,7 @@ const generateOrder = ({ owner, sellToken, buyToken }: GenerateOrderParams): Ord
   } for ${(buyAmount / 10 ** buyToken.decimals).toFixed(2)} ${buyToken.symbol}`
 
   return {
-    id: generateOrderId(orderN), // Unique identifier for the order: 56 bytes encoded as hex without 0x
+    id: generateOrderId(), // Unique identifier for the order: 56 bytes encoded as hex without 0x
     owner: owner.replace('0x', ''),
     status: OrderStatus.PENDING,
     creationTime: new Date().toISOString(),


### PR DESCRIPTION
Closes #237 

There was a fix a while back to fix Explorer vs Etherscan links/messages in toast but it wasn't considering `approve` transactions which were pointing at GP Explorer

Also fixes `mock/orders` to allow testing propery. Can be reenabled to see the correct links. To test the `approve` toast you have to make an approve tx

I'd like this to be in #247 @alfetopito @anxolin 
