### PR TITLE
🧪 Force ethsign experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.15",
+    "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.17",
     "@uniswap/default-token-list": "^2.0.0"
   }
 }

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -113,11 +113,10 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
       signature = (await signOrder({ ...signatureParams, signingScheme })) as EcdsaSignature // Only ECDSA signing supported for now
     } else {
       // Some other error signing. Let it bubble up.
+      console.error(e)
       throw e
     }
   }
-
-  console.log(`we got a signature \\o/`, signature)
 
   const signatureData = signature?.data.toString()
   const creationTime = new Date().toISOString()

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -99,23 +99,25 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
     signingScheme
   }
 
-  try {
-    signature = (await signOrder(signatureParams)) as EcdsaSignature // Only ECDSA signing supported for now
-  } catch (e) {
-    if (e.code === METAMASK_SIGNATURE_ERROR_CODE) {
-      // We tried to sign order the nice way.
-      // That works fine for regular MM addresses. Does not work for Hardware wallets, though.
-      // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-810552020
-      // So, when that specific error occurs, we know this is a problem with MM + HW.
-      // Then, we fallback to ETHSIGN.
-      signingScheme = SigningScheme.ETHSIGN
-      signature = (await signOrder({ ...signatureParams, signingScheme })) as EcdsaSignature // Only ECDSA signing supported for now
-    } else {
-      // Some other error signing. Let it bubble up.
-      console.error(e)
-      throw e
-    }
-  }
+  signingScheme = SigningScheme.ETHSIGN
+  signature = (await signOrder({ ...signatureParams, signingScheme })) as EcdsaSignature // Only ECDSA signing supported for now
+  // try {
+  //   signature = (await signOrder(signatureParams)) as EcdsaSignature // Only ECDSA signing supported for now
+  // } catch (e) {
+  //   if (e.code === METAMASK_SIGNATURE_ERROR_CODE) {
+  //     // We tried to sign order the nice way.
+  //     // That works fine for regular MM addresses. Does not work for Hardware wallets, though.
+  //     // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-810552020
+  //     // So, when that specific error occurs, we know this is a problem with MM + HW.
+  //     // Then, we fallback to ETHSIGN.
+  //     signingScheme = SigningScheme.ETHSIGN
+  //     signature = (await signOrder({ ...signatureParams, signingScheme })) as EcdsaSignature // Only ECDSA signing supported for now
+  //   } else {
+  //     // Some other error signing. Let it bubble up.
+  //     console.error(e)
+  //     throw e
+  //   }
+  // }
 
   const signatureData = signature.data.toString()
   const creationTime = new Date().toISOString()

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -105,7 +105,7 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
     if (e.code === METAMASK_SIGNATURE_ERROR_CODE) {
       // We tried to sign order the nice way.
       // That works fine for regular MM addresses. Does not work for Hardware wallets, though.
-      // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-812672324
+      // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-810552020
       // So, when that specific error occurs, we know this is a problem with MM + HW.
       // Then, we fallback to ETHSIGN.
       signingScheme = SigningScheme.ETHSIGN

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -108,7 +108,6 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
       // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-812672324
       // So, when that specific error occurs, we know this is a problem with MM + HW.
       // Then, we fallback to ETHSIGN.
-      console.info('[trade:postOrder] Wallet does not support EIP712. Trying ETHSIGN instead', e)
       signingScheme = SigningScheme.ETHSIGN
       signature = (await signOrder({ ...signatureParams, signingScheme })) as EcdsaSignature // Only ECDSA signing supported for now
     } else {

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -9,7 +9,7 @@ import { APP_ID, RADIX_DECIMAL, SHORTEST_PRECISION } from 'constants/index'
 import { EcdsaSignature, Signature } from '@gnosis.pm/gp-v2-contracts'
 
 const DEFAULT_SIGNING_SCHEME = SigningScheme.EIP712
-const METAMASK_SIGNATURE_ERROR_CODE = -32603
+// const METAMASK_SIGNATURE_ERROR_CODE = -32603
 
 export interface PostOrderParams {
   account: string

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -9,7 +9,7 @@ import { APP_ID, RADIX_DECIMAL, SHORTEST_PRECISION } from 'constants/index'
 import { EcdsaSignature, Signature } from '@gnosis.pm/gp-v2-contracts'
 
 const DEFAULT_SIGNING_SCHEME = SigningScheme.EIP712
-const METAMASK_SIGNATURE_ERROR = -32603
+const METAMASK_SIGNATURE_ERROR_CODE = -32603
 
 export interface PostOrderParams {
   account: string
@@ -102,7 +102,7 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
   try {
     signature = (await signOrder(signatureParams)) as EcdsaSignature // Only ECDSA signing supported for now
   } catch (e) {
-    if (e.code === METAMASK_SIGNATURE_ERROR) {
+    if (e.code === METAMASK_SIGNATURE_ERROR_CODE) {
       // We tried to sign order the nice way.
       // That works fine for regular MM addresses. Does not work for Hardware wallets, though.
       // See https://github.com/MetaMask/metamask-extension/issues/10240#issuecomment-812672324

--- a/src/custom/utils/trade.ts
+++ b/src/custom/utils/trade.ts
@@ -118,7 +118,7 @@ export async function postOrder(params: PostOrderParams): Promise<string> {
     }
   }
 
-  const signatureData = signature?.data.toString()
+  const signatureData = signature.data.toString()
   const creationTime = new Date().toISOString()
 
   // Call API

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,10 +1674,10 @@
     "@ethersproject/properties" "^5.1.0"
     "@ethersproject/strings" "^5.1.0"
 
-"@gnosis.pm/gp-v2-contracts@^0.0.1-alpha.15":
-  version "0.0.1-alpha.16"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-0.0.1-alpha.16.tgz#6e326e5e2ec845992c7f9f6fc32189c1505ab5b4"
-  integrity sha512-5sufwG3WTotLDRJLw6Y7f1e2HRYEWxSNRwC4xZ5GipQ3EobOpCPKGUIp3iZy0wJa0we0CMyFZtT0WQeVbik7xw==
+"@gnosis.pm/gp-v2-contracts@^0.0.1-alpha.17":
+  version "0.0.1-alpha.17"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-0.0.1-alpha.17.tgz#5c3e08b4a761d13383af631cee255cc7645aa50a"
+  integrity sha512-kr/tpeqvlKVXDka/aFHGFJyT9xgYjAvWK9wszlq4pyH3Qs7WIB0mj9YMdzAmVRVdvpXeLGWgTPZ88xIXD/9X6Q==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
## 🚨Please, don't merge

PoC, just to see if the users complain less when they sign blindly a hash, than when they sign a nice JSON with raw hexes.

This PR is meant to be an experiment to see user reaction to this. The hipotesis to proof or refute is:
* Users complain more for signing a nice JSON with some hex codes that are not easy to verify, and some amounts that are in weis and not in units, than signing a single intelligible hex code.

Before this PR:
![image](https://user-images.githubusercontent.com/2352112/114591893-a4d87080-9c8a-11eb-9688-9c6f4edb07ad.png)

After this PR:
![image](https://user-images.githubusercontent.com/2352112/114591647-6642b600-9c8a-11eb-81ab-9da64b2d3ea9.png)



