### PR TITLE
Change Slippage "Frontrun" message

### DIFF
--- a/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
@@ -233,7 +233,7 @@ export default function SlippageTabs({
               ? 'Enter a valid slippage percentage'
               : slippageError === SlippageError.RiskyLow
               ? 'Your transaction may expire'
-              : 'Your transaction may be frontrun'}
+              : 'High slippage amount selected'}
           </RowBetween>
         )}
       </AutoColumn>


### PR DESCRIPTION
Related to #266 - see comment

![Screenshot from 2021-04-09 10-26-52](https://user-images.githubusercontent.com/21335563/114159826-209a8c00-991e-11eb-93d2-d7c4c5756d81.png)

"Transation may be frontrun" > "High slippage amount selected"
