### PR TITLE
Add default app-id

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,6 @@
+# App Id, get yours in https://discord.gg/egGzDDctuC
+REACT_APP_ID=1
+
 # Node
 REACT_APP_CHAIN_ID="1"
 REACT_APP_NETWORK_URL="https://mainnet.infura.io/v3/1221fd11e90849509afafd330ec7acc6"

--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ To have the interface default to a different network when a wallet is not connec
 3. Change `REACT_APP_NETWORK_URL` to e.g. `"https://{YOUR_NETWORK_ID}.infura.io/v3/{YOUR_INFURA_KEY}"`
 4. Change `REACT_APP_ID` Ask for your id in [chat.gnosis.io](https://chat.gnosis.io)
 5. Change `REACT_APP_API_BASE_URL_{XDAI|RINKEBY|MAINNET}` to e.g. `"http://localhost:8080/api/v1"` when running the services locally.
+
+For production:
+6. Get your own `App Id` in <https://discord.gg/egGzDDctuC>, and set it in `REACT_APP_ID`.


### PR DESCRIPTION
I stumble upon the reason why we don't have an APP ID. The .env has it to 0, but the .env.prod didn't have it.

## Test
Check the app id when you sign an order