### PR TITLE
Theme styling settings for network label.

### DIFF
--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -166,7 +166,7 @@ const HideSmall = styled.span`
   `};
 `
 
-const NetworkCard = styled(YellowCard)`
+export const NetworkCard = styled(YellowCard)`
   border-radius: 12px;
   padding: 8px 12px;
   ${({ theme }) => theme.mediaWidth.upToSmall`

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import HeaderMod, { UniIcon } from './HeaderMod'
+import HeaderMod, { UniIcon, NetworkCard } from './HeaderMod'
 import styled from 'styled-components'
 export { NETWORK_LABELS } from './HeaderMod'
 
@@ -7,6 +7,11 @@ export const Header = styled(HeaderMod)`
 
   ${UniIcon} {
     display: flex;
+  }
+
+  ${NetworkCard} {
+    background: ${({ theme }) => theme.networkCard.background};
+    color: ${({ theme }) => theme.networkCard.text};
   }
 `
 

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -104,7 +104,11 @@ export function themeVariables(darkMode: boolean, colorsTheme: Colors) {
     bgLinearGradient: css`
       background-image: linear-gradient(270deg, ${colorsTheme.purple} 30%, ${colorsTheme.blue1} 70%);
     `,
-    version: colorsTheme.green1
+    version: colorsTheme.green1,
+    networkCard: {
+      background: 'rgba(243, 132, 30, 0.05)',
+      text: colorsTheme.yellow2
+    }
   }
 }
 

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -134,7 +134,11 @@ function themeVariables(colorsTheme: Colors) {
     bgLinearGradient: css`
       background-image: linear-gradient(270deg, ${colorsTheme.purple} 30%, ${colorsTheme.blue1} 70%);
     `,
-    version: colorsTheme.primary1
+    version: colorsTheme.primary1,
+    networkCard: {
+      background: colorsTheme.primary1,
+      text: colorsTheme.text1
+    }
   }
 }
 

--- a/src/custom/theme/styled.d.ts
+++ b/src/custom/theme/styled.d.ts
@@ -86,5 +86,9 @@ declare module 'styled-components' {
     }
     bgLinearGradient: FlattenSimpleInterpolation
     version: string
+    networkCard: {
+      background: string
+      text: string
+    }
   }
 }


### PR DESCRIPTION
Adds theme settings/variables to style the network label (NetworkCard) component:
<img width="205" alt="Screen Shot 2021-03-23 at 13 43 25" src="https://user-images.githubusercontent.com/31534717/112148813-9d1f3200-8bde-11eb-904a-68e01e819117.png">
