### PR TITLE
Add policies as links

### DIFF
--- a/src/custom/components/Menu/MenuMod.tsx
+++ b/src/custom/components/Menu/MenuMod.tsx
@@ -8,6 +8,7 @@ import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useToggleModal } from 'state/application/hooks'
 
 import { ExternalLink, StyledInternalLink } from 'theme'
+import { WithClassName } from '@src/custom/types'
 // import { ButtonPrimary } from 'Button'
 
 const StyledMenuIcon = styled(MenuIcon)`
@@ -101,7 +102,7 @@ export const InternalMenuItem = styled(StyledInternalLink)`
 
 // const CODE_LINK = 'https://github.com/Uniswap/uniswap-interface'
 
-export default function Menu(props?: PropsWithChildren<void>) {
+export default function Menu(props?: PropsWithChildren<void> & WithClassName) {
   // const { account } = useActiveWeb3React()
 
   const node = useRef<HTMLDivElement>()
@@ -112,15 +113,15 @@ export default function Menu(props?: PropsWithChildren<void>) {
 
   return (
     // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
-    <StyledMenu ref={node as any}>
+    <StyledMenu ref={node as any} className={props?.className}>
       <StyledMenuButton onClick={toggle}>
         <StyledMenuIcon />
       </StyledMenuButton>
 
-      {open && (
-        <MenuFlyout>
-          {props?.children}
-          {/* <MenuItem id="link" href="https://uniswap.org/">
+      {open &&
+        /*
+        <MenuFlyout>          
+          <MenuItem id="link" href="https://uniswap.org/">
             <Info size={14} />
             About
           </MenuItem>
@@ -144,9 +145,10 @@ export default function Menu(props?: PropsWithChildren<void>) {
             <ButtonPrimary onClick={openClaimModal} padding="8px 16px" width="100%" borderRadius="12px" mt="0.5rem">
               Claim UNI
             </ButtonPrimary>
-          )} */}
+          )}
         </MenuFlyout>
-      )}
+        */
+        props?.children}
     </StyledMenu>
   )
 }

--- a/src/custom/components/Menu/MenuMod.tsx
+++ b/src/custom/components/Menu/MenuMod.tsx
@@ -8,7 +8,7 @@ import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useToggleModal } from 'state/application/hooks'
 
 import { ExternalLink, StyledInternalLink } from 'theme'
-import { WithClassName } from '@src/custom/types'
+import { WithClassName } from 'types'
 // import { ButtonPrimary } from 'Button'
 
 const StyledMenuIcon = styled(MenuIcon)`

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -3,6 +3,7 @@ import { Code, MessageCircle } from 'react-feather'
 
 import MenuMod, { MenuItem, InternalMenuItem, MenuFlyout as MenuFlyoutUni } from './MenuMod'
 import styled from 'styled-components'
+import { Separator as SeparatorBase } from 'components/swap/styleds'
 
 const CODE_LINK = 'https://github.com/gnosis/gp-swap-ui'
 const DISCORD_LINK = 'https://discord.gg/egGzDDctuC'
@@ -20,6 +21,12 @@ const Policy = styled(InternalMenuItem)`
 
 const MenuFlyout = styled(MenuFlyoutUni)`
   min-width: 11rem;
+`
+
+const Separator = styled(SeparatorBase)`
+  background-color: #0000002e;
+  margin: 0.3rem auto;
+  width: 90%;
 `
 
 export function Menu() {
@@ -40,9 +47,7 @@ export function Menu() {
           Discord
         </MenuItem>
 
-        <span>
-          <hr />
-        </span>
+        <Separator />
 
         <Policy to="/terms-and-conditions">Terms and conditions</Policy>
         <Policy to="/privacy-policy">Privacy policy</Policy>

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -4,7 +4,7 @@ import { Code, MessageCircle } from 'react-feather'
 import MenuMod, { MenuItem, InternalMenuItem, MenuFlyout as MenuFlyoutUni } from './MenuMod'
 import styled from 'styled-components'
 
-const CODE_LINK = 'https://github.com/gnosis/dex-swap'
+const CODE_LINK = 'https://github.com/gnosis/gp-swap-ui'
 const DISCORD_LINK = 'https://discord.gg/egGzDDctuC'
 
 export const StyledMenu = styled(MenuMod)`

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -1,35 +1,53 @@
 import React from 'react'
-import { Code, MessageCircle, IconProps } from 'react-feather'
+import { Code, MessageCircle } from 'react-feather'
 
-import MenuMod, { MenuItem, InternalMenuItem } from './MenuMod'
+import MenuMod, { MenuItem, InternalMenuItem, MenuFlyout as MenuFlyoutUni } from './MenuMod'
 import styled from 'styled-components'
-import { FOOTER_URLS } from '../Footer'
 
 const CODE_LINK = 'https://github.com/gnosis/dex-swap'
-const DISCORD_LINK = 'https://chat.gnosis.io'
+const DISCORD_LINK = 'https://discord.gg/egGzDDctuC'
 
-export const StyledMenu = styled(MenuMod)``
+export const StyledMenu = styled(MenuMod)`
+  hr {
+    margin: 15px 0;
+  }
+`
 
-// remove static gnosis text and leave urls
-const CONTENT_URLS = FOOTER_URLS.slice(1) as { name: string; url: string; Icon?: React.FC<IconProps> }[]
+const Policy = styled(InternalMenuItem)`
+  font-size: 0.8em;
+  text-decoration: underline;
+`
+
+const MenuFlyout = styled(MenuFlyoutUni)`
+  min-width: 11rem;
+`
 
 export function Menu() {
   return (
     <StyledMenu>
-      <MenuItem id="link" href={CODE_LINK}>
-        <Code size={14} />
-        Code
-      </MenuItem>
-      <MenuItem id="link" href={DISCORD_LINK}>
-        <MessageCircle size={14} />
-        Discord
-      </MenuItem>
-      {CONTENT_URLS.map(({ name, url, Icon }, index) => (
-        <InternalMenuItem key={url + '_' + index} to={url}>
-          {Icon && <Icon size={14} />}
-          {name}
+      <MenuFlyout>
+        <InternalMenuItem to="/faq">
+          <Code size={14} />
+          FAQ
         </InternalMenuItem>
-      ))}
+
+        <MenuItem id="link" href={CODE_LINK}>
+          <Code size={14} />
+          Code
+        </MenuItem>
+        <MenuItem id="link" href={DISCORD_LINK}>
+          <MessageCircle size={14} />
+          Discord
+        </MenuItem>
+
+        <span>
+          <hr />
+        </span>
+
+        <Policy to="/terms-and-conditions">Terms and conditions</Policy>
+        <Policy to="/privacy-policy">Privacy policy</Policy>
+        <Policy to="/cookie-policy">Cookie policy</Policy>
+      </MenuFlyout>
     </StyledMenu>
   )
 }


### PR DESCRIPTION
Proposal on top of #425 

* It tries to highlight more the main secctions by removing some protagonism from the policies. 
* Also adds the FAQ link, although we still don't have a page yet. But we will.
* About will not be required as a link, since it's a link in the main header menu
* Corrects the link to the chat

It adds a few overrides to the default styles. For that we need to add the prop className so the style-component can be overrided. 


Before:
![image](https://user-images.githubusercontent.com/2352112/114722391-0efc1e80-9d3a-11eb-9a16-be5b705124e0.png)

After:
![image](https://user-images.githubusercontent.com/2352112/114722462-1e7b6780-9d3a-11eb-9f16-2c4c7bcff182.png)

