### PR TITLE
Advance button - Settings - superseded

### DIFF
--- a/src/custom/components/Settings/SettingsMod.tsx
+++ b/src/custom/components/Settings/SettingsMod.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useRef, useState } from 'react'
-// import { Settings, X } from 'react-feather'
-import { X } from 'react-feather'
+import { Settings, X } from 'react-feather'
 import { Text } from 'rebass'
 import styled, { ThemeContext } from 'styled-components'
 import { useOnClickOutside } from 'hooks/useOnClickOutside'
@@ -20,21 +19,22 @@ import QuestionHelper from 'components/QuestionHelper'
 import { RowBetween, RowFixed } from 'components/Row'
 import Toggle from 'components/Toggle'
 import TransactionSettings from 'components/TransactionSettings'
+import { SettingsTabProp } from '.'
 
-// const StyledMenuIcon = styled(Settings)`
-//   height: 20px;
-//   width: 20px;
+export const StyledMenuIcon = styled(Settings)`
+  height: 20px;
+  width: 20px;
 
-//   > * {
-//     stroke: ${({ theme }) => theme.text2};
-//   }
+  > * {
+    stroke: ${({ theme }) => theme.text2};
+  }
 
-//   :hover {
-//     opacity: 0.7;
-//   }
-// `
+  :hover {
+    opacity: 0.7;
+  }
+`
 
-export const StyledCloseIcon = styled(X)`
+const StyledCloseIcon = styled(X)`
   height: 20px;
   width: 20px;
   :hover {
@@ -46,7 +46,7 @@ export const StyledCloseIcon = styled(X)`
   }
 `
 
-const StyledMenuButton = styled.button`
+export const StyledMenuButton = styled.button`
   position: relative;
   width: 100%;
   height: 100%;
@@ -69,15 +69,14 @@ const StyledMenuButton = styled.button`
     margin-top: 2px;
   }
 `
+export const EmojiWrapper = styled.div`
+  position: absolute;
+  bottom: -6px;
+  right: 0px;
+  font-size: 14px;
+`
 
-// const EmojiWrapper = styled.div`
-//   position: absolute;
-//   bottom: -6px;
-//   right: 0px;
-//   font-size: 14px;
-// `
-
-export const StyledMenu = styled.div`
+const StyledMenu = styled.div`
   margin-left: 0.5rem;
   display: flex;
   justify-content: center;
@@ -87,7 +86,7 @@ export const StyledMenu = styled.div`
   text-align: left;
 `
 
-export const MenuFlyout = styled.span`
+const MenuFlyout = styled.span`
   min-width: 20.125rem;
   background-color: ${({ theme }) => theme.bg2};
   box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.01), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
@@ -106,13 +105,13 @@ export const MenuFlyout = styled.span`
   `};
 `
 
-export const Break = styled.div`
+const Break = styled.div`
   width: 100%;
   height: 1px;
   background-color: ${({ theme }) => theme.bg3};
 `
 
-export const ModalContentWrapper = styled.div`
+const ModalContentWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -121,7 +120,7 @@ export const ModalContentWrapper = styled.div`
   border-radius: 20px;
 `
 
-export default function SettingsTab() {
+export default function SettingsTab({ className, SettingsButton }: SettingsTabProp) {
   const node = useRef<HTMLDivElement>()
   const open = useModalOpen(ApplicationModal.SETTINGS)
   const toggle = useToggleSettingsMenu()
@@ -142,7 +141,7 @@ export default function SettingsTab() {
 
   return (
     // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
-    <StyledMenu ref={node as any}>
+    <StyledMenu ref={node as any} className={className}>
       <Modal isOpen={showConfirmation} onDismiss={() => setShowConfirmation(false)} maxHeight={100}>
         <ModalContentWrapper>
           <AutoColumn gap="lg">
@@ -180,16 +179,19 @@ export default function SettingsTab() {
           </AutoColumn>
         </ModalContentWrapper>
       </Modal>
+      <SettingsButton expertMode={expertMode} toggleSettings={toggle} />
+      {/* 
       <StyledMenuButton onClick={toggle} id="open-settings-dialog-button">
-        {/* <StyledMenuIcon /> */}
-        {/* {expertMode ? (
+        <StyledMenuIcon />
+        {expertMode ? (
           <EmojiWrapper>
             <span role="img" aria-label="wizard-icon">
-              🧙
+              🐮
             </span>
           </EmojiWrapper>
-        ) : null} */}
-      </StyledMenuButton>
+        ) : null}
+      </StyledMenuButton> 
+      */}
       {open && (
         <MenuFlyout>
           <AutoColumn gap="md" style={{ padding: '1rem' }}>

--- a/src/custom/components/Settings/index.tsx
+++ b/src/custom/components/Settings/index.tsx
@@ -114,7 +114,7 @@ function SettingsButton({ toggleSettings, expertMode }: SettingsButtonProps) {
       <StyledMenuIcon />
       {expertMode ? (
         <EmojiWrapper>
-          <span>🥋</span>
+          <span role="img">🥋</span>
         </EmojiWrapper>
       ) : null}
     </StyledMenuButton>

--- a/src/custom/components/Settings/index.tsx
+++ b/src/custom/components/Settings/index.tsx
@@ -1,197 +1,70 @@
-import React, { useContext, useRef, useState } from 'react'
-import { Settings } from 'react-feather'
-import { Text } from 'rebass'
-import styled, { ThemeContext } from 'styled-components'
-import { useOnClickOutside } from 'hooks/useOnClickOutside'
-import { ApplicationModal } from 'state/application/actions'
-import { useModalOpen, useToggleSettingsMenu } from 'state/application/hooks'
-import {
-  useExpertModeManager,
-  useUserTransactionTTL,
-  useUserSlippageTolerance,
-  useUserSingleHopOnly
-} from 'state/user/hooks'
-import { TYPE } from 'theme'
-import { ButtonError } from 'components/Button'
-import { AutoColumn } from 'components/Column'
-import Modal from 'components/Modal'
-import QuestionHelper from 'components/QuestionHelper'
-import { RowBetween, RowFixed } from 'components/Row'
-import Toggle from 'components/Toggle'
-import TransactionSettings from 'components/TransactionSettings'
-import { StyledCloseIcon, StyledMenu, MenuFlyout, Break, ModalContentWrapper } from './SettingsMod'
+import { WithClassName } from '@src/custom/types'
+import React from 'react'
+import styled from 'styled-components'
 
-const StyledMenuIcon = styled(Settings)`
-  height: 20px;
-  width: 20px;
+import SettingsMod, { StyledMenuButton, StyledMenuIcon, EmojiWrapper } from './SettingsMod'
 
-  > * {
-    stroke: ${({ theme }) => theme.text2};
+const Wrapper = styled(SettingsMod)`
+  color: red;
+
+  b {
+    margin: 0px 5px 0px 0px;
+  }
+
+  ${EmojiWrapper} {
+    position: absolute;
+    /* width: 50px; */
+    flex-direction: row;
+    top: 0px;
+    right: 100px;
+
+    span:first-child {
+      font-size: 30px;
+      z-index: 100;
+      /* display: block; */
+      position: absolute;
+      top: -11px;
+      right: -3px;
+    }
+
+    span:last-child {
+      font-size: 25px;
+      /* display: block; */
+      position: absolute;
+      bottom: 0;
+      right: 0;
+    }
   }
 `
 
-const EmojiWrapper = styled.div`
-  position: absolute;
-  bottom: -9px;
-  right: -2px;
-  font-size: 21px;
-`
+export interface SettingsButtonProps {
+  toggleSettings: () => void
+  expertMode: boolean
+}
 
-const StyledMenuButton = styled.button`
-  position: relative;
-  width: 100%;
-  height: 100%;
-  border: none;
-  background-color: transparent;
-  margin: 0;
-  padding: 0;
-  height: 35px;
-  display: flex;
-  align-items: center;
-  padding: 0.15rem 0.5rem;
-  border-radius: 0.5rem;
-  transition: opacity 0.2s ease-in-out;
+export interface SettingsTabProp extends WithClassName {
+  SettingsButton: React.FC<SettingsButtonProps>
+}
 
-  &:hover,
-  &:focus {
-    cursor: pointer;
-    outline: none;
-    opacity: 0.7;
-  }
-
-  > b {
-    margin: 0 5px 0 0;
-  }
-
-  svg {
-    margin-top: 2px;
-  }
-`
+function SettingsButton({ toggleSettings, expertMode }: SettingsButtonProps) {
+  return (
+    <StyledMenuButton onClick={toggleSettings} id="open-settings-dialog-button">
+      <b>Settings</b>
+      <StyledMenuIcon />
+      {expertMode ? (
+        <EmojiWrapper>
+          <span role="img" aria-label="cow-icon">
+            🐮
+          </span>
+          <span role="img" aria-label="kimono-icon">
+            🥋
+          </span>
+        </EmojiWrapper>
+      ) : null}
+    </StyledMenuButton>
+  )
+}
 
 export default function SettingsTab() {
-  const node = useRef<HTMLDivElement>()
-  const open = useModalOpen(ApplicationModal.SETTINGS)
-  const toggle = useToggleSettingsMenu()
-
-  const theme = useContext(ThemeContext)
-  const [userSlippageTolerance, setUserslippageTolerance] = useUserSlippageTolerance()
-
-  const [ttl, setTtl] = useUserTransactionTTL()
-
-  const [expertMode, toggleExpertMode] = useExpertModeManager()
-
-  const [singleHopOnly, setSingleHopOnly] = useUserSingleHopOnly()
-
-  // show confirmation view before turning on
-  const [showConfirmation, setShowConfirmation] = useState(false)
-
-  useOnClickOutside(node, open ? toggle : undefined)
-
-  return (
-    // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
-    <StyledMenu ref={node as any}>
-      <Modal isOpen={showConfirmation} onDismiss={() => setShowConfirmation(false)} maxHeight={100}>
-        <ModalContentWrapper>
-          <AutoColumn gap="lg">
-            <RowBetween style={{ padding: '0 2rem' }}>
-              <div />
-              <Text fontWeight={500} fontSize={20}>
-                Are you sure?
-              </Text>
-              <StyledCloseIcon onClick={() => setShowConfirmation(false)} />
-            </RowBetween>
-            <Break />
-            <AutoColumn gap="lg" style={{ padding: '0 2rem' }}>
-              <Text fontWeight={500} fontSize={20}>
-                Expert mode turns off the confirm transaction prompt and allows high slippage trades that often result
-                in bad rates and lost funds.
-              </Text>
-              <Text fontWeight={600} fontSize={20}>
-                ONLY USE THIS MODE IF YOU KNOW WHAT YOU ARE DOING.
-              </Text>
-              <ButtonError
-                error={true}
-                padding={'12px'}
-                onClick={() => {
-                  if (window.prompt(`Please type the word "confirm" to enable expert mode.`) === 'confirm') {
-                    toggleExpertMode()
-                    setShowConfirmation(false)
-                  }
-                }}
-              >
-                <Text fontSize={20} fontWeight={500} id="confirm-expert-mode">
-                  Turn On Expert Mode
-                </Text>
-              </ButtonError>
-            </AutoColumn>
-          </AutoColumn>
-        </ModalContentWrapper>
-      </Modal>
-      <StyledMenuButton onClick={toggle} id="open-settings-dialog-button">
-        <b>Settings</b>
-        <StyledMenuIcon />
-        {expertMode ? (
-          <EmojiWrapper>
-            <span role="img" aria-label="wizard-icon">
-              🐮
-            </span>
-          </EmojiWrapper>
-        ) : null}
-      </StyledMenuButton>
-      {open && (
-        <MenuFlyout>
-          <AutoColumn gap="md" style={{ padding: '1rem' }}>
-            <Text fontWeight={600} fontSize={14}>
-              Transaction Settings
-            </Text>
-            <TransactionSettings
-              rawSlippage={userSlippageTolerance}
-              setRawSlippage={setUserslippageTolerance}
-              deadline={ttl}
-              setDeadline={setTtl}
-            />
-            <Text fontWeight={600} fontSize={14}>
-              Interface Settings
-            </Text>
-            <RowBetween>
-              <RowFixed>
-                <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
-                  Toggle Expert Mode
-                </TYPE.black>
-                <QuestionHelper text="Bypasses confirmation modals and allows high slippage trades. Use at your own risk." />
-              </RowFixed>
-              <Toggle
-                id="toggle-expert-mode-button"
-                isActive={expertMode}
-                toggle={
-                  expertMode
-                    ? () => {
-                        toggleExpertMode()
-                        setShowConfirmation(false)
-                      }
-                    : () => {
-                        toggle()
-                        setShowConfirmation(true)
-                      }
-                }
-              />
-            </RowBetween>
-            <RowBetween>
-              <RowFixed>
-                <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
-                  Disable Multihops
-                </TYPE.black>
-                <QuestionHelper text="Restricts swaps to direct pairs only." />
-              </RowFixed>
-              <Toggle
-                id="toggle-disable-multihop-button"
-                isActive={singleHopOnly}
-                toggle={() => (singleHopOnly ? setSingleHopOnly(false) : setSingleHopOnly(true))}
-              />
-            </RowBetween>
-          </AutoColumn>
-        </MenuFlyout>
-      )}
-    </StyledMenu>
-  )
+  return <Wrapper SettingsButton={SettingsButton} />
 }

--- a/src/custom/components/Settings/index.tsx
+++ b/src/custom/components/Settings/index.tsx
@@ -114,7 +114,9 @@ function SettingsButton({ toggleSettings, expertMode }: SettingsButtonProps) {
       <StyledMenuIcon />
       {expertMode ? (
         <EmojiWrapper>
-          <span role="img">🥋</span>
+          <span role="img" aria-label="Expert Mode Turned On">
+            🥋
+          </span>
         </EmojiWrapper>
       ) : null}
     </StyledMenuButton>

--- a/src/custom/components/Settings/index.tsx
+++ b/src/custom/components/Settings/index.tsx
@@ -5,34 +5,95 @@ import styled from 'styled-components'
 import SettingsMod, { StyledMenuButton, StyledMenuIcon, EmojiWrapper } from './SettingsMod'
 
 const Wrapper = styled(SettingsMod)`
-  color: red;
+  ${StyledMenuButton} {
+    display: flex;
+    align-items: center;
+    position: relative;
+    width: 100%;
+    height: 100%;
+    border: none;
+    background-color: transparent;
+    margin: 0;
+    padding: 0;
+    height: 35px;
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.5rem;
+    transition: opacity 0.2s ease-in-out;
+    opacity: 0.85;
 
-  b {
-    margin: 0px 5px 0px 0px;
+    &:hover,
+    &:focus {
+      cursor: pointer;
+      outline: none;
+      opacity: 1;
+    }
+
+    > b {
+      margin: 0 3px 0 0;
+    }
+
+    svg {
+      opacity: 1;
+      margin: 2px 0 0;
+      transition: transform 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
+    }
+
+    &:hover > svg {
+      transform: rotate(180deg);
+    }
+  }
+
+  ${StyledMenuIcon} {
+    height: 20px;
+    width: 20px;
+    > * {
+      stroke: ${({ theme }) => theme.text2};
+    }
   }
 
   ${EmojiWrapper} {
     position: absolute;
-    /* width: 50px; */
     flex-direction: row;
-    top: 0px;
-    right: 100px;
+    top: 9px;
+    right: -16px;
+    animation: expertModeOn 3s normal forwards ease-in-out;
 
-    span:first-child {
-      font-size: 30px;
-      z-index: 100;
-      /* display: block; */
-      position: absolute;
-      top: -11px;
-      right: -3px;
+    span {
+      font-size: 20px;
+
+      &::after {
+        content: '🐮';
+        font-size: inherit;
+        position: absolute;
+        top: -13px;
+        right: 0;
+        left: 0;
+        margin: 0 auto;
+      }
     }
+  }
 
-    span:last-child {
-      font-size: 25px;
-      /* display: block; */
-      position: absolute;
-      bottom: 0;
-      right: 0;
+  @keyframes expertModeOn {
+    0% {
+      filter: none;
+    }
+    15% {
+      filter: sepia(1);
+    }
+    30% {
+      filter: sepia(0);
+    }
+    45% {
+      filter: sepia(1);
+    }
+    60% {
+      filter: sepia(0);
+    }
+    75% {
+      filter: sepia(1);
+    }
+    100% {
+      filter: sepia(0);
     }
   }
 `
@@ -53,12 +114,7 @@ function SettingsButton({ toggleSettings, expertMode }: SettingsButtonProps) {
       <StyledMenuIcon />
       {expertMode ? (
         <EmojiWrapper>
-          <span role="img" aria-label="cow-icon">
-            🐮
-          </span>
-          <span role="img" aria-label="kimono-icon">
-            🥋
-          </span>
+          <span>🥋</span>
         </EmojiWrapper>
       ) : null}
     </StyledMenuButton>


### PR DESCRIPTION
Supersedes #440. Tries to simplify the mods. 

- Injects the button, that is what it changes
- Overrides the styles (adds a class to the Mod)
- Add a kimono cow 🐮🥋 (you can kill it, it was just a fun thing to do)

![image](https://user-images.githubusercontent.com/2352112/114922315-cfadfa80-9e2b-11eb-9d92-21b8f76b1bed.png)


@biocom I just did it as a reference to help out with the mods. I think this option makes it easy to modify the styles. Note that I didn't style very good the "Settings" label. Also, probably I made a mess with so much absolute positioning.  