### PR TITLE
[443] ETH/WETH Wrapping logic

### DIFF
--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -14,7 +14,10 @@ export const StyledMenu = styled(MenuMod)`
   }
 `
 
-const Policy = styled(InternalMenuItem)`
+const Policy = styled(InternalMenuItem).attrs(attrs => ({
+  ...attrs,
+  target: '_blank'
+}))`
   font-size: 0.8em;
   text-decoration: underline;
 `

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -79,9 +79,10 @@ export interface Props {
   account?: string
   native: Currency
   wrapped: Token
+  wrapCallback: (() => Promise<void>) | undefined
 }
 
-export default function EthWethWrap({ account, native, wrapped }: Props) {
+export default function EthWethWrap({ account, native, wrapped, wrapCallback }: Props) {
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
   const nativeSymbol = native.symbol || 'native token'
 
@@ -107,7 +108,9 @@ export default function EthWethWrap({ account, native, wrapped }: Props) {
         <span>{wrappedSymbol} balance:</span>
         <span>{wrappedBalance?.toSignificant(SHORT_PRECISION) || '-'}</span>
       </BalanceLabel>
-      <ButtonPrimary padding="0.5rem">Wrap my {nativeSymbol}</ButtonPrimary>
+      <ButtonPrimary padding="0.5rem" onClick={wrapCallback}>
+        Wrap my {nativeSymbol}
+      </ButtonPrimary>
     </Wrapper>
   )
 }

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -86,7 +86,8 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
 export default function useWrapCallback(
   inputCurrency: Currency | undefined,
   outputCurrency: Currency | undefined,
-  typedValue: string | undefined
+  typedValue: string | undefined,
+  isEthTradeOverride?: boolean
 ): WrapUnwrapCallback {
   const { chainId, account } = useActiveWeb3React()
   const wethContract = useWETHContract()
@@ -98,7 +99,8 @@ export default function useWrapCallback(
   return useMemo(() => {
     if (!wethContract || !chainId || !inputCurrency || !outputCurrency) return NOT_APPLICABLE
 
-    const isWrappingEther = inputCurrency === ETHER && currencyEquals(WETH[chainId], outputCurrency)
+    const isWrappingEther =
+      inputCurrency === ETHER && (isEthTradeOverride || currencyEquals(WETH[chainId], outputCurrency))
     const isUnwrappingWeth = currencyEquals(WETH[chainId], inputCurrency) && outputCurrency === ETHER
 
     if (!isWrappingEther && !isUnwrappingWeth) {
@@ -112,5 +114,5 @@ export default function useWrapCallback(
         wethContract
       })
     }
-  }, [wethContract, chainId, inputCurrency, outputCurrency, inputAmount, balance, addTransaction])
+  }, [wethContract, chainId, inputCurrency, outputCurrency, isEthTradeOverride, balance, inputAmount, addTransaction])
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -464,7 +464,12 @@ export default function Swap({
                   )}
                   {isFeeGreater && fee && <FeeGreaterMessage fee={fee} />}
                   {isNativeIn && (
-                    <EthWethWrapMessage account={account ?? undefined} native={native} wrapped={wrappedToken} />
+                    <EthWethWrapMessage
+                      account={account ?? undefined}
+                      native={native}
+                      wrapped={wrappedToken}
+                      wrapCallback={onWrap}
+                    />
                   )}
                 </AutoColumn>
               </Card>

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -42,10 +42,10 @@ function FeeGreaterMessage({ fee }: FeeGreaterMessageProp) {
   )
 }
 
-function EthWethWrapMessage({ account, native, wrapped }: EthWethWrapProps) {
+function EthWethWrapMessage({ account, native, wrapped, wrapCallback }: EthWethWrapProps) {
   return (
     <RowBetween>
-      <EthWethWrap account={account ?? undefined} native={native} wrapped={wrapped} />
+      <EthWethWrap account={account ?? undefined} native={native} wrapped={wrapped} wrapCallback={wrapCallback} />
     </RowBetween>
   )
 }

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -239,7 +239,14 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
       output?.address === wrappedToken.address
     ]
 
-    return { isNativeIn: isNativeIn && !isWrappedOut, isNativeOut: isNativeOut && !isWrappedIn, wrappedToken, native }
+    return {
+      isNativeIn: isNativeIn && !isWrappedOut,
+      isNativeOut: isNativeOut && !isWrappedIn,
+      isWrappedIn,
+      isWrappedOut,
+      wrappedToken,
+      native
+    }
   }, [input, output, native, wrappedToken])
 }
 


### PR DESCRIPTION
Adds ETH/WETH wrapping logic into #443 

Waterfalls into #449 

1. Shows loader and disables `Wrap my NATIVE_TOKEN` button on action - wraps the inputAmount of "from" token
2. menu urls are external target="_blank" behaviour (did this here because ease and not a huge app breaking change)
3. passes an optional param to `useWrapCallback` called `isEthTradeOverride` which is input to signal to app that we are selling ETH and the output token is NOT WETH - this disables blocking the app to show the normal ETH/WETH wrap flow

### QA TESTING
1. all steps from QA testing in #449 
2. Wrap my NATIVE_TOKEN should prompt MM/wallet and wrapping should work with:
  - wallet modal pops up
  - button shows loading spinner and is disabled (can't be clicked why tx in progress)
  - Pending transactions reacts to change and shows transaction properly
  - when confirmed balances update and loading goes away

### Notes
1. when exiting swap page and going back state is lost in trade wiping all wrap ETH to WETH visualisations. Pending transactions remain, and the tx will no fail as it's already been sent to BC, but UX could be weird.

