### PR TITLE
Improve domain check

### DIFF
--- a/.env
+++ b/.env
@@ -6,11 +6,11 @@ REACT_APP_ID="0"
 
 # Domain
 # Accept dev as a list of hosts
-REACT_APP_DOMAIN_PREFIX_DEV=cow-trade.dev
-REACT_APP_DOMAIN_PREFIX_STAGING=cow-trade.staging
-REACT_APP_DOMAIN_PREFIX_PROD=cow.trade
+REACT_APP_DOMAIN_REGEX_DEV=".*"
+#REACT_APP_DOMAIN_REGEX_STAGING="---- N/A ----"
+#REACT_APP_DOMAIN_REGEX_PROD="---- N/A ----"
 
 # EXPLORER
-REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com
-REACT_APP_EXPLORER_URL_STAGING=https://protocol-explorer.staging.gnosisdev.com
-REACT_APP_EXPLORER_URL_PROD=https://gnosis-protocol.io
+#REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com
+#REACT_APP_EXPLORER_URL_STAGING=https://protocol-explorer.staging.gnosisdev.com
+#REACT_APP_EXPLORER_URL_PROD=https://gnosis-protocol.io

--- a/.env.production
+++ b/.env.production
@@ -7,7 +7,7 @@ REACT_APP_PORTIS_ID="c591a488-8b86-41e1-8d2e-f4b169efd3aa"
 REACT_APP_FORTMATIC_KEY="pk_live_9846B20CC0CD7C35"
 
 # Domain
-REACT_APP_DOMAIN_REGEX_DEV="^(:?cow-trade\.dev|localhost:\d{2,5}|pr\d+--gpswapui.review)"
+REACT_APP_DOMAIN_REGEX_DEV="^(:?cow-trade\.dev|localhost:\d{2,5}|pr\d+--gpswapui\.review)"
 REACT_APP_DOMAIN_REGEX_STAGING="^cow-trade\.staging"
 REACT_APP_DOMAIN_REGEX_PROD="^(:?cow.trade|cowswap\.exchange)"
 

--- a/.env.production
+++ b/.env.production
@@ -7,9 +7,9 @@ REACT_APP_PORTIS_ID="c591a488-8b86-41e1-8d2e-f4b169efd3aa"
 REACT_APP_FORTMATIC_KEY="pk_live_9846B20CC0CD7C35"
 
 # Domain
-REACT_APP_DOMAIN_PREFIX_DEV=cow-trade.dev
-REACT_APP_DOMAIN_PREFIX_STAGING=cow-trade.staging
-REACT_APP_DOMAIN_PREFIX_PROD=cow.trade
+REACT_APP_DOMAIN_REGEX_DEV="^(:?cow-trade\.dev|localhost:\d{2,5}|pr\d+--gpswapui.review)"
+REACT_APP_DOMAIN_REGEX_STAGING="^cow-trade\.staging"
+REACT_APP_DOMAIN_REGEX_PROD="^(:?cow.trade|cow-swap\.exchange)"
 
 # Analytics
 REACT_APP_GOOGLE_ANALYTICS_ID_DEV="UA-190948266-3"
@@ -25,6 +25,6 @@ REACT_APP_GOOGLE_ANALYTICS_ID="UA-190948266-1"
 #REACT_APP_API_BASE_URL_XDAI=https://protocol-xdai.dev.gnosisdev.com/api/v1
 
 # EXPLORER
-REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com
-REACT_APP_EXPLORER_URL_STAGING=https://protocol-explorer.staging.gnosisdev.com
-REACT_APP_EXPLORER_URL_PROD=https://gnosis-protocol.io
+#REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com
+#REACT_APP_EXPLORER_URL_STAGING=https://protocol-explorer.staging.gnosisdev.com
+#REACT_APP_EXPLORER_URL_PROD=https://gnosis-protocol.io

--- a/.env.production
+++ b/.env.production
@@ -7,7 +7,7 @@ REACT_APP_PORTIS_ID="c591a488-8b86-41e1-8d2e-f4b169efd3aa"
 REACT_APP_FORTMATIC_KEY="pk_live_9846B20CC0CD7C35"
 
 # Domain
-REACT_APP_DOMAIN_REGEX_DEV="^(:?cow-trade\.dev|localhost:\d{2,5}|pr\d+--gpswapui\.review)"
+REACT_APP_DOMAIN_REGEX_DEV="^(:?cow-trade\.dev|localhost:\d{2,5}|pr\\d+--gpswapui\.review)"
 REACT_APP_DOMAIN_REGEX_STAGING="^cow-trade\.staging"
 REACT_APP_DOMAIN_REGEX_PROD="^(:?cow.trade|cowswap\.exchange)"
 

--- a/.env.production
+++ b/.env.production
@@ -9,7 +9,7 @@ REACT_APP_FORTMATIC_KEY="pk_live_9846B20CC0CD7C35"
 # Domain
 REACT_APP_DOMAIN_REGEX_DEV="^(:?cow-trade\.dev|localhost:\d{2,5}|pr\d+--gpswapui.review)"
 REACT_APP_DOMAIN_REGEX_STAGING="^cow-trade\.staging"
-REACT_APP_DOMAIN_REGEX_PROD="^(:?cow.trade|cow-swap\.exchange)"
+REACT_APP_DOMAIN_REGEX_PROD="^(:?cow.trade|cowswap\.exchange)"
 
 # Analytics
 REACT_APP_GOOGLE_ANALYTICS_ID_DEV="UA-190948266-3"

--- a/src/custom/utils/analytics.ts
+++ b/src/custom/utils/analytics.ts
@@ -1,8 +1,6 @@
-import { checkEnvironment } from './environments'
+import { isDev, isStaging, isProd } from './environments'
 
 export function getAnalyticsId(): string | undefined {
-  const { isDev, isStaging, isProd } = checkEnvironment(window.location.host)
-
   if (isDev) {
     return process.env.REACT_APP_GOOGLE_ANALYTICS_ID_DEV
   } else if (isStaging) {
@@ -11,5 +9,6 @@ export function getAnalyticsId(): string | undefined {
     return process.env.REACT_APP_GOOGLE_ANALYTICS_ID_PROD
   }
 
+  // Undefined by default
   return undefined
 }

--- a/src/custom/utils/environments.ts
+++ b/src/custom/utils/environments.ts
@@ -1,17 +1,17 @@
-function getDomainRegex(domainPrefix: string | undefined): RegExp | undefined {
-  return domainPrefix ? new RegExp('^' + domainPrefix.replace('.', '\\.'), 'i') : undefined
-}
+export function checkEnvironment(host: string) {
+  const getRegex = (regex: string | undefined) => (regex ? new RegExp(regex) : undefined)
 
-export function checkEnvironment(host?: string) {
-  const domainDevRegex = getDomainRegex(process.env.REACT_APP_DOMAIN_PREFIX_DEV)
-  const domainStagingRegex = getDomainRegex(process.env.REACT_APP_DOMAIN_PREFIX_STAGING)
-  const domainProdRegex = getDomainRegex(process.env.REACT_APP_DOMAIN_PREFIX_PROD)
-
-  const hostToCheck = host || window.location.host
+  const domainDevRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_DEV)
+  const domainStagingRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_STAGING)
+  const domainProdRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_PROD)
 
   return {
-    isDev: domainDevRegex?.test(hostToCheck),
-    isStaging: domainStagingRegex?.test(hostToCheck),
-    isProd: domainProdRegex?.test(hostToCheck)
+    isDev: domainDevRegex?.test(host) || false,
+    isStaging: domainStagingRegex?.test(host) || false,
+    isProd: domainProdRegex?.test(host) || false
   }
 }
+
+const { isDev, isStaging, isProd } = checkEnvironment(window.location.host)
+
+export { isDev, isStaging, isProd }

--- a/src/custom/utils/environments.ts
+++ b/src/custom/utils/environments.ts
@@ -1,5 +1,5 @@
 export function checkEnvironment(host: string) {
-  const getRegex = (regex: string | undefined) => regex && new RegExp(regex)
+  const getRegex = (regex: string | undefined) => (regex ? new RegExp(regex) : undefined)
 
   const domainDevRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_DEV)
   const domainStagingRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_STAGING)

--- a/src/custom/utils/explorer.ts
+++ b/src/custom/utils/explorer.ts
@@ -1,8 +1,6 @@
 import { ChainId } from '@uniswap/sdk'
 import { OrderID } from 'utils/operator'
-import { checkEnvironment } from './environments'
-
-const { isDev, isStaging, isProd } = checkEnvironment(window.location.host)
+import { isDev, isStaging } from './environments'
 
 function _getExplorerUrlByEnvironment() {
   let baseUrl: string | undefined
@@ -10,11 +8,9 @@ function _getExplorerUrlByEnvironment() {
     baseUrl = process.env.REACT_APP_EXPLORER_URL_DEV || 'https://protocol-explorer.dev.gnosisdev.com'
   } else if (isStaging) {
     baseUrl = process.env.REACT_APP_EXPLORER_URL_STAGING || 'https://protocol-explorer.staging.gnosisdev.com'
-  } else if (isProd) {
-    baseUrl = process.env.REACT_APP_EXPLORER_URL_PROD || 'https://gnosis-protocol.io'
   } else {
-    // default to dev
-    baseUrl = process.env.REACT_APP_EXPLORER_URL_DEV || 'https://protocol-explorer.dev.gnosisdev.com'
+    // Production by default
+    baseUrl = process.env.REACT_APP_EXPLORER_URL_PROD || 'https://gnosis-protocol.io'
   }
 
   return {


### PR DESCRIPTION
- Prepares for the final domain (cow-swap.exchange)
- Make production the default for the links to the explorer (to account for IPFS and weird links)
- Allow more complex checks using regex expressions
- Add detection for localhost and PRaul
- Disable envs `REACT_APP_EXPLORER_URL_DEV` so it uses the default
- Expose the `isDev, isStaging, isProd` directly, not through a function, since they are static values that don't change.