### PR TITLE
Add HeaderLinks + Alpha positioning.

### DIFF
--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -1,9 +1,10 @@
 import { ChainId } from '@uniswap/sdk'
 import React, { useState } from 'react'
 import { Text } from 'rebass'
-// import { NavLink } from 'react-router-dom'
-// import { darken } from 'polished'
+import { NavLink } from 'react-router-dom'
+import { darken } from 'polished'
 // import { useTranslation } from 'react-i18next'
+import { LinkType } from './index'
 
 import styled from 'styled-components'
 
@@ -112,7 +113,7 @@ const HeaderRow = styled(RowFixed)`
   `};
 `
 
-const HeaderLinks = styled(Row)`
+export const HeaderLinks = styled(Row)`
   justify-content: center;
   ${({ theme }) => theme.mediaWidth.upToMedium`
     padding: 1rem 0 1rem 1rem;
@@ -183,7 +184,7 @@ const BalanceText = styled(Text)`
   `};
 `
 
-const Title = styled.a`
+export const Title = styled.a`
   display: flex;
   align-items: center;
   pointer-events: auto;
@@ -204,34 +205,34 @@ export const UniIcon = styled.div`
   }
 `
 
-// const activeClassName = 'ACTIVE'
+const activeClassName = 'ACTIVE'
 
-// const StyledNavLink = styled(NavLink).attrs({
-//   activeClassName
-// })`
-//   ${({ theme }) => theme.flexRowNoWrap}
-//   align-items: left;
-//   border-radius: 3rem;
-//   outline: none;
-//   cursor: pointer;
-//   text-decoration: none;
-//   color: ${({ theme }) => theme.text2};
-//   font-size: 1rem;
-//   width: fit-content;
-//   margin: 0 12px;
-//   font-weight: 500;
+const StyledNavLink = styled(NavLink).attrs({
+  activeClassName
+})`
+  ${({ theme }) => theme.flexRowNoWrap}
+  align-items: left;
+  border-radius: 3rem;
+  outline: none;
+  cursor: pointer;
+  text-decoration: none;
+  color: ${({ theme }) => theme.text2};
+  font-size: 1rem;
+  width: fit-content;
+  margin: 0 12px;
+  font-weight: 500;
 
-//   &.${activeClassName} {
-//     border-radius: 12px;
-//     font-weight: 600;
-//     color: ${({ theme }) => theme.text1};
-//   }
+  &.${activeClassName} {
+    border-radius: 12px;
+    font-weight: 600;
+    color: ${({ theme }) => theme.text1};
+  }
 
-//   :hover,
-//   :focus {
-//     color: ${({ theme }) => darken(0.1, theme.text1)};
-//   }
-// `
+  :hover,
+  :focus {
+    color: ${({ theme }) => darken(0.1, theme.text1)};
+  }
+`
 
 /*
 const StyledExternalLink = styled(ExternalLink).attrs({
@@ -307,7 +308,7 @@ const CHAIN_CURRENCY_LABELS: { [chainId in ChainId]?: string } = {
   [ChainId.XDAI]: 'xDAI'
 }
 
-export default function HeaderMod(props: { statusLabel: React.ReactNode } & WithClassName) {
+export default function HeaderMod(props: { headerLinks: LinkType[] } & WithClassName) {
   const { account, chainId } = useActiveWeb3React()
   // const { t } = useTranslation()
 
@@ -343,8 +344,16 @@ export default function HeaderMod(props: { statusLabel: React.ReactNode } & With
             <LogoImage />
           </UniIcon>
         </Title>
-        {props.statusLabel}
+        {/* {props.statusLabel} */}
         <HeaderLinks>
+          {props.headerLinks &&
+            props.headerLinks.map(({ id, title, path }) => {
+              return (
+                <StyledNavLink key={id} to={path}>
+                  {title}
+                </StyledNavLink>
+              )
+            })}
           {/* <StyledNavLink id={`swap-nav-link`} to={'/swap'}>
             {t('swap')}
           </StyledNavLink> */}

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -1,33 +1,54 @@
 import React from 'react'
-import HeaderMod, { UniIcon, NetworkCard } from './HeaderMod'
+import HeaderMod, { UniIcon, NetworkCard, Title, HeaderLinks } from './HeaderMod'
 import styled from 'styled-components'
 import { status as appStatus } from '@src/../package.json'
 
 export { NETWORK_LABELS } from './HeaderMod'
+
+export interface LinkType {
+  id: number
+  title: string
+  path: string
+}
+
+const headerLinks: LinkType[] = [
+  { id: 0, title: 'Swap', path: '/swap' },
+  { id: 1, title: 'About', path: '/about' }
+]
 
 export const HeaderModWrapper = styled(HeaderMod)`
   border-bottom: ${({ theme }) => theme.header.border};
 
   ${UniIcon} {
     display: flex;
+    margin: 0 16px 0 0;
+    position: relative;
+
+    &::after {
+      content: '${appStatus}';
+      display: block;
+      font-size: 10px;
+      font-weight: bold;
+      position: absolute;
+      right: 12px;
+      top: 2px;
+    }
+  }
+
+  ${Title} {
+    margin: 0;
+    text-decoration: none;
+    color: ${({ theme }) => theme.text1};
+  }
+
+  ${HeaderLinks} {
+    margin: 5px 0 0 0;
   }
 
   ${NetworkCard} {
     background: ${({ theme }) => theme.networkCard.background};
     color: ${({ theme }) => theme.networkCard.text};
   }
-`
-
-const AppStatusWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 10px;
-  background: ${({ theme }) => theme.primary1};
-  border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
-  /* negative margin matches logo margin right */
-  margin: auto 0 0 -10px;
-  padding: 2px 6px;
 `
 
 export const LogoImage = styled.img.attrs(props => ({
@@ -40,5 +61,5 @@ export const LogoImage = styled.img.attrs(props => ({
 `
 
 export default function Header() {
-  return <HeaderModWrapper statusLabel={<AppStatusWrapper>{appStatus}</AppStatusWrapper>} />
+  return <HeaderModWrapper headerLinks={headerLinks} />
 }


### PR DESCRIPTION


- Adds the HeaderLinks
- Restyle ALPHA to make room for HeaderLinks + simplify Props for `statusLabel` by instead using it as a value in the CSS pseudo-element `::after`.

<img width="1084" alt="Screen Shot 2021-03-24 at 16 46 59" src="https://user-images.githubusercontent.com/31534717/112340119-8e10b080-8cc0-11eb-951d-bda917fa38ae.png">


<img width="399" alt="Screen Shot 2021-03-24 at 17 03 40" src="https://user-images.githubusercontent.com/31534717/112342865-e6e14880-8cc2-11eb-9ac2-29734d828448.png">
