### PR TITLE
Try ETHSIGN signature in case EIP712 is not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.15",
+    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.17",
     "@uniswap/default-token-list": "^2.0.0"
   }
 }

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -113,11 +113,10 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
       signature = (await signOrder({ ...signatureParams, signingScheme })) as EcdsaSignature // Only ECDSA signing supported for now
     } else {
       // Some other error signing. Let it bubble up.
+      console.error(e)
       throw e
     }
   }
-
-  console.log(`we got a signature \\o/`, signature)
 
   const signatureData = signature?.data.toString()
   const creationTime = new Date().toISOString()

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -105,7 +105,7 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
     if (e.code === METAMASK_SIGNATURE_ERROR_CODE) {
       // We tried to sign order the nice way.
       // That works fine for regular MM addresses. Does not work for Hardware wallets, though.
-      // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-812672324
+      // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-810552020
       // So, when that specific error occurs, we know this is a problem with MM + HW.
       // Then, we fallback to ETHSIGN.
       signingScheme = SigningScheme.ETHSIGN

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -108,7 +108,6 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
       // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-812672324
       // So, when that specific error occurs, we know this is a problem with MM + HW.
       // Then, we fallback to ETHSIGN.
-      console.info('[trade:postOrder] Wallet does not support EIP712. Trying ETHSIGN instead', e)
       signingScheme = SigningScheme.ETHSIGN
       signature = (await signOrder({ ...signatureParams, signingScheme })) as EcdsaSignature // Only ECDSA signing supported for now
     } else {

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -9,7 +9,7 @@ import { APP_ID, RADIX_DECIMAL, SHORTEST_PRECISION } from 'constants/index'
 import { EcdsaSignature, Signature } from '@gnosis.pm/gp-v2-contracts'
 
 const DEFAULT_SIGNING_SCHEME = SigningScheme.EIP712
-const METAMASK_SIGNATURE_ERROR = -32603
+const METAMASK_SIGNATURE_ERROR_CODE = -32603
 
 export interface PostOrderParams {
   account: string
@@ -102,7 +102,7 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
   try {
     signature = (await signOrder(signatureParams)) as EcdsaSignature // Only ECDSA signing supported for now
   } catch (e) {
-    if (e.code === METAMASK_SIGNATURE_ERROR) {
+    if (e.code === METAMASK_SIGNATURE_ERROR_CODE) {
       // We tried to sign order the nice way.
       // That works fine for regular MM addresses. Does not work for Hardware wallets, though.
       // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-812672324

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -118,7 +118,7 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
     }
   }
 
-  const signatureData = signature?.data.toString()
+  const signatureData = signature.data.toString()
   const creationTime = new Date().toISOString()
 
   // Call API

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,10 +1674,10 @@
     "@ethersproject/properties" "^5.1.0"
     "@ethersproject/strings" "^5.1.0"
 
-"@gnosis.pm/gp-v2-contracts@^0.0.1-alpha.15":
-  version "0.0.1-alpha.16"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-0.0.1-alpha.16.tgz#6e326e5e2ec845992c7f9f6fc32189c1505ab5b4"
-  integrity sha512-5sufwG3WTotLDRJLw6Y7f1e2HRYEWxSNRwC4xZ5GipQ3EobOpCPKGUIp3iZy0wJa0we0CMyFZtT0WQeVbik7xw==
+"@gnosis.pm/gp-v2-contracts@^0.0.1-alpha.17":
+  version "0.0.1-alpha.17"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-0.0.1-alpha.17.tgz#5c3e08b4a761d13383af631cee255cc7645aa50a"
+  integrity sha512-kr/tpeqvlKVXDka/aFHGFJyT9xgYjAvWK9wszlq4pyH3Qs7WIB0mj9YMdzAmVRVdvpXeLGWgTPZ88xIXD/9X6Q==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
# Summary

Closes #324 

For now, implementing only `solution 1` described in this comment https://github.com/gnosis/gp-swap-ui/issues/324#issuecomment-816158280

`Solution 2` might come at a later point. I'll create an issue and leave a draft PR with the progress so far.

## ~Currently not working~ Working :partying_face: 

The caveat is that you'll see two sign modals in Metamask:
1. Regular high detail signature request. 
    Clicking on sign does not actually pop up in the Ledger.
    Behind the scenes this is when we know the wallet doesn't support EIP712 and try a different method
2. Hash signature request. 
    Uses ETHSIGN, will now ask for confirmation in the Ledger

This is the same behaviour as the Safe for signing messages with Ledger via MM.

# Testing
1. Make sure you have a Ledger available for testing
2. Import a Ledger account into Metamask
3. Perform a trade as usual

- [ ] When MM shows up, you should see the modals as described above
- [ ] After clicking `sing` on both, and confirming it once in the Ledger, the order should be placed

# Note
This change required a contract package update.
Make sure you see `alpha.17`
![screenshot_2021-04-09_09-35-38](https://user-images.githubusercontent.com/43217/114212727-00b39a00-9917-11eb-9694-4f8716d219df.png)
