### PR TITLE
[443] - [FIRST PART] - ETH/WETH Component + smple logic

### DIFF
--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -14,7 +14,10 @@ export const StyledMenu = styled(MenuMod)`
   }
 `
 
-const Policy = styled(InternalMenuItem)`
+const Policy = styled(InternalMenuItem).attrs(attrs => ({
+  ...attrs,
+  target: '_blank'
+}))`
   font-size: 0.8em;
   text-decoration: underline;
 `

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -23,7 +23,7 @@ const MenuFlyout = styled(MenuFlyoutUni)`
   min-width: 11rem;
 `
 
-const Separator = styled(SeparatorBase)`
+export const Separator = styled(SeparatorBase)`
   background-color: #0000002e;
   margin: 0.3rem auto;
   width: 90%;

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Separator } from 'components/Menu'
+import { ArrowDown, AlertTriangle } from 'react-feather'
+import { ButtonLight } from '../../Button/ButtonMod'
+import { Currency, Token } from '@uniswap/sdk'
+import { useCurrencyBalances } from 'state/wallet/hooks'
+import { SHORT_PRECISION } from 'constants/index'
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flexColumnNoWrap}
+  background: ${({ theme }) => theme.bg2};
+  align-items: center;
+  justify-content: center;
+  margin: auto;
+  padding: 1rem;
+  width: 100%;
+
+  border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
+  font-size: smaller;
+
+    > ${Separator} {
+        margin: -0.3rem 0 0.6rem 0;
+    }
+
+  > ${ButtonLight} {
+      background: ${({ theme }) => theme.bg1};
+  }
+`
+const WarningWrapper = styled(Wrapper)`
+  ${({ theme }) => theme.flexRowNoWrap}
+  padding: 0.5rem;
+
+  color: red;
+  font-weight: 800;
+  font-size: small;
+
+  > svg {
+    margin-right: 0.5rem;
+  }
+
+  > div {
+    ${({ theme }) => theme.flexColumnNoWrap}
+    align-items: flex-start;
+    justify-content: center;
+    font-size: smaller;
+  }
+`
+
+const BalanceLabel = styled.p<{ background?: string }>`
+  display: flex;
+  justify-content: space-between;
+  width: 90%;
+
+  background: ${({ background = 'initial' }) => background};
+
+  > span {
+    &:first-child {
+      margin-right: auto;
+    }
+  }
+`
+
+interface Params {
+  account?: string
+  native: Currency
+  wrapped: Token
+}
+
+export default function EthWethWrap({ account, native, wrapped }: Params) {
+  const wrappedSymbol = wrapped.symbol || 'wrapped native token'
+  const nativeSymbol = native.symbol || 'native token'
+
+  const [nativeBalance, wrappedBalance] = useCurrencyBalances(account, [native, wrapped])
+
+  return (
+    <Wrapper>
+      <WarningWrapper>
+        <AlertTriangle size={30} />
+        <div>
+          <span>Only {wrappedSymbol} can be used to swap.</span>
+          <span>
+            Wrap your {nativeSymbol} first or switch to {wrappedSymbol}
+          </span>
+        </div>
+      </WarningWrapper>
+      <BalanceLabel>
+        <span>{nativeSymbol} balance:</span> <span>{nativeBalance?.toSignificant(SHORT_PRECISION) || '-'}</span>
+      </BalanceLabel>
+      <Separator />
+      <ArrowDown size={14} />
+      <BalanceLabel background="">
+        <span>{wrappedSymbol} balance:</span>
+        <span>{wrappedBalance?.toSignificant(SHORT_PRECISION) || '-'}</span>
+      </BalanceLabel>
+      <ButtonLight padding="0.5rem">Wrap my {nativeSymbol}</ButtonLight>
+    </Wrapper>
+  )
+}

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useCallback } from 'react'
 import styled from 'styled-components'
 import { Separator } from 'components/Menu'
 import { ArrowDown, AlertTriangle } from 'react-feather'
@@ -7,6 +7,7 @@ import { Currency, Token } from '@uniswap/sdk'
 import { useCurrencyBalances } from 'state/wallet/hooks'
 import { SHORT_PRECISION } from 'constants/index'
 import { colors } from 'theme'
+import Loader from 'components/Loader'
 
 const COLOUR_SHEET = colors(false)
 
@@ -28,11 +29,16 @@ const Wrapper = styled.div`
   }
 
   > ${ButtonPrimary} {
-      // TODO: themed
+      // TODO: @biocom themed
       background: #62d9ff;
       width: 75%;
       padding: 0.4rem;
       margin-top: 0.3rem;
+
+      &:disabled {
+        // TODO: @biocom disabled prop should already do this
+        background-color: ${({ theme }) => theme.disabled}
+      }
   }
 `
 const WarningWrapper = styled(Wrapper)`
@@ -79,13 +85,31 @@ export interface Props {
   account?: string
   native: Currency
   wrapped: Token
+  wrapCallback: () => Promise<void>
 }
 
-export default function EthWethWrap({ account, native, wrapped }: Props) {
+export default function EthWethWrap({ account, native, wrapped, wrapCallback }: Props) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const [nativeBalance, wrappedBalance] = useCurrencyBalances(account, [native, wrapped])
+
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
   const nativeSymbol = native.symbol || 'native token'
 
-  const [nativeBalance, wrappedBalance] = useCurrencyBalances(account, [native, wrapped])
+  const handleWrap = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      await wrapCallback()
+    } catch (error) {
+      console.error('Error wrapping ETH:', error)
+
+      setError(new Error(error))
+    } finally {
+      setLoading(false)
+    }
+  }, [wrapCallback])
 
   return (
     <Wrapper>
@@ -96,6 +120,11 @@ export default function EthWethWrap({ account, native, wrapped }: Props) {
           <span>
             Wrap your {nativeSymbol} first or switch to {wrappedSymbol}
           </span>
+          {error && (
+            <span>
+              <strong>{error.message}</strong>
+            </span>
+          )}
         </div>
       </WarningWrapper>
       <BalanceLabel>
@@ -107,7 +136,9 @@ export default function EthWethWrap({ account, native, wrapped }: Props) {
         <span>{wrappedSymbol} balance:</span>
         <span>{wrappedBalance?.toSignificant(SHORT_PRECISION) || '-'}</span>
       </BalanceLabel>
-      <ButtonPrimary padding="0.5rem">Wrap my {nativeSymbol}</ButtonPrimary>
+      <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handleWrap}>
+        {loading ? <Loader /> : `Wrap my ${nativeSymbol}`}
+      </ButtonPrimary>
     </Wrapper>
   )
 }

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -2,48 +2,58 @@ import React from 'react'
 import styled from 'styled-components'
 import { Separator } from 'components/Menu'
 import { ArrowDown, AlertTriangle } from 'react-feather'
-import { ButtonLight } from '../../Button/ButtonMod'
+import { ButtonPrimary } from 'components/Button'
 import { Currency, Token } from '@uniswap/sdk'
 import { useCurrencyBalances } from 'state/wallet/hooks'
 import { SHORT_PRECISION } from 'constants/index'
+import { colors } from 'theme'
+
+const COLOUR_SHEET = colors(false)
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap}
   background: ${({ theme }) => theme.bg2};
   align-items: center;
   justify-content: center;
-  margin: auto;
+  margin: 0.3rem auto 0;
   padding: 1rem;
   width: 100%;
 
   border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
   font-size: smaller;
 
-    > ${Separator} {
-        margin: -0.3rem 0 0.6rem 0;
-    }
+  > ${Separator} {
+      margin: -0.3rem 0 0.6rem 0;
+      width: 83%;
+  }
 
-  > ${ButtonLight} {
-      background: ${({ theme }) => theme.bg1};
+  > ${ButtonPrimary} {
+      // TODO: themed
+      background: #62d9ff;
+      width: 75%;
+      padding: 0.4rem;
+      margin-top: 0.3rem;
   }
 `
 const WarningWrapper = styled(Wrapper)`
   ${({ theme }) => theme.flexRowNoWrap}
-  padding: 0.5rem;
+  padding: 0rem;
 
-  color: red;
-  font-weight: 800;
+  color: ${({ theme }) => theme.red1};
+  font-weight: 600;
   font-size: small;
 
+  // warning logo
   > svg {
     margin-right: 0.5rem;
   }
 
+  // warning text
   > div {
     ${({ theme }) => theme.flexColumnNoWrap}
     align-items: flex-start;
     justify-content: center;
-    font-size: smaller;
+    font-size: 90%;
   }
 `
 
@@ -51,6 +61,10 @@ const BalanceLabel = styled.p<{ background?: string }>`
   display: flex;
   justify-content: space-between;
   width: 90%;
+  padding: 0.5rem 0.7rem;
+  margin: 0.5rem 0;
+
+  border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
 
   background: ${({ background = 'initial' }) => background};
 
@@ -88,12 +102,12 @@ export default function EthWethWrap({ account, native, wrapped }: Params) {
         <span>{nativeSymbol} balance:</span> <span>{nativeBalance?.toSignificant(SHORT_PRECISION) || '-'}</span>
       </BalanceLabel>
       <Separator />
-      <ArrowDown size={14} />
-      <BalanceLabel background="">
+      <ArrowDown size={18} color={COLOUR_SHEET.primary1} />
+      <BalanceLabel background={COLOUR_SHEET.bg1}>
         <span>{wrappedSymbol} balance:</span>
         <span>{wrappedBalance?.toSignificant(SHORT_PRECISION) || '-'}</span>
       </BalanceLabel>
-      <ButtonLight padding="0.5rem">Wrap my {nativeSymbol}</ButtonLight>
+      <ButtonPrimary padding="0.5rem">Wrap my {nativeSymbol}</ButtonPrimary>
     </Wrapper>
   )
 }

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -86,7 +86,8 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
 export default function useWrapCallback(
   inputCurrency: Currency | undefined,
   outputCurrency: Currency | undefined,
-  typedValue: string | undefined
+  typedValue: string | undefined,
+  isEthTradeOverride?: boolean
 ): WrapUnwrapCallback {
   const { chainId, account } = useActiveWeb3React()
   const wethContract = useWETHContract()
@@ -98,7 +99,8 @@ export default function useWrapCallback(
   return useMemo(() => {
     if (!wethContract || !chainId || !inputCurrency || !outputCurrency) return NOT_APPLICABLE
 
-    const isWrappingEther = inputCurrency === ETHER && currencyEquals(WETH[chainId], outputCurrency)
+    const isWrappingEther =
+      inputCurrency === ETHER && (isEthTradeOverride || currencyEquals(WETH[chainId], outputCurrency))
     const isUnwrappingWeth = currencyEquals(WETH[chainId], inputCurrency) && outputCurrency === ETHER
 
     if (!isWrappingEther && !isUnwrappingWeth) {
@@ -112,5 +114,5 @@ export default function useWrapCallback(
         wethContract
       })
     }
-  }, [wethContract, chainId, inputCurrency, outputCurrency, inputAmount, balance, addTransaction])
+  }, [wethContract, chainId, inputCurrency, outputCurrency, isEthTradeOverride, balance, inputAmount, addTransaction])
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -112,11 +112,15 @@ export default function Swap({
   } = useDerivedSwapInfo()
 
   // Checks if either currency is native ETH
-  const { isNativeIn, native, wrappedToken } = useDetectNativeToken(
+  // MOD: adds this hook
+  const { isNativeIn, isWrappedOut, native, wrappedToken } = useDetectNativeToken(
     { currency: currencies.INPUT, address: INPUT.currencyId },
     { currency: currencies.OUTPUT, address: OUTPUT.currencyId },
     chainId
   )
+
+  // Is user swapping Eth as From token and not wrapping to WETH?
+  const isNativeInSwap = isNativeIn && !isWrappedOut
 
   // Is fee greater than input?
   const { isFeeGreater, fee } = useIsFeeGreaterThanInput({ chainId, address: INPUT.currencyId, parsedAmount })
@@ -124,9 +128,12 @@ export default function Swap({
   const { wrapType, execute: onWrap, inputError: wrapInputError } = useWrapCallback(
     currencies[Field.INPUT],
     currencies[Field.OUTPUT],
-    typedValue
+    typedValue,
+    // should override and get wrapCallback?
+    isNativeInSwap
   )
-  const showWrap: boolean = wrapType !== WrapType.NOT_APPLICABLE
+
+  const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
   const { address: recipientAddress } = useENSAddress(recipient)
   const toggledVersion = useToggledVersion()
   const tradesByVersion = {
@@ -463,8 +470,13 @@ export default function Swap({
                     </RowBetween>
                   )}
                   {isFeeGreater && fee && <FeeGreaterMessage fee={fee} />}
-                  {isNativeIn && (
-                    <EthWethWrapMessage account={account ?? undefined} native={native} wrapped={wrappedToken} />
+                  {isNativeIn && onWrap && (
+                    <EthWethWrapMessage
+                      account={account ?? undefined}
+                      native={native}
+                      wrapped={wrappedToken}
+                      wrapCallback={onWrap}
+                    />
                   )}
                 </AutoColumn>
               </Card>
@@ -484,7 +496,7 @@ export default function Swap({
                 {wrapInputError ??
                   (wrapType === WrapType.WRAP ? 'Wrap' : wrapType === WrapType.UNWRAP ? 'Unwrap' : null)}
               </ButtonPrimary>
-            ) : isNativeIn ? (
+            ) : !swapInputError && isNativeIn ? (
               <SwitchToWethBtn wrappedToken={wrappedToken} />
             ) : noRoute && userHasSpecifiedInputOutput ? (
               isFeeGreater ? (

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -42,10 +42,10 @@ function FeeGreaterMessage({ fee }: FeeGreaterMessageProp) {
   )
 }
 
-function EthWethWrapMessage({ account, native, wrapped }: EthWethWrapProps) {
+function EthWethWrapMessage({ account, native, wrapped, wrapCallback }: EthWethWrapProps) {
   return (
     <RowBetween>
-      <EthWethWrap account={account ?? undefined} native={native} wrapped={wrapped} />
+      <EthWethWrap account={account ?? undefined} native={native} wrapped={wrapped} wrapCallback={wrapCallback} />
     </RowBetween>
   )
 }

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -240,7 +240,7 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
     ]
 
     return { isNativeIn: isNativeIn && !isWrappedOut, isNativeOut: isNativeOut && !isWrappedIn, wrappedToken, native }
-  }, [input?.address, input?.currency, native, output?.address, output?.currency, wrappedToken])
+  }, [input, output, native, wrappedToken])
 }
 
 export function useIsFeeGreaterThanInput({

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -239,7 +239,14 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
       output?.address === wrappedToken.address
     ]
 
-    return { isNativeIn: isNativeIn && !isWrappedOut, isNativeOut: isNativeOut && !isWrappedIn, wrappedToken, native }
+    return {
+      isNativeIn: isNativeIn && !isWrappedOut,
+      isNativeOut: isNativeOut && !isWrappedIn,
+      isWrappedIn,
+      isWrappedOut,
+      wrappedToken,
+      native
+    }
   }, [input, output, native, wrappedToken])
 }
 


### PR DESCRIPTION
Part of #443 

Merges into `443/eth-weth-flow` as a base

![Screenshot from 2021-04-16 11-44-42](https://user-images.githubusercontent.com/21335563/115013605-29a0d580-9ea9-11eb-9082-55747b044af6.png)

### QA Instructions
_NATIVE TOKEN and WRAPPED NATIVE TOKEN refer to ETH/WETH on anything but xDAI and XDAI/WXDAI on xDai chain, respectively_
1. load NATIVE_TOKEN as sell token
2. load anything but WRAPPED_NATIVE_TOKEN
3. should show component to wrap
4. should show proper balances for both NATIVE_TOKEN and WRAPPED_NATIVE_TOKEN
5. "Wrap my NATIVE_TOKEN" should be clickable BUT not do anything. (not implemented)
6. "Switch to WRAPPED_NATIVE_TOKEN should indeed be clickable and switch as expected
7. names of NATIVE and WRAPPED_NATIVE tokens should be correct across chains