### PR TITLE
ETH can be used as BUY token

### DIFF
--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -231,10 +231,10 @@ interface CurrencyWithAddress {
 export function useShouldDisableEth(input?: CurrencyWithAddress, output?: CurrencyWithAddress) {
   const weth = useWETHContract()
   return useMemo(() => {
-    const [isEthIn, isEthOut] = [input?.currency === ETHER, output?.currency === ETHER]
-    const [isWethIn, isWethOut] = [input?.address === weth?.address, output?.address === weth?.address]
+    const isEthIn = input?.currency === ETHER
+    const isWethOut = output?.address === weth?.address
 
-    return { showEthDisabled: (isEthIn && !isWethOut) || (isEthOut && !isWethIn), weth }
+    return { showEthDisabled: isEthIn && !isWethOut, weth }
   }, [input, output, weth])
 }
 


### PR DESCRIPTION
# Summary

Part of #355 

# Testing

1. Connect your wallet
2. Pick any token other than the wrapped native token as the SELL token
3. Pick `ETH`/`xDai` (depending on which network you are on) as the BUY token
 - [ ] Swap button should be enabled and clickable
![screenshot_2021-04-16_07-58-08](https://user-images.githubusercontent.com/43217/115043712-a754e900-9e89-11eb-9b4c-ffc1ebaf6457.png)

4. Click on wrap button

- [ ] In the signature request, the BUY token should be set to `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
![screenshot_2021-04-16_07-58-18](https://user-images.githubusercontent.com/43217/115043940-df5c2c00-9e89-11eb-85eb-5a1f53c932b6.png)

5. Sign the order

## Notes

1. Backend does not yet support selling ETH/xDai, so the order won't match
2. Explorer does not yet support displaying ETH/xDai, so the order won't load
    Fix on this PR https://github.com/gnosis/gp-ui/pull/383. Use https://pr383--gpui.review.gnosisdev.com/

