### PR TITLE
[165] Expired Order delay

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -40,4 +40,5 @@ export const BUY_ETHER_TOKEN: { [chainId in ChainId]: Token } = {
 export const ORDER_ID_SHORT_LENGTH = 8
 export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
 export const DEFAULT_ORDER_DELAY = 20000 // 20s
-export const EXPIRED_ORDERS_BUFFER = 60 * 2 * 1000 // 2 minutes
+export const EXPIRED_ORDERS_BUFFER = 45 * 1000 // 45s
+export const CHECK_EXPIRED_ORDERS_INTERVAL = 10000 // 10 sec

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -40,3 +40,4 @@ export const BUY_ETHER_TOKEN: { [chainId in ChainId]: Token } = {
 export const ORDER_ID_SHORT_LENGTH = 8
 export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
 export const DEFAULT_ORDER_DELAY = 20000 // 20s
+export const EXPIRED_ORDERS_BUFFER = 60 * 2 * 1000 // 2 minutes

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -18,7 +18,8 @@ import {
   DEFAULT_ORDER_DELAY,
   GP_SETTLEMENT_CONTRACT_ADDRESS,
   SHORT_PRECISION,
-  EXPIRED_ORDERS_BUFFER
+  EXPIRED_ORDERS_BUFFER,
+  CHECK_EXPIRED_ORDERS_INTERVAL
 } from 'constants/index'
 import { GP_V2_SETTLEMENT_INTERFACE } from 'constants/GPv2Settlement'
 import { stringToCurrency } from '../swap/extension'
@@ -123,15 +124,6 @@ const constructGetLogsRetry = (provider: Web3Provider) => {
   }
 
   return getLogsRetry
-}
-
-/**
- * @name _validToWithBuffer
- * @description returns order validTo with added buffer time
- * @param buffer buffer amount in MS
- */
-function _validToWithBuffer(validTo: Date, buffer = 0) {
-  return new Date(Date.parse(validTo.toUTCString()) + buffer)
 }
 
 export function EventUpdater(): null {
@@ -300,8 +292,6 @@ export function EventUpdater(): null {
   return null
 }
 
-const CHECK_EXPIRED_ORDERS_INTERVAL = 10000 // 10 sec
-
 export function ExpiredOrdersWatcher(): null {
   const { chainId } = useActiveWeb3React()
 
@@ -327,7 +317,7 @@ export function ExpiredOrdersWatcher(): null {
         const validTo = typeof order.validTo === 'number' ? new Date(order.validTo * 1000) : order.validTo
 
         // let's get the current date, with our expired order validTo given a buffer time
-        return _validToWithBuffer(validTo, EXPIRED_ORDERS_BUFFER) < now
+        return now.valueOf() - validTo.valueOf() < EXPIRED_ORDERS_BUFFER
       })
 
       const expiredIds = expiredOrders.map(({ id }) => id)

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -311,13 +311,12 @@ export function ExpiredOrdersWatcher(): null {
       // but don't clearInterval so we can restart when there are new orders
       if (pendingOrdersRef.current.length === 0) return
 
-      const now = new Date()
       const expiredOrders = pendingOrdersRef.current.filter(order => {
         // validTo is either a Date or unix timestamp in seconds
         const validTo = typeof order.validTo === 'number' ? new Date(order.validTo * 1000) : order.validTo
 
         // let's get the current date, with our expired order validTo given a buffer time
-        return now.valueOf() - validTo.valueOf() < EXPIRED_ORDERS_BUFFER
+        return Date.now() - validTo.valueOf() > EXPIRED_ORDERS_BUFFER
       })
 
       const expiredIds = expiredOrders.map(({ id }) => id)

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -126,12 +126,12 @@ const constructGetLogsRetry = (provider: Web3Provider) => {
 }
 
 /**
- * @name getNowWithBuffer
- * @description returns current date with added buffer time
+ * @name _validToWithBuffer
+ * @description returns order validTo with added buffer time
  * @param buffer buffer amount in MS
  */
-function _getNowWithBuffer(buffer = 0) {
-  return new Date(Date.now() + buffer)
+function _validToWithBuffer(validTo: Date, buffer = 0) {
+  return new Date(Date.parse(validTo.toUTCString()) + buffer)
 }
 
 export function EventUpdater(): null {
@@ -321,13 +321,13 @@ export function ExpiredOrdersWatcher(): null {
       // but don't clearInterval so we can restart when there are new orders
       if (pendingOrdersRef.current.length === 0) return
 
-      // let's get the current date, with our expired order buffer time set in
-      const nowWithBuffer = _getNowWithBuffer(EXPIRED_ORDERS_BUFFER)
+      const now = new Date()
       const expiredOrders = pendingOrdersRef.current.filter(order => {
         // validTo is either a Date or unix timestamp in seconds
         const validTo = typeof order.validTo === 'number' ? new Date(order.validTo * 1000) : order.validTo
 
-        return validTo < nowWithBuffer
+        // let's get the current date, with our expired order validTo given a buffer time
+        return _validToWithBuffer(validTo, EXPIRED_ORDERS_BUFFER) < now
       })
 
       const expiredIds = expiredOrders.map(({ id }) => id)


### PR DESCRIPTION
Closes #165 - Order X has expired message shown followed by a fulfilled order message due to race conditions

This PR doesn't address the race condition underlying issue as that is a more extensive fix for later. I believe for the forementioned, a good solution could (waiting on confirmation) be querying the `orders` endpoint and checking the `OrderMetaData["invalidated"]` prop, which, if reliable, would allow us to check against potentially `expired` orders list if they are indeed `invalidated`

However this fix adds a `BUFFER` time in MS to the user selected `validTo` (2minutes right now) and uses that to check if an expired order notification should be sent out