### PR TITLE
263.2 - Support internal hash links (markdown related)

### DIFF
--- a/src/custom/components/Footer/index.tsx
+++ b/src/custom/components/Footer/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import Version from '../Version'
+
+const FooterVersion = styled(Version)`
+  margin-right: auto;
+  min-width: max-content;
+`
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flexRowNoWrap}
+  align-items: center;
+  justify-content: space-evenly;
+  margin: auto 6rem 0 2rem;
+
+  width: 100%;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    display: none;
+  `}
+`
+
+export default function Footer({ children }: { children?: React.ReactChildren }) {
+  return (
+    <Wrapper>
+      <FooterVersion />
+      {children}
+    </Wrapper>
+  )
+}

--- a/src/custom/components/HashLink/index.tsx
+++ b/src/custom/components/HashLink/index.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect } from 'react'
+import { LinkProps, useLocation, Link } from 'react-router-dom'
+
+const HashLink = (props: LinkProps) => {
+  const location = useLocation()
+
+  useEffect(() => {
+    const id = location.hash.slice(1)
+    const elem = document.getElementById(id)
+
+    if (!elem) return
+
+    window.scrollTo(0, elem.offsetTop)
+  }, [location.hash])
+
+  return <Link {...props}>{props.children}</Link>
+}
+
+export default HashLink

--- a/src/custom/components/HashLink/index.tsx
+++ b/src/custom/components/HashLink/index.tsx
@@ -5,15 +5,17 @@ const HashLink = (props: LinkProps) => {
   const location = useLocation()
 
   useEffect(() => {
+    // bail out if the hash doesn't match our proposed anchor hash
+    if (props.to !== location.hash) return
+
     const id = location.hash.slice(1)
     const elem = document.getElementById(id)
 
-    if (!elem) return
+    // scroll element into view if it exists
+    elem?.scrollIntoView()
+  }, [location.hash, props.to])
 
-    window.scrollTo(0, elem.offsetTop)
-  }, [location.hash])
-
-  return <Link {...props}/>
+  return <Link {...props} />
 }
 
 export default HashLink

--- a/src/custom/components/HashLink/index.tsx
+++ b/src/custom/components/HashLink/index.tsx
@@ -13,7 +13,7 @@ const HashLink = (props: LinkProps) => {
     window.scrollTo(0, elem.offsetTop)
   }, [location.hash])
 
-  return <Link {...props}>{props.children}</Link>
+  return <Link {...props}/>
 }
 
 export default HashLink

--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -94,12 +94,10 @@ export const HeaderElement = styled.div`
   `};
 `
 
-/*
-const HeaderElementWrap = styled.div`
+export const HeaderElementWrap = styled.div`
   display: flex;
   align-items: center;
 `
-*/
 
 export const HeaderRow = styled(RowFixed)`
   ${({ theme }) => theme.mediaWidth.upToMedium`

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -13,8 +13,10 @@ import HeaderMod, {
   HeaderElement,
   HideSmall,
   BalanceText,
-  AccountElement
+  AccountElement,
+  HeaderElementWrap
 } from './HeaderMod'
+import Menu from '../Menu'
 import styled from 'styled-components'
 import { status as appStatus } from '@src/../package.json'
 import { useActiveWeb3React } from 'hooks'
@@ -130,12 +132,9 @@ export default function Header() {
             <Web3Status />
           </AccountElement>
         </HeaderElement>
-        {/* <HeaderElementWrap>
-          <StyledMenuButton onClick={() => toggleDarkMode()}>
-            {darkMode ? <Moon size={20} /> : <Sun size={20} />}
-          </StyledMenuButton>
+        <HeaderElementWrap>
           <Menu />
-        </HeaderElementWrap> */}
+        </HeaderElementWrap>
       </HeaderControls>
     </HeaderModWrapper>
   )

--- a/src/custom/components/Markdown/index.tsx
+++ b/src/custom/components/Markdown/index.tsx
@@ -4,7 +4,7 @@ import { ReactMarkdownPropsBase } from 'react-markdown'
 import useFetchFile from 'hooks/useFetchFile'
 import { Title, Content, PageWrapper } from 'components/Markdown/markdown.styled'
 import { HeadingRenderer, LinkRenderer } from './renderers'
-import ScrollToTop from '../ScrollToTop'
+// import ScrollToTop from '../ScrollToTop'
 
 interface MarkdownParams {
   content: string
@@ -24,13 +24,13 @@ export default function Markdown({ content, title }: MarkdownParams) {
         {file && <CustomReactMarkdown>{file}</CustomReactMarkdown>}
         {error && <CustomReactMarkdown>{error}</CustomReactMarkdown>}
       </Content>
-      <ScrollToTop
+      {/* <ScrollToTop
         styleProps={{
           bottom: '8.8%',
           right: 'calc(50% - 4.6rem)',
           background: '#9bd7c2'
         }}
-      />
+      /> */}
     </PageWrapper>
   )
 }

--- a/src/custom/components/Markdown/index.tsx
+++ b/src/custom/components/Markdown/index.tsx
@@ -1,12 +1,20 @@
 import React, { ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown/with-html'
+import { ReactMarkdownPropsBase } from 'react-markdown'
 import useFetchFile from 'hooks/useFetchFile'
 import { Title, Content, PageWrapper } from 'components/Markdown/markdown.styled'
+import { HeadingRenderer, LinkRenderer } from './renderers'
 
 interface MarkdownParams {
   content: string
   title?: ReactNode
 }
+
+const CustomReactMarkdown = (props: ReactMarkdownPropsBase & { children: string }) => (
+  <ReactMarkdown {...props} renderers={{ heading: HeadingRenderer, link: LinkRenderer }} allowDangerousHtml>
+    {props.children}
+  </ReactMarkdown>
+)
 
 export default function Markdown({ content, title }: MarkdownParams) {
   const { error, file } = useFetchFile(content)
@@ -14,16 +22,8 @@ export default function Markdown({ content, title }: MarkdownParams) {
     <PageWrapper>
       {title && <Title>{title}</Title>}
       <Content>
-        {file && (
-          <ReactMarkdown allowDangerousHtml linkTarget="_blank">
-            {file}
-          </ReactMarkdown>
-        )}
-        {error && (
-          <ReactMarkdown allowDangerousHtml linkTarget="_blank">
-            {error}
-          </ReactMarkdown>
-        )}
+        {file && <CustomReactMarkdown>{file}</CustomReactMarkdown>}
+        {error && <CustomReactMarkdown>{error}</CustomReactMarkdown>}
       </Content>
     </PageWrapper>
   )

--- a/src/custom/components/Markdown/index.tsx
+++ b/src/custom/components/Markdown/index.tsx
@@ -12,9 +12,7 @@ interface MarkdownParams {
 }
 
 const CustomReactMarkdown = (props: ReactMarkdownPropsBase & { children: string }) => (
-  <ReactMarkdown {...props} renderers={{ heading: HeadingRenderer, link: LinkRenderer }} allowDangerousHtml>
-    {props.children}
-  </ReactMarkdown>
+  <ReactMarkdown {...props} renderers={{ heading: HeadingRenderer, link: LinkRenderer }} allowDangerousHtml />
 )
 
 export default function Markdown({ content, title }: MarkdownParams) {

--- a/src/custom/components/Markdown/index.tsx
+++ b/src/custom/components/Markdown/index.tsx
@@ -4,6 +4,7 @@ import { ReactMarkdownPropsBase } from 'react-markdown'
 import useFetchFile from 'hooks/useFetchFile'
 import { Title, Content, PageWrapper } from 'components/Markdown/markdown.styled'
 import { HeadingRenderer, LinkRenderer } from './renderers'
+import ScrollToTop from '../ScrollToTop'
 
 interface MarkdownParams {
   content: string
@@ -25,6 +26,13 @@ export default function Markdown({ content, title }: MarkdownParams) {
         {file && <CustomReactMarkdown>{file}</CustomReactMarkdown>}
         {error && <CustomReactMarkdown>{error}</CustomReactMarkdown>}
       </Content>
+      <ScrollToTop
+        styleProps={{
+          bottom: '8.8%',
+          right: 'calc(50% - 4.6rem)',
+          background: '#9bd7c2'
+        }}
+      />
     </PageWrapper>
   )
 }

--- a/src/custom/components/Markdown/renderers.tsx
+++ b/src/custom/components/Markdown/renderers.tsx
@@ -23,7 +23,7 @@ const HeadingRenderer = (props: { level: number; children: ReactNode }) => {
 }
 
 const LinkRenderer = (props: { href: string; children: React.ReactNode }) => {
-  const isExternalLink = props.href.match(/^(https?:)?\/\//)
+  const isExternalLink = /^(https?:)?\/\//.test(props.href)
   return isExternalLink ? (
     <a target="_blank" href={props.href} rel="noopener noreferrer">
       {props.children}

--- a/src/custom/components/Markdown/renderers.tsx
+++ b/src/custom/components/Markdown/renderers.tsx
@@ -47,24 +47,3 @@ const LinkRenderer = (props: { href: string; children: React.ReactNode }) => {
 }
 
 export { HeadingRenderer, LinkRenderer }
-
-// // Another overcomplicated React thing? ok!
-// // react-markdown doesn't auto add ids to header tags
-// // making TOCs impossible without some annoying plugins to install etc
-// // https://github.com/remarkjs/react-markdown/issues/404
-// function flatten(text: string, child: ReactNode): any {
-//   return typeof child === 'string'
-//     ? text + child
-//     : React.Children.toArray((child as ReactElement).props.children).reduce(flatten, text)
-// }
-
-// /**
-//  * HeadingRenderer is a custom renderer
-//  * It parses the heading and attaches an id to it to be used as an anchor
-//  */
-// const HeadingRenderer = (props: { level: number; children: ReactNode }) => {
-//   const children = React.Children.toArray(props.children)
-//   const text = children.reduce(flatten, '')
-//   const slug = text.toLowerCase().replace(/\W/g, '-')
-//   return React.createElement('h' + props.level, { id: slug }, props.children)
-// }

--- a/src/custom/components/Markdown/renderers.tsx
+++ b/src/custom/components/Markdown/renderers.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode, ReactElement } from 'react'
+import HashLink from 'components/HashLink'
+
+// Another overcomplicated React thing? ok!
+// react-markdown doesn't auto add ids to header tags
+// making TOCs impossible without some annoying plugins to install etc
+// https://github.com/remarkjs/react-markdown/issues/404
+function flatten(text: string, child: ReactNode): any {
+  return typeof child === 'string'
+    ? text + child
+    : React.Children.toArray((child as ReactElement).props.children).reduce(flatten, text)
+}
+
+/**
+ * HeadingRenderer is a custom renderer
+ * It parses the heading and attaches an id to it to be used as an anchor
+ */
+const HeadingRenderer = (props: { level: number; children: ReactNode }) => {
+  const children = React.Children.toArray(props.children)
+  const text = children.reduce(flatten, '')
+  const slug = text.toLowerCase().replace(/\W/g, '-')
+  return React.createElement('h' + props.level, { id: slug }, props.children)
+}
+
+const LinkRenderer = (props: { href: string; children: React.ReactNode }) => {
+  const isExternalLink = props.href.match(/^(https?:)?\/\//)
+  return isExternalLink ? (
+    <a target="_blank" href={props.href} rel="noopener noreferrer">
+      {props.children}
+    </a>
+  ) : (
+    <HashLink href={props.href} to={props.href}>
+      {props.children}
+    </HashLink>
+  )
+}
+
+export { HeadingRenderer, LinkRenderer }

--- a/src/custom/components/Menu/MenuMod.tsx
+++ b/src/custom/components/Menu/MenuMod.tsx
@@ -7,7 +7,8 @@ import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useToggleModal } from 'state/application/hooks'
 
-import { ExternalLink } from 'theme'
+import { ExternalLink, StyledInternalLink } from 'theme'
+import { WithClassName } from 'types'
 // import { ButtonPrimary } from 'Button'
 
 const StyledMenuIcon = styled(MenuIcon)`
@@ -85,9 +86,23 @@ export const MenuItem = styled(ExternalLink)`
   }
 `
 
+export const InternalMenuItem = styled(StyledInternalLink)`
+  flex: 1;
+  padding: 0.5rem 0.5rem;
+  color: ${({ theme }) => theme.text2};
+  :hover {
+    color: ${({ theme }) => theme.text1};
+    cursor: pointer;
+    text-decoration: none;
+  }
+  > svg {
+    margin-right: 8px;
+  }
+`
+
 // const CODE_LINK = 'https://github.com/Uniswap/uniswap-interface'
 
-export default function Menu(props?: PropsWithChildren<void>) {
+export default function Menu(props?: PropsWithChildren<void> & WithClassName) {
   // const { account } = useActiveWeb3React()
 
   const node = useRef<HTMLDivElement>()
@@ -98,15 +113,15 @@ export default function Menu(props?: PropsWithChildren<void>) {
 
   return (
     // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
-    <StyledMenu ref={node as any}>
+    <StyledMenu ref={node as any} className={props?.className}>
       <StyledMenuButton onClick={toggle}>
         <StyledMenuIcon />
       </StyledMenuButton>
 
-      {open && (
-        <MenuFlyout>
-          {props?.children}
-          {/* <MenuItem id="link" href="https://uniswap.org/">
+      {open &&
+        /*
+        <MenuFlyout>          
+          <MenuItem id="link" href="https://uniswap.org/">
             <Info size={14} />
             About
           </MenuItem>
@@ -130,9 +145,10 @@ export default function Menu(props?: PropsWithChildren<void>) {
             <ButtonPrimary onClick={openClaimModal} padding="8px 16px" width="100%" borderRadius="12px" mt="0.5rem">
               Claim UNI
             </ButtonPrimary>
-          )} */}
+          )}
         </MenuFlyout>
-      )}
+        */
+        props?.children}
     </StyledMenu>
   )
 }

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -1,25 +1,58 @@
 import React from 'react'
 import { Code, MessageCircle } from 'react-feather'
 
-import MenuMod, { MenuItem } from './MenuMod'
+import MenuMod, { MenuItem, InternalMenuItem, MenuFlyout as MenuFlyoutUni } from './MenuMod'
 import styled from 'styled-components'
+import { Separator as SeparatorBase } from 'components/swap/styleds'
 
-const CODE_LINK = 'https://github.com/gnosis/dex-swap'
-const DISCORD_LINK = 'https://chat.gnosis.io'
+const CODE_LINK = 'https://github.com/gnosis/gp-swap-ui'
+const DISCORD_LINK = 'https://discord.gg/egGzDDctuC'
 
-export const StyledMenu = styled(MenuMod)``
+export const StyledMenu = styled(MenuMod)`
+  hr {
+    margin: 15px 0;
+  }
+`
+
+const Policy = styled(InternalMenuItem)`
+  font-size: 0.8em;
+  text-decoration: underline;
+`
+
+const MenuFlyout = styled(MenuFlyoutUni)`
+  min-width: 11rem;
+`
+
+const Separator = styled(SeparatorBase)`
+  background-color: #0000002e;
+  margin: 0.3rem auto;
+  width: 90%;
+`
 
 export function Menu() {
   return (
     <StyledMenu>
-      <MenuItem id="link" href={CODE_LINK}>
-        <Code size={14} />
-        Code
-      </MenuItem>
-      <MenuItem id="link" href={DISCORD_LINK}>
-        <MessageCircle size={14} />
-        Discord
-      </MenuItem>
+      <MenuFlyout>
+        <InternalMenuItem to="/faq">
+          <Code size={14} />
+          FAQ
+        </InternalMenuItem>
+
+        <MenuItem id="link" href={CODE_LINK}>
+          <Code size={14} />
+          Code
+        </MenuItem>
+        <MenuItem id="link" href={DISCORD_LINK}>
+          <MessageCircle size={14} />
+          Discord
+        </MenuItem>
+
+        <Separator />
+
+        <Policy to="/terms-and-conditions">Terms and conditions</Policy>
+        <Policy to="/privacy-policy">Privacy policy</Policy>
+        <Policy to="/cookie-policy">Cookie policy</Policy>
+      </MenuFlyout>
     </StyledMenu>
   )
 }

--- a/src/custom/components/ScrollToTop/index.tsx
+++ b/src/custom/components/ScrollToTop/index.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { ArrowUpCircle } from 'react-feather'
+import useDebouncedChangeHandler from 'utils/useDebouncedChangeHandler'
+
+interface WrapperProps {
+  top?: string
+  right?: string
+  bottom?: string
+  left?: string
+  background?: string
+}
+
+const Wrapper = styled.div<WrapperProps>`
+    position: fixed;
+    ${({ top }): string | undefined => top && `top: ${top};`}
+    ${({ left }): string | undefined => left && `left: ${left};`}
+    ${({ bottom }): string | undefined => bottom && `bottom: ${bottom};`}
+    ${({ right }): string | undefined => right && `right: ${right};`}
+
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center; 
+    align-items: center;
+
+    font-size: larger;
+    background: ${({ background, theme }) => background || theme.primary1}
+    border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius}
+
+    padding: 0.2rem 0.4rem;
+
+    cursor: pointer;
+    opacity: 0.4;
+
+    &:hover {
+        opacity: 1;
+    }
+
+    > svg {
+        margin: 0 0.4rem;
+    }
+
+    transition: opacity 0.4s ease-in-out;
+`
+
+export default function ScrollToTop(props: { styleProps?: WrapperProps }) {
+  const [position, setPosition] = useState(window.scrollY)
+  const [, debouncedSetPosition] = useDebouncedChangeHandler(position, setPosition, 500)
+
+  const handleClick = () => window.scrollTo(0, 0)
+
+  useEffect(() => {
+    const scrollListener = () => debouncedSetPosition(window.scrollY)
+
+    window.addEventListener('scroll', scrollListener)
+
+    return () => window.removeEventListener('scroll', scrollListener)
+  }, [debouncedSetPosition])
+
+  if (position < 250) return null
+
+  return (
+    <Wrapper {...props.styleProps} onClick={handleClick}>
+      Scroll to top <ArrowUpCircle size="1.6rem" />
+    </Wrapper>
+  )
+}

--- a/src/custom/components/ScrollToTop/index.tsx
+++ b/src/custom/components/ScrollToTop/index.tsx
@@ -34,6 +34,8 @@ const Wrapper = styled.div<WrapperProps>`
     cursor: pointer;
     opacity: 0.4;
 
+    transition: opacity 0.4s ease-in-out;
+    
     &:hover {
         opacity: 1;
     }
@@ -42,24 +44,27 @@ const Wrapper = styled.div<WrapperProps>`
         margin: 0 0.4rem;
     }
 
-    transition: opacity 0.4s ease-in-out;
 `
 
+const SHOW_SCROLL_TOP_THRESHOLD = 250
+
 export default function ScrollToTop(props: { styleProps?: WrapperProps }) {
-  const [position, setPosition] = useState(window.scrollY)
-  const [, debouncedSetPosition] = useDebouncedChangeHandler(position, setPosition, 500)
+  const [isShown, setIsShown] = useState(() => window.scrollY >= SHOW_SCROLL_TOP_THRESHOLD)
+  const [, debouncedSetPosition] = useDebouncedChangeHandler(isShown, setIsShown, 500)
 
   const handleClick = () => window.scrollTo(0, 0)
 
   useEffect(() => {
-    const scrollListener = () => debouncedSetPosition(window.scrollY)
+    const scrollListener = () => debouncedSetPosition(window.scrollY >= SHOW_SCROLL_TOP_THRESHOLD)
 
-    window.addEventListener('scroll', scrollListener)
+    // make eventListener passive as to not block main thread (thanks @velenir)
+    // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners
+    window.addEventListener('scroll', scrollListener, { passive: true })
 
     return () => window.removeEventListener('scroll', scrollListener)
   }, [debouncedSetPosition])
 
-  if (position < 250) return null
+  if (!isShown) return null
 
   return (
     <Wrapper {...props.styleProps} onClick={handleClick}>

--- a/src/custom/components/ScrollToTop/index.tsx
+++ b/src/custom/components/ScrollToTop/index.tsx
@@ -13,10 +13,13 @@ interface WrapperProps {
 
 const Wrapper = styled.div<WrapperProps>`
     position: fixed;
-    ${({ top }): string | undefined => top && `top: ${top};`}
-    ${({ left }): string | undefined => left && `left: ${left};`}
-    ${({ bottom }): string | undefined => bottom && `bottom: ${bottom};`}
-    ${({ right }): string | undefined => right && `right: ${right};`}
+    ${({ theme, background = theme.primary1, top, right, bottom, left }) => ({
+      background,
+      top,
+      right,
+      bottom,
+      left
+    })}
 
     display: flex;
     flex-flow: row nowrap;
@@ -24,7 +27,6 @@ const Wrapper = styled.div<WrapperProps>`
     align-items: center;
 
     font-size: larger;
-    background: ${({ background, theme }) => background || theme.primary1}
     border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius}
 
     padding: 0.2rem 0.4rem;

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -57,14 +57,10 @@ const VERSIONS: Record<
 const versionsList = Object.keys(VERSIONS)
 
 const StyledPolling = styled.div`
-  position: fixed;
+  position: relative;
   display: flex;
   flex-flow: column nowrap;
   align-items: flex-start;
-  // gap: 0.5rem;
-
-  left: 0;
-  bottom: 0;
 
   padding: 1rem;
 
@@ -102,10 +98,10 @@ const LogoWrapper = styled.img`
   margin-left: 0.5rem;
 `
 
-const Version = () => {
+const Version = ({ className }: { className?: string }) => {
   const { chainId = DEFAULT_NETWORK_FOR_LISTS } = useActiveWeb3React()
   return (
-    <StyledPolling>
+    <StyledPolling className={className}>
       {/* it's hardcoded anyways */}
       {versionsList.map(key => {
         const { href, version } = VERSIONS[key]

--- a/src/custom/pages/About/About.md
+++ b/src/custom/pages/About/About.md
@@ -1,3 +1,7 @@
+# About
+
+### (updated: April 2021)
+
 ## What is CowSwap?
 
 ** CowSwap ** is a Interdum et malesuada fames ac ante ipsum primis in faucibus. Proin vitae blandit leo. Etiam consequat diam eu tortor scelerisque mattis. Nulla eu lacus accumsan, consequat ante et, molestie ex. Cras eu ante nisl. Vestibulum ut sagittis ex. Praesent et metus a ligula porta interdum.

--- a/src/custom/pages/App/AppMod.tsx
+++ b/src/custom/pages/App/AppMod.tsx
@@ -31,10 +31,13 @@ import DarkModeQueryParamReader from 'theme'
 // import Vote from './Vote'
 // import VotePage from './Vote/VotePage'
 
+import Footer from 'components/Footer'
+
 const AppWrapper = styled.div`
   display: flex;
   flex-flow: column;
   align-items: flex-start;
+  min-height: 100vh;
   overflow-x: hidden;
 `
 
@@ -62,6 +65,8 @@ const BodyWrapper = styled.div`
 
   z-index: 1;
 `
+
+const FooterWrapper = styled(HeaderWrapper)``
 
 const Marginer = styled.div`
   margin-top: 5rem;
@@ -117,6 +122,9 @@ export default function App(props?: PropsWithChildren<void>) {
           </Web3ReactManager>
           <Marginer />
         </BodyWrapper>
+        <FooterWrapper>
+          <Footer />
+        </FooterWrapper>
       </AppWrapper>
     </Suspense>
   )

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -6,6 +6,7 @@ import { Route, Switch } from 'react-router-dom'
 import Swap from 'pages/Swap'
 import PrivacyPolicy from 'pages/PrivacyPolicy'
 import CookiePolicy from 'pages/CookiePolicy'
+import TermsAndConditions from 'pages/TermsAndConditions'
 // import About from 'pages/About'
 
 export const Wrapper = styled(AppMod)``
@@ -21,6 +22,7 @@ export default function App() {
         {/* <Route exact strict path="/about" component={About} /> */}
         <Route exact strict path="/privacy-policy" component={PrivacyPolicy} />
         <Route exact strict path="/cookie-policy" component={CookiePolicy} />
+        <Route exact strict path="/terms-and-conditions" component={TermsAndConditions} />
         <Route component={RedirectPathToSwapOnly} />
       </Switch>
     </Wrapper>

--- a/src/custom/pages/AppBody/index.tsx
+++ b/src/custom/pages/AppBody/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { BodyWrapper as BodyWrapperMod } from '@src/pages/AppBody'
 import styled from 'styled-components'
-import Version from 'components/Version'
 
 export const BodyWrapper = styled(BodyWrapperMod)`
   box-shadow: ${({ theme }) => theme.appBody.boxShadow};
@@ -13,10 +12,5 @@ export const BodyWrapper = styled(BodyWrapperMod)`
 
 // The styled container element that wraps the content of most pages and the tabs.
 export default function AppBody({ children, className }: { children: React.ReactNode; className?: string }) {
-  return (
-    <BodyWrapper className={className}>
-      {children}
-      <Version />
-    </BodyWrapper>
-  )
+  return <BodyWrapper className={className}>{children}</BodyWrapper>
 }

--- a/src/custom/pages/CookiePolicy/CookiePolicy.md
+++ b/src/custom/pages/CookiePolicy/CookiePolicy.md
@@ -3,7 +3,7 @@
 
 ### (updated: March 2021)
 
-As described in our [Privacy Policy](/#/privacy-policy), for general web-browsing of this website, your personal data is not revealed to us, although certain statistical information is available to us via our internet service provider as well as through the use of special tracking technologies. Such information tells us about the pages you are clicking on or the hardware you are using, but not your name, age, address or anything we can use to identify you personally.
+As described in our [Privacy Policy](/privacy-policy), for general web-browsing of this website, your personal data is not revealed to us, although certain statistical information is available to us via our internet service provider as well as through the use of special tracking technologies. Such information tells us about the pages you are clicking on or the hardware you are using, but not your name, age, address or anything we can use to identify you personally.
 
 This Cookie Policy sets out some further detail on how and why we use these technologies on our website. The terms "we", "us", and "our" includes Gnosis Limited and our affiliates. The terms “you” and “your” includes our clients, business partners and users of this website. By using our website, you consent to storage and access to cookies and other technologies on your device, in accordance with this Cookie Policy.
 

--- a/src/custom/pages/PrivacyPolicy/PrivacyPolicy.md
+++ b/src/custom/pages/PrivacyPolicy/PrivacyPolicy.md
@@ -15,17 +15,17 @@ In this Policy, “processing” means any operation or set of operations which 
 ## Navigating this Policy
 If you are viewing this policy online, you can click on the below links to jump to the relevant section:
     
-1. [Your information and the Blockchain](#your-information-and-the-blockchain)
-2. [How We Use Personal Data](/#/privacy-policy#How-We-Use-Personal-Data)
-3. [Use of Third Party Applications](#Use-of-Third-Party-Applications)
-4. [Sharing Your Personal Data](#Sharing-Your-Personal-Data)
-5. [Transferring Your data outside of the EU](#Transferring-Your-data-outside-of-the-EU)
-6. [Existence of Automated Decision-making](#Existence-of-Automated-Decision-making)
-7. [Data Security](#bookmark=id.k8qc5kgqu9hp)
-8. [Your Rights as a Data Subject](#bookmark=id.v430se3znxne)
-9. [Storing Personal Data](#bookmark=id.fstyffug7piv)
-10. [Changes to this Privacy Policy](#bookmark=id.utritvoelpzi)
-11. [Our details](#bookmark=id.qllwcj1249z0)
+1. [Your information and the Blockchain](#1--your-information-and-the-blockchain)
+2. [How We Use Personal Data](#2--how-we-use-personal-data)
+3. [Use of Third Party Applications](#3--use-of-third-party-applications)
+4. [Sharing Your Personal Data](#4--sharing-your-personal-data)
+5. [Transferring Your data outside of the EU](#5--transferring-your-data-outside-of-the-eu)
+6. [Existence of Automated Decision-making](#6--existence-of-automated-decision-making)
+7. [Data Security](#7--data-security)
+8. [Your Rights as a Data Subject](#8--your-rights-as-a-data-subject)
+9. [Storing Personal Data](#9--storing-personal-data)
+10. [Changes to this Privacy Policy](#10--changes-to-this-privacy-policy)
+11. [Our details](#11--our-details)
 
 ### 1. Your information and the Blockchain ###
 Blockchain technology, also known as distributed ledger technology (or simply ‘DLT’), is at the core of our business. Blockchains are decentralized and made up of digitally recorded data in a chain of packages called ‘blocks’. The manner in which these blocks are linked is chronological, meaning that the data is very difficult to alter once recorded. Since the ledger may be distributed all over the world (across several ‘nodes’ which usually replicate the ledger) this means there is no single person making decisions or otherwise administering the system (such as an operator of a cloud computing system), and that there is no centralized place where it is located either.

--- a/src/custom/pages/TermsAndConditions/TermsAndConditions.md
+++ b/src/custom/pages/TermsAndConditions/TermsAndConditions.md
@@ -1,0 +1,9 @@
+# Disclaimer
+
+### (updated: April 3021)
+
+This graphical user interface (GUI) and the underlying smart contracts of the Gnosis Protocol are a proof of concept Alpha version. 
+
+The GUI, the protocol and all content is provided on an “as is” and “as available” basis. You use this GUI and the protocol at your own risk and assume full responsibility for such use. 
+
+The information on the GUI does not constitute investment advice, financial advice, legal advice, tax advice or any other sort of advice. You are solely responsible for your own investment decisions and transactions.

--- a/src/custom/pages/TermsAndConditions/index.tsx
+++ b/src/custom/pages/TermsAndConditions/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import content from 'pages/About/About.md'
+import content from './TermsAndConditions.md'
 import Markdown from 'components/Markdown'
 
-export default function About() {
+export default function TermsAndConditions() {
   return <Markdown content={content} />
 }


### PR DESCRIPTION
Merges into #390 

Adds capabilities for internal links with markdown

## Typical over-engineered react way of doing this

Adds `ScrollToTop` comp for easier access to links