### PR TITLE
Check localstorage token lists shape matches new state

### DIFF
--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -1,4 +1,4 @@
-import { TokenAddressMap, useDefaultTokenList, useUnsupportedTokenList } from './../state/lists/hooks'
+import { TokenAddressMap, useDefaultTokenList, useUnsupportedTokenList } from 'state/lists/hooks'
 import { parseBytes32String } from '@ethersproject/strings'
 import { Currency, ETHER, Token, currencyEquals } from '@uniswap/sdk'
 import { useMemo } from 'react'


### PR DESCRIPTION
Waterfalls into #244 

This PR is to make sure that the `localstorage` token lists saved matches the new shape created in PR #244 

Seeing as the fundamental type shape changes, it was breaking when not returning the new `initialState` inside the `reducerMod` case of `updateVersion` - as that action is fired on load to initialise tokens lists from `localStorage`

If a user has the old shape saved in storage, it would throw. This PR fixes that.

### Test:
Copy the `localStorage` for `redux_local_storage_simple_lists` entry from `gp-swap.staging.gnosisdev.com` into the same key in this PR and see that it changes. Can also check redux store to see if changes the `lists` entry when detecting incompatible data shape.