### PR TITLE
Reduce changes swap mod

### DIFF
--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -61,13 +61,13 @@ const BalanceLabel = styled.p<{ background?: string }>`
   }
 `
 
-interface Params {
+export interface Props {
   account?: string
   native: Currency
   wrapped: Token
 }
 
-export default function EthWethWrap({ account, native, wrapped }: Params) {
+export default function EthWethWrap({ account, native, wrapped }: Props) {
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
   const nativeSymbol = native.symbol || 'native token'
 

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -57,7 +57,6 @@ const Wrapper = styled.div``
 
 export default function Swap({
   history,
-  className,
   FeeGreaterMessage,
   EthWethWrapMessage,
   SwitchToWethBtn,
@@ -334,7 +333,7 @@ export default function Swap({
   )
 
   return (
-    <Wrapper className={className}>
+    <>
       <TokenWarningModal
         isOpen={importTokensNotInDefault.length > 0 && !dismissTokenWarning}
         tokens={importTokensNotInDefault}
@@ -595,6 +594,6 @@ export default function Swap({
       ) : (
         <UnsupportedCurrencyFooter show={swapIsUnsupported} currencies={[currencies.INPUT, currencies.OUTPUT]} />
       )}
-    </Wrapper>
+    </>
   )
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 import { ArrowDown } from 'react-feather'
 import ReactGA from 'react-ga'
 import { Text } from 'rebass'
-import styled, { ThemeContext } from 'styled-components'
+import { ThemeContext } from 'styled-components'
 import AddressInputPanel from 'components/AddressInputPanel'
 import { ButtonError, ButtonLight, ButtonPrimary, ButtonConfirmed } from 'components/Button'
 import Card, { GreyCard } from 'components/Card'
@@ -15,7 +15,7 @@ import { AutoRow, RowBetween } from 'components/Row'
 import AdvancedSwapDetailsDropdown from 'components/swap/AdvancedSwapDetailsDropdown'
 import BetterTradeLink, { DefaultVersionLink } from 'components/swap/BetterTradeLink'
 import confirmPriceImpactWithoutFee from 'components/swap/confirmPriceImpactWithoutFee'
-import { ArrowWrapper, BottomGrouping, SwapCallbackError } from 'components/swap/styleds'
+import { ArrowWrapper, BottomGrouping, SwapCallbackError, Wrapper } from 'components/swap/styleds'
 import TradePrice from 'components/swap/TradePrice'
 import TokenWarningModal from 'components/TokenWarningModal'
 import ProgressSteps from 'components/ProgressSteps'
@@ -52,8 +52,6 @@ import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter
 import { isTradeBetter } from 'utils/trades'
 import FeeInformationTooltip from 'components/swap/FeeInformationTooltip'
 import { SwapProps } from '.'
-
-const Wrapper = styled.div``
 
 export default function Swap({
   history,

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -1,1 +1,107 @@
-export { default } from './SwapMod'
+import React, { useContext } from 'react'
+import { RouteComponentProps } from 'react-router-dom'
+import styled from 'styled-components'
+import { ThemeContext } from 'styled-components'
+import { CurrencyAmount, Token } from '@uniswap/sdk'
+import { Text } from 'rebass'
+
+import { ButtonSize, TYPE } from 'theme/index'
+
+import { WithClassName } from 'custom/types'
+import SwapMod from './SwapMod'
+import { RowBetween, RowFixed } from 'components/Row'
+import QuestionHelper from 'components/QuestionHelper'
+import { ButtonError, ButtonPrimary } from 'components/Button'
+import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
+import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
+
+interface FeeGreaterMessageProp {
+  fee: CurrencyAmount
+}
+
+export type SwapProps = RouteComponentProps &
+  WithClassName & {
+    FeeGreaterMessage: React.FC<FeeGreaterMessageProp>
+    EthWethWrapMessage: React.FC<EthWethWrapProps>
+    SwitchToWethBtn: React.FC<SwitchToWethBtnProps>
+    FeesExceedFromAmountMessage: React.FC
+  }
+
+function FeeGreaterMessage({ fee }: FeeGreaterMessageProp) {
+  const theme = useContext(ThemeContext)
+
+  return (
+    <RowBetween>
+      <RowFixed>
+        <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
+          Fee
+        </TYPE.black>
+        <QuestionHelper text="GP Swap has 0 gas fees. A portion of the sell amount in each trade goes to the GP Protocol." />
+      </RowFixed>
+      <TYPE.black fontSize={14} color={theme.text1}>
+        {fee.toSignificant(4)} {fee.currency.symbol}
+      </TYPE.black>
+    </RowBetween>
+  )
+}
+
+function EthWethWrapMessage({ account, native, wrapped }: EthWethWrapProps) {
+  return (
+    <RowBetween>
+      <EthWethWrap account={account ?? undefined} native={native} wrapped={wrapped} />
+    </RowBetween>
+  )
+}
+
+interface SwitchToWethBtnProps {
+  wrappedToken: Token
+}
+
+function SwitchToWethBtn({ wrappedToken }: SwitchToWethBtnProps) {
+  const replaceSwapState = useReplaceSwapState()
+  const { independentField, typedValue, OUTPUT } = useSwapState()
+
+  return (
+    <ButtonPrimary
+      buttonSize={ButtonSize.BIG}
+      id="swap-button"
+      onClick={() =>
+        replaceSwapState({
+          inputCurrencyId: wrappedToken.address,
+          outputCurrencyId: OUTPUT.currencyId,
+          typedValue,
+          recipient: null,
+          field: independentField
+        })
+      }
+    >
+      <TYPE.main mb="4px">Switch to {wrappedToken.symbol}</TYPE.main>
+    </ButtonPrimary>
+  )
+}
+
+function FeesExceedFromAmountMessage() {
+  return (
+    <RowBetween>
+      <ButtonError buttonSize={ButtonSize.BIG} error id="swap-button" disabled>
+        <Text fontSize={20} fontWeight={500}>
+          Fees exceed from amount
+        </Text>
+      </ButtonError>
+    </RowBetween>
+  )
+}
+
+const Wrapper = styled(SwapMod)``
+
+export default function Swap(props: RouteComponentProps) {
+  return (
+    <Wrapper
+      FeeGreaterMessage={FeeGreaterMessage}
+      EthWethWrapMessage={EthWethWrapMessage}
+      SwitchToWethBtn={SwitchToWethBtn}
+      FeesExceedFromAmountMessage={FeesExceedFromAmountMessage}
+      {...props}
+    />
+  )
+}

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
-import styled from 'styled-components'
 import { ThemeContext } from 'styled-components'
 import { CurrencyAmount, Token } from '@uniswap/sdk'
 import { Text } from 'rebass'
@@ -90,11 +89,9 @@ function FeesExceedFromAmountMessage() {
   )
 }
 
-const Wrapper = styled(SwapMod)``
-
 export default function Swap(props: RouteComponentProps) {
   return (
-    <Wrapper
+    <SwapMod
       FeeGreaterMessage={FeeGreaterMessage}
       EthWethWrapMessage={EthWethWrapMessage}
       SwitchToWethBtn={SwitchToWethBtn}

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -7,7 +7,6 @@ import { Text } from 'rebass'
 
 import { ButtonSize, TYPE } from 'theme/index'
 
-import { WithClassName } from 'custom/types'
 import SwapMod from './SwapMod'
 import { RowBetween, RowFixed } from 'components/Row'
 import QuestionHelper from 'components/QuestionHelper'
@@ -19,13 +18,12 @@ interface FeeGreaterMessageProp {
   fee: CurrencyAmount
 }
 
-export type SwapProps = RouteComponentProps &
-  WithClassName & {
-    FeeGreaterMessage: React.FC<FeeGreaterMessageProp>
-    EthWethWrapMessage: React.FC<EthWethWrapProps>
-    SwitchToWethBtn: React.FC<SwitchToWethBtnProps>
-    FeesExceedFromAmountMessage: React.FC
-  }
+export interface SwapProps extends RouteComponentProps {
+  FeeGreaterMessage: React.FC<FeeGreaterMessageProp>
+  EthWethWrapMessage: React.FC<EthWethWrapProps>
+  SwitchToWethBtn: React.FC<SwitchToWethBtnProps>
+  FeesExceedFromAmountMessage: React.FC
+}
 
 function FeeGreaterMessage({ fee }: FeeGreaterMessageProp) {
   const theme = useContext(ThemeContext)


### PR DESCRIPTION
This PR moves quite some logic form the Mod to our index. It does so by creating smaller components that are injected to the SwapMod

This changes are applied on top of #449 

This way the Mod are now easily comparable. 
Also uses the word Fee instead of Fee/GP for coherence with other parts.


----------------
EDIT 1: 

~~It has a small issue. I think I have an additional DIV or something breaking the layout a bit.~~
~~probably an easy fix. Ill look at this later, but @W3stside if you want to go for it, also do.~~

----------------
EDIT 2: Fixed!