### PR TITLE
[250] Header Menu content pages ([...] Menu)

### DIFF
--- a/src/custom/components/Footer/index.tsx
+++ b/src/custom/components/Footer/index.tsx
@@ -3,12 +3,17 @@ import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import Version from '../Version'
-const FOOTER_URLS = [
+import { BookOpen, Search, Book, AlertTriangle } from 'react-feather'
+export const FOOTER_URLS = [
   { name: '© 2021 Gnosis' },
-  { name: 'About', url: '/about' },
-  { name: 'Cookies', url: '/cookie-policy' },
-  { name: 'Privacy', url: '/privacy-policy' },
-  { name: 'Terms', url: '/terms-and-conditions' }
+  {
+    name: 'About',
+    url: '/about',
+    Icon: BookOpen
+  },
+  { name: 'Cookies', url: '/cookie-policy', Icon: Search },
+  { name: 'Privacy', url: '/privacy-policy', Icon: AlertTriangle },
+  { name: 'Terms', url: '/terms-and-conditions', Icon: Book }
 ]
 
 const FooterVersion = styled(Version)`

--- a/src/custom/components/Header/HeaderMod.tsx
+++ b/src/custom/components/Header/HeaderMod.tsx
@@ -94,12 +94,10 @@ export const HeaderElement = styled.div`
   `};
 `
 
-/*
-const HeaderElementWrap = styled.div`
+export const HeaderElementWrap = styled.div`
   display: flex;
   align-items: center;
 `
-*/
 
 export const HeaderRow = styled(RowFixed)`
   ${({ theme }) => theme.mediaWidth.upToMedium`

--- a/src/custom/components/Header/index.tsx
+++ b/src/custom/components/Header/index.tsx
@@ -13,8 +13,10 @@ import HeaderMod, {
   HeaderElement,
   HideSmall,
   BalanceText,
-  AccountElement
+  AccountElement,
+  HeaderElementWrap
 } from './HeaderMod'
+import Menu from '../Menu'
 import styled from 'styled-components'
 import { status as appStatus } from '@src/../package.json'
 import { useActiveWeb3React } from 'hooks'
@@ -130,12 +132,9 @@ export default function Header() {
             <Web3Status />
           </AccountElement>
         </HeaderElement>
-        {/* <HeaderElementWrap>
-          <StyledMenuButton onClick={() => toggleDarkMode()}>
-            {darkMode ? <Moon size={20} /> : <Sun size={20} />}
-          </StyledMenuButton>
+        <HeaderElementWrap>
           <Menu />
-        </HeaderElementWrap> */}
+        </HeaderElementWrap>
       </HeaderControls>
     </HeaderModWrapper>
   )

--- a/src/custom/components/Menu/MenuMod.tsx
+++ b/src/custom/components/Menu/MenuMod.tsx
@@ -8,6 +8,7 @@ import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useToggleModal } from 'state/application/hooks'
 
 import { ExternalLink, StyledInternalLink } from 'theme'
+import { WithClassName } from 'types'
 // import { ButtonPrimary } from 'Button'
 
 const StyledMenuIcon = styled(MenuIcon)`
@@ -101,7 +102,7 @@ export const InternalMenuItem = styled(StyledInternalLink)`
 
 // const CODE_LINK = 'https://github.com/Uniswap/uniswap-interface'
 
-export default function Menu(props?: PropsWithChildren<void>) {
+export default function Menu(props?: PropsWithChildren<void> & WithClassName) {
   // const { account } = useActiveWeb3React()
 
   const node = useRef<HTMLDivElement>()
@@ -112,15 +113,15 @@ export default function Menu(props?: PropsWithChildren<void>) {
 
   return (
     // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
-    <StyledMenu ref={node as any}>
+    <StyledMenu ref={node as any} className={props?.className}>
       <StyledMenuButton onClick={toggle}>
         <StyledMenuIcon />
       </StyledMenuButton>
 
-      {open && (
-        <MenuFlyout>
-          {props?.children}
-          {/* <MenuItem id="link" href="https://uniswap.org/">
+      {open &&
+        /*
+        <MenuFlyout>          
+          <MenuItem id="link" href="https://uniswap.org/">
             <Info size={14} />
             About
           </MenuItem>
@@ -144,9 +145,10 @@ export default function Menu(props?: PropsWithChildren<void>) {
             <ButtonPrimary onClick={openClaimModal} padding="8px 16px" width="100%" borderRadius="12px" mt="0.5rem">
               Claim UNI
             </ButtonPrimary>
-          )} */}
+          )}
         </MenuFlyout>
-      )}
+        */
+        props?.children}
     </StyledMenu>
   )
 }

--- a/src/custom/components/Menu/MenuMod.tsx
+++ b/src/custom/components/Menu/MenuMod.tsx
@@ -7,7 +7,7 @@ import { useOnClickOutside } from 'hooks/useOnClickOutside'
 import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useToggleModal } from 'state/application/hooks'
 
-import { ExternalLink } from 'theme'
+import { ExternalLink, StyledInternalLink } from 'theme'
 // import { ButtonPrimary } from 'Button'
 
 const StyledMenuIcon = styled(MenuIcon)`
@@ -72,6 +72,20 @@ export const MenuFlyout = styled.span`
 `
 
 export const MenuItem = styled(ExternalLink)`
+  flex: 1;
+  padding: 0.5rem 0.5rem;
+  color: ${({ theme }) => theme.text2};
+  :hover {
+    color: ${({ theme }) => theme.text1};
+    cursor: pointer;
+    text-decoration: none;
+  }
+  > svg {
+    margin-right: 8px;
+  }
+`
+
+export const InternalMenuItem = styled(StyledInternalLink)`
   flex: 1;
   padding: 0.5rem 0.5rem;
   color: ${({ theme }) => theme.text2};

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -1,35 +1,58 @@
 import React from 'react'
-import { Code, MessageCircle, IconProps } from 'react-feather'
+import { Code, MessageCircle } from 'react-feather'
 
-import MenuMod, { MenuItem, InternalMenuItem } from './MenuMod'
+import MenuMod, { MenuItem, InternalMenuItem, MenuFlyout as MenuFlyoutUni } from './MenuMod'
 import styled from 'styled-components'
-import { FOOTER_URLS } from '../Footer'
+import { Separator as SeparatorBase } from 'components/swap/styleds'
 
-const CODE_LINK = 'https://github.com/gnosis/dex-swap'
-const DISCORD_LINK = 'https://chat.gnosis.io'
+const CODE_LINK = 'https://github.com/gnosis/gp-swap-ui'
+const DISCORD_LINK = 'https://discord.gg/egGzDDctuC'
 
-export const StyledMenu = styled(MenuMod)``
+export const StyledMenu = styled(MenuMod)`
+  hr {
+    margin: 15px 0;
+  }
+`
 
-// remove static gnosis text and leave urls
-const CONTENT_URLS = FOOTER_URLS.slice(1) as { name: string; url: string; Icon?: React.FC<IconProps> }[]
+const Policy = styled(InternalMenuItem)`
+  font-size: 0.8em;
+  text-decoration: underline;
+`
+
+const MenuFlyout = styled(MenuFlyoutUni)`
+  min-width: 11rem;
+`
+
+const Separator = styled(SeparatorBase)`
+  background-color: #0000002e;
+  margin: 0.3rem auto;
+  width: 90%;
+`
 
 export function Menu() {
   return (
     <StyledMenu>
-      <MenuItem id="link" href={CODE_LINK}>
-        <Code size={14} />
-        Code
-      </MenuItem>
-      <MenuItem id="link" href={DISCORD_LINK}>
-        <MessageCircle size={14} />
-        Discord
-      </MenuItem>
-      {CONTENT_URLS.map(({ name, url, Icon }, index) => (
-        <InternalMenuItem key={url + '_' + index} to={url}>
-          {Icon && <Icon size={14} />}
-          {name}
+      <MenuFlyout>
+        <InternalMenuItem to="/faq">
+          <Code size={14} />
+          FAQ
         </InternalMenuItem>
-      ))}
+
+        <MenuItem id="link" href={CODE_LINK}>
+          <Code size={14} />
+          Code
+        </MenuItem>
+        <MenuItem id="link" href={DISCORD_LINK}>
+          <MessageCircle size={14} />
+          Discord
+        </MenuItem>
+
+        <Separator />
+
+        <Policy to="/terms-and-conditions">Terms and conditions</Policy>
+        <Policy to="/privacy-policy">Privacy policy</Policy>
+        <Policy to="/cookie-policy">Cookie policy</Policy>
+      </MenuFlyout>
     </StyledMenu>
   )
 }

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
-import { Code, MessageCircle } from 'react-feather'
+import { Code, MessageCircle, IconProps } from 'react-feather'
 
-import MenuMod, { MenuItem } from './MenuMod'
+import MenuMod, { MenuItem, InternalMenuItem } from './MenuMod'
 import styled from 'styled-components'
+import { FOOTER_URLS } from '../Footer'
 
 const CODE_LINK = 'https://github.com/gnosis/dex-swap'
 const DISCORD_LINK = 'https://chat.gnosis.io'
 
 export const StyledMenu = styled(MenuMod)``
+
+// remove static gnosis text and leave urls
+const CONTENT_URLS = FOOTER_URLS.slice(1) as { name: string; url: string; Icon?: React.FC<IconProps> }[]
 
 export function Menu() {
   return (
@@ -20,6 +24,12 @@ export function Menu() {
         <MessageCircle size={14} />
         Discord
       </MenuItem>
+      {CONTENT_URLS.map(({ name, url, Icon }, index) => (
+        <InternalMenuItem key={url + '_' + index} to={url}>
+          {Icon && <Icon size={14} />}
+          {name}
+        </InternalMenuItem>
+      ))}
     </StyledMenu>
   )
 }


### PR DESCRIPTION
Relevant to #418 and to #250 

@anxolin I'm opening this as it was related to the Footer and the content pages + to see how similar our PRs are based on your slack message that you also are working on adding this back in

1. added the content pages (essentially the footer links) into the menu 
2. added icons to the menu items (just picked random ones can be re-explored)
3. created InternalMenuItem for internal links

### Desktop
![Screenshot from 2021-04-14 13-04-04](https://user-images.githubusercontent.com/21335563/114707283-eec06580-9d21-11eb-83ab-daaae90316c1.png)

### Mobile
![Screenshot from 2021-04-14 13-04-51](https://user-images.githubusercontent.com/21335563/114707350-0566bc80-9d22-11eb-8cf3-9a8fd5adb794.png)


## QA
1. Just open the menu and check that the links all work and go to right places
2. for now the About page is not linking anywhere proper as we're waiting #308 