### PR TITLE
Preventing empty messages by using existing notification data

### DIFF
--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -46,7 +46,7 @@ function _computeFulfilledSummary({
 
   // if we can find the order from the API
   // and our specific order exists in our state, let's use that
-  if (orderFromApi) {
+  if (orderFromApi && Number(orderFromApi.executedBuyAmount) > 0 && Number(orderFromApi.executedSellAmount) > 0) {
     const { buyToken, sellToken, executedBuyAmount, executedSellAmount } = orderFromApi
 
     if (orderFromStore) {
@@ -62,6 +62,8 @@ function _computeFulfilledSummary({
       // We only have the API order info, let's at least use that
       summary = `Swap ${sellToken} for ${buyToken}`
     }
+  } else {
+    console.log(`computeFulfilledSummary::API data not yet in sync with blockchain`)
   }
 
   return summary

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -63,7 +63,7 @@ function _computeFulfilledSummary({
       summary = `Swap ${sellToken} for ${buyToken}`
     }
   } else {
-    console.log(`computeFulfilledSummary::API data not yet in sync with blockchain`)
+    console.log(`[state:orders:updater] computeFulfilledSummary::API data not yet in sync with blockchain`)
   }
 
   return summary


### PR DESCRIPTION
# Summary

Quick fix for #258 

Simply use existing values when API data is out of sync.
Will do a follow up with an attempt of a more permanent and reliable fix.
But for now this will prevent the notifications with `0` values

# Testing

Unfortunately, it's not easy to reproduce, as we must rely on a race condition between the blockchain and the backend.
The best way to verify the fix is to keep placing orders and watch the console for this message: `computeFulfilledSummary::API data not yet in sync with blockchain`
When that happens, the notification would (before this fix) be `Swaped 0 token... etc`, and now you would get all values filled in.