### PR TITLE
Add multi-network support

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
+# App Id, get yours at https://discord.gg/egGzDDctuC
+REACT_APP_ID="0"
+
 # Nodes
 REACT_APP_CHAIN_ID="1"
 REACT_APP_SUPPORTED_CHAIN_IDS="1,4,100"
@@ -7,6 +10,3 @@ REACT_APP_NETWORK_URL_100=https://rpc.xdaichain.com
 
 # Wallet Connect
 REACT_APP_WALLETCONNECT_BRIDGE_URL="wss://safe-walletconnect.gnosis.io/"
-
-# Override with your APP_ID
-REACT_APP_ID="0"

--- a/.env
+++ b/.env
@@ -1,5 +1,11 @@
+# Nodes
 REACT_APP_CHAIN_ID="1"
-REACT_APP_NETWORK_URL="https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6"
+REACT_APP_SUPPORTED_CHAIN_IDS="1,4,100"
+REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6
+REACT_APP_NETWORK_URL_4=https://rinkeby.infura.io/v3/1221fd11e90849509afafd330ec7acc6
+REACT_APP_NETWORK_URL_100=https://rpc.xdaichain.com
+
+# Wallet Connect
 REACT_APP_WALLETCONNECT_BRIDGE_URL="wss://safe-walletconnect.gnosis.io/"
 
 # Override with your APP_ID

--- a/.env.production
+++ b/.env.production
@@ -1,9 +1,12 @@
-# App Id, get yours in https://discord.gg/egGzDDctuC
+# App Id, get yours at https://discord.gg/egGzDDctuC
 REACT_APP_ID=1
 
 # Node
 REACT_APP_CHAIN_ID="1"
-REACT_APP_NETWORK_URL="https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6"
+REACT_APP_SUPPORTED_CHAIN_IDS="1,4,100"
+REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6
+REACT_APP_NETWORK_URL_4=https://rinkeby.infura.io/v3/1221fd11e90849509afafd330ec7acc6
+REACT_APP_NETWORK_URL_100=https://rpc.xdaichain.com
 
 # Wallets
 REACT_APP_PORTIS_ID="c591a488-8b86-41e1-8d2e-f4b169efd3aa"

--- a/.github/uniswap-original/workflows/tests.yaml
+++ b/.github/uniswap-original/workflows/tests.yaml
@@ -35,9 +35,7 @@ jobs:
       - run: yarn build
         env:
           CI: false
-          REACT_APP_SUPPORTED_CHAIN_IDS="1,4"
-          REACT_APP_NETWORK_URL_1: 'https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6'
-          REACT_APP_NETWORK_URL_4: 'https://rinkeby.infura.io/v3/1221fd11e90849509afafd330ec7acc6'
+          REACT_APP_NETWORK_URL: 'https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6'
       - run: yarn integration-test
 
   unit-tests:

--- a/.github/uniswap-original/workflows/tests.yaml
+++ b/.github/uniswap-original/workflows/tests.yaml
@@ -35,7 +35,9 @@ jobs:
       - run: yarn build
         env:
           CI: false
-          REACT_APP_NETWORK_URL: 'https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6'
+          REACT_APP_SUPPORTED_CHAIN_IDS="1,4"
+          REACT_APP_NETWORK_URL_1: 'https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6'
+          REACT_APP_NETWORK_URL_4: 'https://rinkeby.infura.io/v3/1221fd11e90849509afafd330ec7acc6'
       - run: yarn integration-test
 
   unit-tests:

--- a/README.md
+++ b/README.md
@@ -68,9 +68,15 @@ yarn cypress
 To have the interface default to a different network when a wallet is not connected:
 
 1. Make a copy of `.env` named `.env.local`
-2. Change `REACT_APP_NETWORK_ID` to `"{YOUR_NETWORK_ID}"`
-3. Change `REACT_APP_NETWORK_URL` to e.g. `"https://{YOUR_NETWORK_ID}.infura.io/v3/{YOUR_INFURA_KEY}"`
-4. Change `REACT_APP_ID` Ask for your id in [chat.gnosis.io](https://chat.gnosis.io)
+2. Change `REACT_APP_NETWORK_ID` to `"{YOUR_NETWORK_ID}"`. This will be your default network id
+3. Define your own list of supported networks:
+```ini
+REACT_APP_SUPPORTED_CHAIN_IDS="1,4,100"
+REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/{YOUR_INFURA_KEY}
+REACT_APP_NETWORK_URL_4=https://rinkeby.infura.io/v3/{YOUR_INFURA_KEY}
+REACT_APP_NETWORK_URL_100=https://rpc.xdaichain.com
+``` 
+4. Change `REACT_APP_ID` Ask for your id at [chat.gnosis.io](https://chat.gnosis.io)
 5. Change `REACT_APP_API_BASE_URL_{XDAI|RINKEBY|MAINNET}` to e.g. `"http://localhost:8080/api/v1"` when running the services locally.
 
 For production:

--- a/src/custom/connectors/index.ts
+++ b/src/custom/connectors/index.ts
@@ -98,7 +98,6 @@ export const portis = new PortisConnector({
 // mainnet only
 export const walletlink = new WalletLinkConnector({
   url: rpcNetworks[NETWORK_CHAIN_ID],
-  appName: 'Uniswap',
-  appLogoUrl:
-    'https://mpng.pngfly.com/20181202/bex/kisspng-emoji-domain-unicorn-pin-badges-sticker-unicorn-tumblr-emoji-unicorn-iphoneemoji-5c046729264a77.5671679315437924251569.jpg'
+  appName: 'Cow Swap',
+  appLogoUrl: 'https://raw.githubusercontent.com/gnosis/gp-swap-ui/develop/public/images/logo-square-512.png'
 })

--- a/src/custom/connectors/index.ts
+++ b/src/custom/connectors/index.ts
@@ -1,16 +1,110 @@
-import { ChainId } from '@uniswap/sdk'
+import { Web3Provider } from '@ethersproject/providers'
 import { InjectedConnector } from '@web3-react/injected-connector'
+import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
+import { WalletLinkConnector } from '@web3-react/walletlink-connector'
+import { PortisConnector } from '@web3-react/portis-connector'
 
-export {
-  NETWORK_CHAIN_ID,
-  fortmatic,
-  portis,
-  network,
-  walletconnect,
-  walletlink,
-  getNetworkLibrary
-} from '@src/connectors'
+import { FortmaticConnector } from 'connectors/Fortmatic'
+import { NetworkConnector } from 'connectors/NetworkConnector'
 
-export const injected = new InjectedConnector({
-  supportedChainIds: [ChainId.MAINNET, ChainId.ROPSTEN, ChainId.RINKEBY, ChainId.GÖRLI, ChainId.KOVAN, ChainId.XDAI]
+const SUPPORTED_CHAIN_IDS = process.env.REACT_APP_SUPPORTED_CHAIN_IDS
+const DEFAULT_CHAIN_ID = Number(process.env.REACT_APP_CHAIN_ID || '1')
+
+const FORMATIC_KEY = process.env.REACT_APP_FORTMATIC_KEY
+const PORTIS_ID = process.env.REACT_APP_PORTIS_ID
+
+export const NETWORK_CHAIN_ID: number = parseInt(process.env.REACT_APP_CHAIN_ID ?? '1')
+
+type RpcNetworks = { [chainId: number]: string }
+
+function getRpcNetworks(): [RpcNetworks, number[]] {
+  // Make sure the mandatory envs are present
+  if (typeof SUPPORTED_CHAIN_IDS === 'undefined') {
+    throw new Error(`REACT_APP_NETWORK_URL must be a defined environment variable`)
+  }
+
+  // Get list of supported chains
+  const chainIds = SUPPORTED_CHAIN_IDS.split(',').map(chainId => Number(chainId.trim()))
+  if (chainIds.length === 0) {
+    throw new Error(`At least one network should be supported. REACT_APP_CHAIN_ID`)
+  }
+
+  // Make sure the default chain is in the list of supported chains
+  if (!chainIds.includes(DEFAULT_CHAIN_ID)) {
+    throw new Error(
+      `The default chain id (${DEFAULT_CHAIN_ID}) must be part of the list of supported networks: ${chainIds.join(
+        ', '
+      )}`
+    )
+  }
+
+  // Return rpc urls per network
+  const rpcNetworks = chainIds.reduce<RpcNetworks>((acc, chainId) => {
+    const url = process.env['REACT_APP_NETWORK_URL_' + chainId]
+
+    if (typeof url === 'undefined') {
+      throw new Error(
+        `Network ${chainId} is supported, however 'REACT_APP_NETWORK_URL_${chainId} environment variable was not defined`
+      )
+    }
+
+    acc[chainId] = url
+
+    return acc
+  }, {})
+
+  // Get chainIds (excluding the DEFAULT_CHAIN_ID)
+  // Reason: By convention we will return DEFAULT_CHAIN_ID as the first element in the supported networks
+  const otherChainIds = Object.keys(rpcNetworks)
+    .map(Number)
+    .filter(networkId => networkId !== DEFAULT_CHAIN_ID)
+  const supportedChainIds = [DEFAULT_CHAIN_ID, ...otherChainIds]
+
+  return [rpcNetworks, supportedChainIds]
+}
+
+const [rpcNetworks, supportedChainIds] = getRpcNetworks()
+
+export const network = new NetworkConnector({
+  urls: rpcNetworks,
+  defaultChainId: NETWORK_CHAIN_ID
+})
+
+let networkLibrary: Web3Provider | undefined
+export function getNetworkLibrary(): Web3Provider {
+  return (networkLibrary = networkLibrary ?? new Web3Provider(network.provider as any))
+}
+
+export const injected = new InjectedConnector({ supportedChainIds })
+
+// mainnet only
+export const walletconnect = new WalletConnectConnector({
+  // TODO: Use any network when this PR is merged https://github.com/NoahZinsmeister/web3-react/pull/185
+  // rpc: rpcNetworks,
+  rpc: { 1: rpcNetworks[DEFAULT_CHAIN_ID] },
+  bridge: 'https://bridge.walletconnect.org',
+  qrcode: true,
+  pollingInterval: 15000
+})
+
+// mainnet only
+export const fortmatic = new FortmaticConnector({
+  apiKey: FORMATIC_KEY ?? '',
+  chainId: DEFAULT_CHAIN_ID
+})
+
+// mainnet only
+export const portis = new PortisConnector({
+  dAppId: PORTIS_ID ?? '',
+  // TODO: Allow to configure multiple networks in portis
+  // networks: supportedChainIds
+  networks: [DEFAULT_CHAIN_ID]
+})
+
+// mainnet only
+export const walletlink = new WalletLinkConnector({
+  url: rpcNetworks[DEFAULT_CHAIN_ID],
+  appName: 'Uniswap',
+  appLogoUrl:
+    'https://mpng.pngfly.com/20181202/bex/kisspng-emoji-domain-unicorn-pin-badges-sticker-unicorn-tumblr-emoji-unicorn-iphoneemoji-5c046729264a77.5671679315437924251569.jpg'
 })

--- a/src/custom/connectors/index.ts
+++ b/src/custom/connectors/index.ts
@@ -14,7 +14,7 @@ function getRpcNetworks(): [RpcNetworks, number[]] {
   const defaultChainId = parseInt(process.env.REACT_APP_CHAIN_ID ?? '1')
 
   // Make sure the mandatory envs are present
-  if (typeof supportedChainIdsEnv === 'undefined') {
+  if (!supportedChainIdsEnv) {
     throw new Error(`REACT_APP_NETWORK_URL must be a defined environment variable`)
   }
 
@@ -35,7 +35,7 @@ function getRpcNetworks(): [RpcNetworks, number[]] {
   const rpcNetworks = chainIds.reduce<RpcNetworks>((acc, chainId) => {
     const url = process.env['REACT_APP_NETWORK_URL_' + chainId]
 
-    if (typeof url === 'undefined') {
+    if (!url) {
       throw new Error(
         `Network ${chainId} is supported, however 'REACT_APP_NETWORK_URL_${chainId} environment variable was not defined`
       )

--- a/src/custom/connectors/index.ts
+++ b/src/custom/connectors/index.ts
@@ -7,32 +7,27 @@ import { PortisConnector } from '@web3-react/portis-connector'
 import { FortmaticConnector } from 'connectors/Fortmatic'
 import { NetworkConnector } from 'connectors/NetworkConnector'
 
-const SUPPORTED_CHAIN_IDS = process.env.REACT_APP_SUPPORTED_CHAIN_IDS
-export const NETWORK_CHAIN_ID = parseInt(process.env.REACT_APP_CHAIN_ID ?? '1')
-
-const FORMATIC_KEY = process.env.REACT_APP_FORTMATIC_KEY
-const PORTIS_ID = process.env.REACT_APP_PORTIS_ID
-
 type RpcNetworks = { [chainId: number]: string }
 
 function getRpcNetworks(): [RpcNetworks, number[]] {
+  const supportedChainIdsEnv = process.env.REACT_APP_SUPPORTED_CHAIN_IDS
+  const defaultChainId = parseInt(process.env.REACT_APP_CHAIN_ID ?? '1')
+
   // Make sure the mandatory envs are present
-  if (typeof SUPPORTED_CHAIN_IDS === 'undefined') {
+  if (typeof supportedChainIdsEnv === 'undefined') {
     throw new Error(`REACT_APP_NETWORK_URL must be a defined environment variable`)
   }
 
   // Get list of supported chains
-  const chainIds = SUPPORTED_CHAIN_IDS.split(',').map(chainId => Number(chainId.trim()))
+  const chainIds = supportedChainIdsEnv.split(',').map(chainId => Number(chainId.trim()))
   if (chainIds.length === 0) {
     throw new Error(`At least one network should be supported. REACT_APP_CHAIN_ID`)
   }
 
   // Make sure the default chain is in the list of supported chains
-  if (!chainIds.includes(NETWORK_CHAIN_ID)) {
+  if (!chainIds.includes(defaultChainId)) {
     throw new Error(
-      `The default chain id (${NETWORK_CHAIN_ID}) must be part of the list of supported networks: ${chainIds.join(
-        ', '
-      )}`
+      `The default chain id (${defaultChainId}) must be part of the list of supported networks: ${chainIds.join(', ')}`
     )
   }
 
@@ -55,13 +50,14 @@ function getRpcNetworks(): [RpcNetworks, number[]] {
   // Reason: By convention we will return NETWORK_CHAIN_ID as the first element in the supported networks
   const otherChainIds = Object.keys(rpcNetworks)
     .map(Number)
-    .filter(networkId => networkId !== NETWORK_CHAIN_ID)
-  const supportedChainIds = [NETWORK_CHAIN_ID, ...otherChainIds]
+    .filter(networkId => networkId !== defaultChainId)
+  const supportedChainIds = [defaultChainId, ...otherChainIds]
 
   return [rpcNetworks, supportedChainIds]
 }
 
 const [rpcNetworks, supportedChainIds] = getRpcNetworks()
+export const NETWORK_CHAIN_ID = supportedChainIds[0]
 
 export const network = new NetworkConnector({
   urls: rpcNetworks,
@@ -87,13 +83,13 @@ export const walletconnect = new WalletConnectConnector({
 
 // mainnet only
 export const fortmatic = new FortmaticConnector({
-  apiKey: FORMATIC_KEY ?? '',
+  apiKey: process.env.REACT_APP_FORTMATIC_KEY ?? '',
   chainId: NETWORK_CHAIN_ID
 })
 
 // mainnet only
 export const portis = new PortisConnector({
-  dAppId: PORTIS_ID ?? '',
+  dAppId: process.env.REACT_APP_PORTIS_ID ?? '',
   // TODO: Allow to configure multiple networks in portis
   // networks: supportedChainIds
   networks: [NETWORK_CHAIN_ID]

--- a/src/custom/connectors/index.ts
+++ b/src/custom/connectors/index.ts
@@ -8,12 +8,10 @@ import { FortmaticConnector } from 'connectors/Fortmatic'
 import { NetworkConnector } from 'connectors/NetworkConnector'
 
 const SUPPORTED_CHAIN_IDS = process.env.REACT_APP_SUPPORTED_CHAIN_IDS
-const DEFAULT_CHAIN_ID = Number(process.env.REACT_APP_CHAIN_ID || '1')
+export const NETWORK_CHAIN_ID = parseInt(process.env.REACT_APP_CHAIN_ID ?? '1')
 
 const FORMATIC_KEY = process.env.REACT_APP_FORTMATIC_KEY
 const PORTIS_ID = process.env.REACT_APP_PORTIS_ID
-
-export const NETWORK_CHAIN_ID: number = parseInt(process.env.REACT_APP_CHAIN_ID ?? '1')
 
 type RpcNetworks = { [chainId: number]: string }
 
@@ -30,9 +28,9 @@ function getRpcNetworks(): [RpcNetworks, number[]] {
   }
 
   // Make sure the default chain is in the list of supported chains
-  if (!chainIds.includes(DEFAULT_CHAIN_ID)) {
+  if (!chainIds.includes(NETWORK_CHAIN_ID)) {
     throw new Error(
-      `The default chain id (${DEFAULT_CHAIN_ID}) must be part of the list of supported networks: ${chainIds.join(
+      `The default chain id (${NETWORK_CHAIN_ID}) must be part of the list of supported networks: ${chainIds.join(
         ', '
       )}`
     )
@@ -53,12 +51,12 @@ function getRpcNetworks(): [RpcNetworks, number[]] {
     return acc
   }, {})
 
-  // Get chainIds (excluding the DEFAULT_CHAIN_ID)
-  // Reason: By convention we will return DEFAULT_CHAIN_ID as the first element in the supported networks
+  // Get chainIds (excluding the NETWORK_CHAIN_ID)
+  // Reason: By convention we will return NETWORK_CHAIN_ID as the first element in the supported networks
   const otherChainIds = Object.keys(rpcNetworks)
     .map(Number)
-    .filter(networkId => networkId !== DEFAULT_CHAIN_ID)
-  const supportedChainIds = [DEFAULT_CHAIN_ID, ...otherChainIds]
+    .filter(networkId => networkId !== NETWORK_CHAIN_ID)
+  const supportedChainIds = [NETWORK_CHAIN_ID, ...otherChainIds]
 
   return [rpcNetworks, supportedChainIds]
 }
@@ -81,7 +79,7 @@ export const injected = new InjectedConnector({ supportedChainIds })
 export const walletconnect = new WalletConnectConnector({
   // TODO: Use any network when this PR is merged https://github.com/NoahZinsmeister/web3-react/pull/185
   // rpc: rpcNetworks,
-  rpc: { 1: rpcNetworks[DEFAULT_CHAIN_ID] },
+  rpc: { 1: rpcNetworks[NETWORK_CHAIN_ID] },
   bridge: 'https://bridge.walletconnect.org',
   qrcode: true,
   pollingInterval: 15000
@@ -90,7 +88,7 @@ export const walletconnect = new WalletConnectConnector({
 // mainnet only
 export const fortmatic = new FortmaticConnector({
   apiKey: FORMATIC_KEY ?? '',
-  chainId: DEFAULT_CHAIN_ID
+  chainId: NETWORK_CHAIN_ID
 })
 
 // mainnet only
@@ -98,12 +96,12 @@ export const portis = new PortisConnector({
   dAppId: PORTIS_ID ?? '',
   // TODO: Allow to configure multiple networks in portis
   // networks: supportedChainIds
-  networks: [DEFAULT_CHAIN_ID]
+  networks: [NETWORK_CHAIN_ID]
 })
 
 // mainnet only
 export const walletlink = new WalletLinkConnector({
-  url: rpcNetworks[DEFAULT_CHAIN_ID],
+  url: rpcNetworks[NETWORK_CHAIN_ID],
   appName: 'Uniswap',
   appLogoUrl:
     'https://mpng.pngfly.com/20181202/bex/kisspng-emoji-domain-unicorn-pin-badges-sticker-unicorn-tumblr-emoji-unicorn-iphoneemoji-5c046729264a77.5671679315437924251569.jpg'


### PR DESCRIPTION
This PR should be backwards compatible and allows us to configure a list of RPC nodes for the different networks instead of the hardcoded mainnet one.

This is the first step for solving the issue with wallet connect (and the other wallets). In uniswap they don't work in Rinkeby, and way less they don't work in xDAI.

The second step will be a PR that uses this solution https://github.com/NoahZinsmeister/web3-react/pull/185 
I left a TODO for this. 

## Test
Play around with the new config params, and see if it make sense how the app is bootstrapped 