### PR TITLE
Move appStatus label out of the mod

### DIFF
--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -7,8 +7,6 @@ import { Text } from 'rebass'
 
 import styled from 'styled-components'
 
-import { status as appStatus } from '@src/../package.json'
-
 // import Logo from 'assets/svg/logo.svg'
 // import LogoDark from 'assets/svg/logo_white.svg'
 
@@ -309,23 +307,7 @@ const CHAIN_CURRENCY_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.XDAI]: 'xDAI'
 }
 
-const Wrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  font-size: 10px;
-
-  background: ${({ theme }) => theme.primary1};
-  border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
-
-  /* negative margin matches logo margin right */
-  margin: auto 0 0 -10px;
-  padding: 2px 6px;
-`
-const AppStatus = ({ appStatus }: { appStatus?: string }) => <Wrapper>{appStatus}</Wrapper>
-
-export default function HeaderMod(props: WithClassName) {
+export default function HeaderMod(props: { statusLabel: React.ReactNode } & WithClassName) {
   const { account, chainId } = useActiveWeb3React()
   // const { t } = useTranslation()
 
@@ -361,7 +343,7 @@ export default function HeaderMod(props: WithClassName) {
             <LogoImage />
           </UniIcon>
         </Title>
-        {appStatus && <AppStatus appStatus={appStatus} />}
+        {props.statusLabel}
         <HeaderLinks>
           {/* <StyledNavLink id={`swap-nav-link`} to={'/swap'}>
             {t('swap')}

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -26,6 +26,7 @@ const AppStatusWrapper = styled.div`
   font-weight: 800;
   letter-spacing: 0.2rem;
   text-transform: uppercase;
+  border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
 `
 
 export const LogoImage = styled.img.attrs(props => ({

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -17,16 +17,12 @@ const AppStatusWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 8px;
-  background: white;
-  border: 2px solid ${({ theme }) => theme.primary1};
-  color: ${({ theme }) => theme.primary1};
-  margin: auto 0 -5px -5px;
-  padding: 3px 6px;
-  font-weight: 800;
-  letter-spacing: 0.2rem;
-  text-transform: uppercase;
+  font-size: 10px;
+  background: ${({ theme }) => theme.primary1};
   border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
+  /* negative margin matches logo margin right */
+  margin: auto 0 0 -10px;
+  padding: 2px 6px;
 `
 
 export const LogoImage = styled.img.attrs(props => ({

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -1,13 +1,31 @@
+import React from 'react'
 import HeaderMod, { UniIcon } from './HeaderMod'
 import styled from 'styled-components'
+import { status as appStatus } from '@src/../package.json'
+
 export { NETWORK_LABELS } from './HeaderMod'
 
-export const Header = styled(HeaderMod)`
+export const HeaderModWrapper = styled(HeaderMod)`
   border-bottom: ${({ theme }) => (theme.header?.border ? theme.header.border : `1px solid ${theme.border}`)};
 
   ${UniIcon} {
     display: flex;
   }
+`
+
+const AppStatusWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  background: white;
+  border: 2px solid ${({ theme }) => theme.primary1};
+  color: ${({ theme }) => theme.primary1};
+  margin: auto 0 -5px -5px;
+  padding: 3px 6px;
+  font-weight: 800;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
 `
 
 export const LogoImage = styled.img.attrs(props => ({
@@ -19,4 +37,6 @@ export const LogoImage = styled.img.attrs(props => ({
   object-fit: contain;
 `
 
-export default Header
+export default function Header() {
+  return <HeaderModWrapper statusLabel={<AppStatusWrapper>{appStatus}</AppStatusWrapper>} />
+}


### PR DESCRIPTION
This PR is mainly to move out of the "Mod" file of the header one additional element we included.
We try to keep the mods as closed as possible as in uni, so most of the new things should be done in the index.tsx

I took the opportunity of making this change, to modify a bit the styles. I'm happy if we want to restore the old ones or improve my proposal. I changed it mainly to try to make it more readable.

Before:
![image](https://user-images.githubusercontent.com/2352112/111814904-53330500-88db-11eb-827f-ff9d0061f305.png)

After:
![image](https://user-images.githubusercontent.com/2352112/111814947-60e88a80-88db-11eb-8a7a-7c1119988b2e.png)

Edit: I ended up roudeding also the corners, not sure what's best
![image](https://user-images.githubusercontent.com/2352112/111815129-98573700-88db-11eb-9e74-a814af85e4d6.png)


Edit II: Reverted the CSS, left the refactor (after michel comment)
![image](https://user-images.githubusercontent.com/2352112/112210144-a0d0aa00-8c1a-11eb-8516-0efd2cc6189d.png)
