### PR TITLE
Release/0.8.0 try3

### DIFF
--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -46,7 +46,6 @@ const HeaderFrame = styled.div`
   z-index: 2;
   ${({ theme }) => theme.mediaWidth.upToMedium`
     grid-template-columns: 1fr;
-    padding: 0 1rem;
     width: calc(100%);
     position: relative;
   `};

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -8,7 +8,7 @@ import HeaderMod, {
   Title,
   HeaderLinks,
   HeaderRow,
-  StyledNavLink,
+  // StyledNavLink,
   HeaderControls,
   HeaderElement,
   HideSmall,
@@ -109,10 +109,10 @@ export default function Header() {
           </UniIcon>
         </Title>
         <AppStatusWrapper>{appStatus}</AppStatusWrapper>
-        <HeaderLinks>
+        {/* <HeaderLinks>
           <StyledNavLink to="/swap">Swap</StyledNavLink>
-          {/* <StyledNavLink to="/about">About</StyledNavLink> */}
-        </HeaderLinks>
+          <StyledNavLink to="/about">About</StyledNavLink>
+        </HeaderLinks> */}
       </HeaderRow>
       <HeaderControls>
         <HeaderElement>


### PR DESCRIPTION
Extends https://github.com/gnosis/gp-swap-ui/pull/375

## Changes
1. removes "Swap" header url from header
2. changes responsive header padding back 1rem

Before:
![Screenshot from 2021-04-01 11-06-52](https://user-images.githubusercontent.com/21335563/113278931-6cc04d80-92da-11eb-9c28-899a14a07fee.png)
Header has bad padding, Swap link is there

After:
![Screenshot from 2021-04-01 11-07-07](https://user-images.githubusercontent.com/21335563/113278964-75188880-92da-11eb-98e1-d1017e3eb85c.png)
Header padding reverted, swap link gone
