### PR TITLE
258/trade notification with empty values part2

### DIFF
--- a/src/custom/state/orders/actions.ts
+++ b/src/custom/state/orders/actions.ts
@@ -55,7 +55,6 @@ export interface OrderFulfillmentData {
 export interface FulfillOrdersBatchParams {
   ordersData: OrderFulfillmentData[]
   chainId: ChainId
-  lastCheckedBlock: number
 }
 
 export const fulfillOrdersBatch = createAction<FulfillOrdersBatchParams>('order/fullfillOrdersBatch')

--- a/src/custom/state/orders/consts.ts
+++ b/src/custom/state/orders/consts.ts
@@ -7,3 +7,5 @@ export const ContractDeploymentBlocks: Partial<Record<ChainId, number>> = {
   [ChainId.RINKEBY]: 7724701,
   [ChainId.XDAI]: 13566914
 }
+
+export const OPERATOR_API_POLL_INTERVAL = 10000 // in ms

--- a/src/custom/state/orders/reducer.ts
+++ b/src/custom/state/orders/reducer.ts
@@ -109,10 +109,7 @@ export default createReducer(initialState, builder =>
     })
     .addCase(fulfillOrdersBatch, (state, action) => {
       prefillState(state, action)
-      const { ordersData, chainId, lastCheckedBlock } = action.payload
-
-      // update lastCheckedBlock
-      state[chainId].lastCheckedBlock = lastCheckedBlock
+      const { ordersData, chainId } = action.payload
 
       const pendingOrders = state[chainId].pending
       const fulfilledOrders = state[chainId].fulfilled

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -33,7 +33,8 @@ interface TradeEventParams {
   // id?: string | string[] // to filter by id
 }
 
-function apiOrderIsSettled(orderFromApi: OrderMetaData | null): boolean {
+function isOrderFinalized(orderFromApi: OrderMetaData | null): boolean {
+  // TODO: for now only checks for execution. Check also whether order is expired. Right?
   return (
     orderFromApi !== null && Number(orderFromApi.executedBuyAmount) > 0 && Number(orderFromApi.executedSellAmount) > 0
   )
@@ -51,7 +52,7 @@ function _computeFulfilledSummary({
 
   // if we can find the order from the API
   // and our specific order exists in our state, let's use that
-  if (orderFromApi && Number(orderFromApi.executedBuyAmount) > 0 && Number(orderFromApi.executedSellAmount) > 0) {
+  if (orderFromApi && isOrderFinalized(orderFromApi)) {
     const { buyToken, sellToken, executedBuyAmount, executedSellAmount } = orderFromApi
 
     if (orderFromStore) {
@@ -167,7 +168,7 @@ export function EventUpdaterApiOnly(): null {
       console.log('EventUpdaterApiOnly::got api orders', orders)
 
       const ordersBatchData: OrderLogPopupMixData[] = orders
-        .filter(([, apiOrder]) => apiOrderIsSettled(apiOrder))
+        .filter(([, orderFromApi]) => isOrderFinalized(orderFromApi))
         .map(([orderFromStore, orderFromApi]) => {
           const summary = _computeFulfilledSummary({ orderFromStore, orderFromApi })
           return {

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -1,42 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useActiveWeb3React } from 'hooks'
-import { useBlockNumber } from 'state/application/hooks'
 import { OrderFulfillmentData, Order } from './actions'
-import { Web3Provider } from '@ethersproject/providers'
-import { Log, Filter } from '@ethersproject/abstract-provider'
-import {
-  useLastCheckedBlock,
-  usePendingOrders,
-  useFulfillOrdersBatch,
-  useFindOrderById,
-  useExpireOrdersBatch
-} from './hooks'
-import { buildBlock2DateMap } from 'utils/blocks'
-import { registerOnWindow } from 'utils/misc'
+import { Log } from '@ethersproject/abstract-provider'
+import { usePendingOrders, useFulfillOrdersBatch, useExpireOrdersBatch } from './hooks'
 import { getOrder, OrderMetaData } from 'utils/operator'
-import {
-  GP_SETTLEMENT_CONTRACT_ADDRESS,
-  SHORT_PRECISION,
-  EXPIRED_ORDERS_BUFFER,
-  CHECK_EXPIRED_ORDERS_INTERVAL
-} from 'constants/index'
-import { GP_V2_SETTLEMENT_INTERFACE } from 'constants/GPv2Settlement'
+import { SHORT_PRECISION, EXPIRED_ORDERS_BUFFER, CHECK_EXPIRED_ORDERS_INTERVAL } from 'constants/index'
 import { stringToCurrency } from '../swap/extension'
 import { OPERATOR_API_POLL_INTERVAL } from './consts'
 import { ChainId } from '@uniswap/sdk'
 
 type OrderLogPopupMixData = OrderFulfillmentData & Pick<Log, 'transactionHash'> & Partial<Pick<Order, 'summary'>>
 
-const TradeEvent = GP_V2_SETTLEMENT_INTERFACE.getEvent('Trade')
-
-interface TradeEventParams {
-  owner: string // address
-  // maybe enable when orderUid is indexed
-  // id?: string | string[] // to filter by id
-}
-
 function isOrderFinalized(orderFromApi: OrderMetaData | null): boolean {
-  // TODO: for now only checks for execution. Check also whether order is expired. Right?
   return (
     orderFromApi !== null && Number(orderFromApi.executedBuyAmount) > 0 && Number(orderFromApi.executedSellAmount) > 0
   )
@@ -77,65 +52,6 @@ function _computeFulfilledSummary({
   return summary
 }
 
-const generateTradeEventTopics = ({ owner /*, id */ }: TradeEventParams) => {
-  const TradeEventTopics = GP_V2_SETTLEMENT_INTERFACE.encodeFilterTopics(TradeEvent, [owner /*, id*/])
-  return TradeEventTopics
-}
-
-const decodeTradeEvent = (tradeEventLog: Log) => {
-  return GP_V2_SETTLEMENT_INTERFACE.decodeEventLog(TradeEvent, tradeEventLog.data, tradeEventLog.topics)
-}
-
-type RetryFilter = Filter & { fromBlock: number; toBlock: number }
-
-const constructGetLogsRetry = (provider: Web3Provider) => {
-  // tries fetching logs
-  // if breaks, retries on half the range
-  const getLogsRetry = async ({ fromBlock, toBlock, ...rest }: RetryFilter): Promise<Log[]> => {
-    try {
-      console.log(`EventUpdater::Getting logs fromBlock: ${fromBlock} toBlock ${toBlock}`)
-      const logs = await provider.getLogs({
-        fromBlock,
-        toBlock,
-        ...rest
-      })
-      // console.log('logs', logs)
-      return logs
-    } catch (error) {
-      console.error(`Error getting logs fromBlock: ${fromBlock} toBlock ${toBlock}`, error)
-
-      // expect -- RPC Error: query returned more than 10000 results --
-      // if a different error - rethrow
-      if (!error?.message?.includes('query returned more than')) throw error
-
-      // still too many logs in 1 block
-      // rethrow
-      // but this shouldn't happen
-      if (toBlock === fromBlock) {
-        console.error(`Too many logs in block ${toBlock}. Aborting`)
-        throw error
-      }
-
-      const midBlock = Math.floor((toBlock + fromBlock) / 2)
-
-      const [beforeMidLogs, afterMidLogs] = await Promise.all([
-        getLogsRetry({
-          fromBlock,
-          toBlock: midBlock
-        }),
-        getLogsRetry({
-          fromBlock: midBlock + 1,
-          toBlock
-        })
-      ])
-
-      return beforeMidLogs.concat(afterMidLogs)
-    }
-  }
-
-  return getLogsRetry
-}
-
 async function fetchOrderPopupData(orderFromStore: Order, chainId: ChainId): Promise<OrderLogPopupMixData | null> {
   const orderFromApi = await getOrder(chainId, orderFromStore.id)
 
@@ -153,7 +69,7 @@ async function fetchOrderPopupData(orderFromStore: Order, chainId: ChainId): Pro
   }
 }
 
-export function EventUpdaterApiOnly(): null {
+export function EventUpdater(): null {
   const { chainId } = useActiveWeb3React()
 
   const pending = usePendingOrders({ chainId })
@@ -188,172 +104,6 @@ export function EventUpdaterApiOnly(): null {
 
     return () => clearInterval(interval)
   }, [pending, chainId, updateOrders])
-
-  return null
-}
-
-export function EventUpdater(): null {
-  const { account, chainId, library } = useActiveWeb3React()
-  // console.log('EventUpdater::library', library)
-  // console.log('EventUpdater::chainId', chainId)
-
-  const lastBlockNumber = useBlockNumber()
-  const lastCheckedBlock = useLastCheckedBlock({ chainId })
-  console.log('EventUpdater::lastCheckedBlock', lastCheckedBlock)
-  console.log('EventUpdater::lastBlockNumber', lastBlockNumber)
-
-  const fulfillOrdersBatch = useFulfillOrdersBatch()
-
-  const getLogsRetry = useMemo(() => {
-    if (!library) return null
-    return constructGetLogsRetry(library)
-  }, [library])
-
-  const eventTopics = useMemo(() => {
-    if (!account) return null
-    return generateTradeEventTopics({ owner: account })
-  }, [account])
-
-  const contractAddress = chainId && GP_SETTLEMENT_CONTRACT_ADDRESS[chainId]
-
-  const findOrderById = useFindOrderById({ chainId })
-
-  useEffect(() => {
-    if (!chainId || !library || !getLogsRetry || !lastBlockNumber || !eventTopics || !contractAddress) return
-
-    registerOnWindow({
-      getLogsRetry: (fromBlock: number, toBlock: number) => {
-        // to play around with in console
-        return getLogsRetry({
-          fromBlock,
-          toBlock,
-          topics: eventTopics
-        })
-      }
-    })
-
-    // don't check for fromBlock > toBlock
-    if (lastCheckedBlock + 1 > lastBlockNumber) return
-
-    const getPastEvents = async () => {
-      console.log('EventUpdater::getLogs', {
-        fromBlock: lastCheckedBlock + 1,
-        toBlock: lastBlockNumber,
-        address: contractAddress,
-        topics: eventTopics
-      })
-
-      const logs = await getLogsRetry({
-        fromBlock: lastCheckedBlock + 1,
-        toBlock: lastBlockNumber,
-        address: contractAddress,
-        topics: eventTopics
-      })
-
-      const block2DateMap = await buildBlock2DateMap(library, logs)
-
-      // Filter out orders that should not trigger a pop-up
-      const pendingLogsAndOrders = logs.reduce<[Log, Order][]>((acc, log) => {
-        const { orderUid: id } = decodeTradeEvent(log)
-
-        console.log(`EventUpdater::Detected Trade event for order ${id} of token in block`, log.blockNumber)
-
-        const orderFromStore = findOrderById(id)
-        if (!orderFromStore || orderFromStore.status !== 'pending') {
-          console.log(`EventUpdater::Order ${id} not pending or not on local storage, ignoring it`)
-          return acc
-        }
-
-        acc.push([log, orderFromStore])
-
-        return acc
-      }, [])
-
-      const ordersBatchData: OrderLogPopupMixData[] = await Promise.all(
-        pendingLogsAndOrders.map(async ([log, orderFromStore]) => {
-          const id = orderFromStore.id
-
-          // We've found the orderId in the Trade event
-          // But the backend may not be completely updated yet, e.g
-          // the frontend is ahead of the backend in regards to data freshness
-          // TODO: temporary! change to a better solution
-          // https://github.com/gnosis/gp-swap-ui/issues/213
-          const orderFromApi = await getOrder(chainId, id)
-
-          // using order from store and api compute summary
-          const summary = _computeFulfilledSummary({ orderFromApi, orderFromStore })
-
-          return {
-            id,
-            fulfillmentTime: block2DateMap[log.blockHash].toISOString(),
-            transactionHash: log.transactionHash,
-            summary
-          }
-        })
-      )
-
-      // SET lastCheckedBlock = lastBlockNumber
-      // AND fulfill orders
-      // ordersBatchData can be empty
-      fulfillOrdersBatch({
-        ordersData: ordersBatchData,
-        chainId
-        // lastCheckedBlock: lastBlockNumber
-      })
-
-      // console.log('logs', logs)
-
-      // TODO: extend addPopup to accept whatever we want to show for Orders
-      // if (logs.length > 0) {
-      //   const firstBlock = logs[0].blockNumber
-      //   const lastBlock = logs[logs.length - 1].blockNumber
-
-      //   const blocksRangeStr = firstBlock === lastBlock ? `block ${firstBlock}` : `blocks ${firstBlock} - ${lastBlock}`
-      //   // Sample popup for events
-      //   addPopup(
-      //     {
-      //       txn: {
-      //         hash: logs[0].transactionHash,
-      //         success: true,
-      //         summary: `EventUpdater::Detected ${logs.length} token Transfers in ${blocksRangeStr}`
-      //       }
-      //     },
-      //     logs[0].transactionHash
-      //   )
-      // }
-    }
-
-    getPastEvents()
-  }, [
-    chainId,
-    library,
-    lastBlockNumber,
-    lastCheckedBlock,
-    getLogsRetry,
-    eventTopics,
-    fulfillOrdersBatch,
-    contractAddress,
-    findOrderById
-  ])
-
-  // TODO: maybe implement event watching instead of getPastEvents on every block
-  // useEffect(() => {
-  //   if (!chainId || !library || !lastBlockNumber) return
-
-  //   const listener = (log: Log) => {
-  //     console.log('Transfer::log', log) // the log isn't decoded, if used through contract, can have decoded already
-
-  //     // decode manually for now
-  //     const { from, to, amount } = decodeTransferEvent(log)
-
-  //     console.log('Detected transfer of token', log.address, { from, to, amount })
-  //   }
-  //   library.on(TransferEventTopics, listener)
-
-  //   return () => {
-  //     library.off(TransferEventTopics, listener)
-  //   }
-  // }, [chainId, library])
 
   return null
 }

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -137,7 +137,7 @@ const constructGetLogsRetry = (provider: Web3Provider) => {
 }
 
 export function EventUpdaterApiOnly(): null {
-  const { chainId, library } = useActiveWeb3React()
+  const { chainId } = useActiveWeb3React()
 
   const pending = usePendingOrders({ chainId })
   const fulfillOrdersBatch = useFulfillOrdersBatch()
@@ -146,12 +146,6 @@ export function EventUpdaterApiOnly(): null {
     async (pending: Order[], chainId: ChainId) => {
       console.log('EventUpdaterApiOnly::calling update')
 
-      const lastBlockNumber = await library?.getBlockNumber()
-      if (!lastBlockNumber) {
-        console.log('EventUpdaterApiOnly::update, exiting', chainId, lastBlockNumber)
-
-        return
-      }
       const orders = await Promise.all(
         pending.map<Promise<[Order, OrderMetaData | null]>>(async orderFromStore => {
           const orderFromApi = await getOrder(chainId, orderFromStore.id)
@@ -173,18 +167,12 @@ export function EventUpdaterApiOnly(): null {
         })
       console.log('EventUpdaterApiOnly::filtered and parsed orders batch', ordersBatchData)
 
-      // SET lastCheckedBlock = lastBlockNumber
-      // AND fulfill orders
-      // ordersBatchData can be empty
       fulfillOrdersBatch({
         ordersData: ordersBatchData,
-        chainId,
-        // TODO: this is not good! we should keep the same that's in store
-        // this might have side effects everywhere else, like when checking balances or such
-        lastCheckedBlock: lastBlockNumber
+        chainId
       })
     },
-    [fulfillOrdersBatch, library]
+    [fulfillOrdersBatch]
   )
 
   useEffect(() => {
@@ -311,8 +299,8 @@ export function EventUpdater(): null {
       // ordersBatchData can be empty
       fulfillOrdersBatch({
         ordersData: ordersBatchData,
-        chainId,
-        lastCheckedBlock: lastBlockNumber
+        chainId
+        // lastCheckedBlock: lastBlockNumber
       })
 
       // console.log('logs', logs)

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -22,6 +22,7 @@ import {
 } from 'constants/index'
 import { GP_V2_SETTLEMENT_INTERFACE } from 'constants/GPv2Settlement'
 import { stringToCurrency } from '../swap/extension'
+import { OPERATOR_API_POLL_INTERVAL } from './consts'
 
 type OrderLogPopupMixData = OrderFulfillmentData & Pick<Log, 'transactionHash'> & Partial<Pick<Order, 'summary'>>
 
@@ -190,7 +191,7 @@ export function EventUpdaterApiOnly(): null {
       })
     }
 
-    interval = setInterval(update, 10000)
+    interval = setInterval(update, OPERATOR_API_POLL_INTERVAL)
 
     return (): void => {
       interval && clearInterval(interval)

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -160,9 +160,9 @@ export function EventUpdaterApiOnly(): null {
         return
       }
       const orders = await Promise.all(
-        pending.map<Promise<[Order, OrderMetaData | null]>>(async storeOrder => {
-          const apiOrder = await getOrder(chainId, storeOrder.id)
-          return [storeOrder, apiOrder]
+        pending.map<Promise<[Order, OrderMetaData | null]>>(async orderFromStore => {
+          const orderFromApi = await getOrder(chainId, orderFromStore.id)
+          return [orderFromStore, orderFromApi]
         })
       )
       console.log('EventUpdaterApiOnly::got api orders', orders)

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -12,10 +12,9 @@ import {
   useExpireOrdersBatch
 } from './hooks'
 import { buildBlock2DateMap } from 'utils/blocks'
-import { delay, registerOnWindow } from 'utils/misc'
+import { registerOnWindow } from 'utils/misc'
 import { getOrder, OrderMetaData } from 'utils/operator'
 import {
-  DEFAULT_ORDER_DELAY,
   GP_SETTLEMENT_CONTRACT_ADDRESS,
   SHORT_PRECISION,
   EXPIRED_ORDERS_BUFFER,
@@ -214,7 +213,7 @@ export function EventUpdater(): null {
           // the frontend is ahead of the backend in regards to data freshness
           // TODO: temporary! change to a better solution
           // https://github.com/gnosis/gp-swap-ui/issues/213
-          const orderFromApi = await delay(DEFAULT_ORDER_DELAY, getOrder(chainId, id))
+          const orderFromApi = await getOrder(chainId, id)
 
           // using order from store and api compute summary
           const summary = _computeFulfilledSummary({ orderFromApi, orderFromStore })

--- a/src/custom/state/orders/updater.ts
+++ b/src/custom/state/orders/updater.ts
@@ -174,8 +174,7 @@ export function EventUpdaterApiOnly(): null {
           return {
             id: orderFromStore.id,
             fulfillmentTime: new Date().toISOString(),
-            // TODO: get this from the API!!!
-            transactionHash: 'nothing for now',
+            transactionHash: '', // there's no need  for a txHash as we'll link the notification to the Explorer
             summary
           }
         })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ import TransactionUpdater from './state/transactions/updater'
 import UserUpdater from './state/user/updater'
 import FeesUpdater from 'state/fee/updater'
 import XdaiUpdater from 'state/network/updater'
-import { ExpiredOrdersWatcher, EventUpdater } from 'state/orders/updater'
+import { ExpiredOrdersWatcher, EventUpdaterApiOnly } from 'state/orders/updater'
 // import { EventUpdater } from 'state/orders/mocks'
 import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from 'theme'
 import getLibrary from './utils/getLibrary'
@@ -57,7 +57,8 @@ function Updaters() {
       <ApplicationUpdater />
       <TransactionUpdater />
       <MulticallUpdater />
-      <EventUpdater />
+      {/* <EventUpdater /> */}
+      <EventUpdaterApiOnly />
       <ExpiredOrdersWatcher />
       <FeesUpdater />
     </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ import TransactionUpdater from './state/transactions/updater'
 import UserUpdater from './state/user/updater'
 import FeesUpdater from 'state/fee/updater'
 import XdaiUpdater from 'state/network/updater'
-import { ExpiredOrdersWatcher, EventUpdaterApiOnly } from 'state/orders/updater'
+import { ExpiredOrdersWatcher, EventUpdater } from 'state/orders/updater'
 // import { EventUpdater } from 'state/orders/mocks'
 import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from 'theme'
 import getLibrary from './utils/getLibrary'
@@ -57,8 +57,7 @@ function Updaters() {
       <ApplicationUpdater />
       <TransactionUpdater />
       <MulticallUpdater />
-      {/* <EventUpdater /> */}
-      <EventUpdaterApiOnly />
+      <EventUpdater />
       <ExpiredOrdersWatcher />
       <FeesUpdater />
     </>


### PR DESCRIPTION
# Summary

"Real" solution to #258, built on top of the "temporary" solution on https://github.com/gnosis/gp-swap-ui/pull/353

Relying on polling operator API instead of blockchain events to update pending orders.

Only when there are pending orders on local state, queries operator API until the order is executed.
Query is triggered every 10s.

## Note
~:warning: Did not have time yet for extensive testing, more testing required!~

~Will continue next week in this or a new PR.~

Tested it several times, tested with expired orders as well.
All good, did not find any issues.