### PR TITLE
250[part of it] Add Terms and Conditions page

### DIFF
--- a/src/custom/pages/About/About.md
+++ b/src/custom/pages/About/About.md
@@ -1,3 +1,7 @@
+# About
+
+### (updated: April 2021)
+
 ## What is CowSwap?
 
 ** CowSwap ** is a Interdum et malesuada fames ac ante ipsum primis in faucibus. Proin vitae blandit leo. Etiam consequat diam eu tortor scelerisque mattis. Nulla eu lacus accumsan, consequat ante et, molestie ex. Cras eu ante nisl. Vestibulum ut sagittis ex. Praesent et metus a ligula porta interdum.

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -3,5 +3,5 @@ import content from 'pages/About/About.md'
 import Markdown from 'components/Markdown'
 
 export default function About() {
-  return <Markdown content={content} title="About" />
+  return <Markdown content={content} />
 }

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -6,6 +6,7 @@ import { Route, Switch } from 'react-router-dom'
 import Swap from 'pages/Swap'
 import PrivacyPolicy from 'pages/PrivacyPolicy'
 import CookiePolicy from 'pages/CookiePolicy'
+import TermsAndConditions from 'pages/TermsAndConditions'
 // import About from 'pages/About'
 
 export const Wrapper = styled(AppMod)``
@@ -21,6 +22,7 @@ export default function App() {
         {/* <Route exact strict path="/about" component={About} /> */}
         <Route exact strict path="/privacy-policy" component={PrivacyPolicy} />
         <Route exact strict path="/cookie-policy" component={CookiePolicy} />
+        <Route exact strict path="/terms-and-conditions" component={TermsAndConditions} />
         <Route component={RedirectPathToSwapOnly} />
       </Switch>
     </Wrapper>

--- a/src/custom/pages/TermsAndConditions/TermsAndConditions.md
+++ b/src/custom/pages/TermsAndConditions/TermsAndConditions.md
@@ -1,0 +1,5 @@
+# Disclaimer
+
+### (updated: April 2021)
+
+This graphical user interface (GUI) and the underlying smart contracts of the Gnosis Protocol are a proof of concept Alpha version. The GUI, the protocol and all content is provided on an “as is” and “as available” basis. You use this GUI and the protocol at your own risk and assume full responsibility for such use. The information on the GUI does not constitute investment advice, financial advice, legal advice, tax advice or any other sort of advice. You are solely responsible for your own investment decisions and transactions.

--- a/src/custom/pages/TermsAndConditions/TermsAndConditions.md
+++ b/src/custom/pages/TermsAndConditions/TermsAndConditions.md
@@ -1,5 +1,9 @@
 # Disclaimer
 
-### (updated: April 2021)
+### (updated: April 3021)
 
-This graphical user interface (GUI) and the underlying smart contracts of the Gnosis Protocol are a proof of concept Alpha version. The GUI, the protocol and all content is provided on an “as is” and “as available” basis. You use this GUI and the protocol at your own risk and assume full responsibility for such use. The information on the GUI does not constitute investment advice, financial advice, legal advice, tax advice or any other sort of advice. You are solely responsible for your own investment decisions and transactions.
+This graphical user interface (GUI) and the underlying smart contracts of the Gnosis Protocol are a proof of concept Alpha version. 
+
+The GUI, the protocol and all content is provided on an “as is” and “as available” basis. You use this GUI and the protocol at your own risk and assume full responsibility for such use. 
+
+The information on the GUI does not constitute investment advice, financial advice, legal advice, tax advice or any other sort of advice. You are solely responsible for your own investment decisions and transactions.

--- a/src/custom/pages/TermsAndConditions/index.tsx
+++ b/src/custom/pages/TermsAndConditions/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+import content from './TermsAndConditions.md'
+import Markdown from 'components/Markdown'
+
+export default function TermsAndConditions() {
+  return <Markdown content={content} />
+}


### PR DESCRIPTION
Pointing at #398 to quiet down the commit history, but ultimately should end up in `release/v0.9.0` 

Closes part of #250 

Next PR will address the `footer` updated to include links to pages