### PR TITLE
[266] Transaction may fail > Transaction may expire

### DIFF
--- a/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
@@ -232,7 +232,7 @@ export default function SlippageTabs({
             {slippageError === SlippageError.InvalidInput
               ? 'Enter a valid slippage percentage'
               : slippageError === SlippageError.RiskyLow
-              ? 'Your transaction may fail'
+              ? 'Your transaction may expire'
               : 'Your transaction may be frontrun'}
           </RowBetween>
         )}


### PR DESCRIPTION
Closes #266 

![Screenshot from 2021-04-07 13-36-14](https://user-images.githubusercontent.com/21335563/113867280-40a73f80-97a6-11eb-802d-e871e268097f.png)

Something to consider: https://github.com/gnosis/gp-swap-ui/issues/266#issuecomment-814877094

`Transaction may be frontrun` - solvers may be able to do this but we control the solver for now, making this sth to consider changing/removing.