### PR TITLE
Fix price impact display

### DIFF
--- a/src/custom/components/swap/TradeSummary.tsx
+++ b/src/custom/components/swap/TradeSummary.tsx
@@ -4,7 +4,10 @@ import { CurrencyAmount, Percent, TradeType } from '@uniswap/sdk'
 
 import { Field } from '@src/state/swap/actions'
 import { TYPE } from '@src/theme'
-import { computeSlippageAdjustedAmounts } from '@src/utils/prices'
+import {
+  computeSlippageAdjustedAmounts,
+  computeTradePriceBreakdown as computeTradePriceBreakdownUni
+} from '@src/utils/prices'
 
 import { AutoColumn } from '@src/components/Column'
 import QuestionHelper from '@src/components/QuestionHelper'
@@ -17,8 +20,12 @@ import { DEFAULT_PRECISION } from '@src/custom/constants'
 export function computeTradePriceBreakdown(
   trade?: TradeWithFee | null
 ): { priceImpactWithoutFee: Percent | undefined; realizedFee: CurrencyAmount | undefined | null } {
+  // This is needed because we are using Uniswap pools for the price calculation,
+  // thus, we need to account for the LP fees the same way as Uniswap does.
+  const { priceImpactWithoutFee } = computeTradePriceBreakdownUni(trade)
+
   return {
-    priceImpactWithoutFee: trade?.priceImpact,
+    priceImpactWithoutFee,
     realizedFee:
       trade?.tradeType === TradeType.EXACT_INPUT
         ? trade?.outputAmountWithoutFee?.subtract(trade.outputAmount)


### PR DESCRIPTION
# Summary

Closes #372 

Price impact was not accounting for ROUTE hops. Now it does.


# Comparison
 Uniswap | CowSwap
:---:|:---:
![screenshot_2021-04-19_13-33-10](https://user-images.githubusercontent.com/43217/115300203-881dbc00-a114-11eb-8210-a1fe09d7c198.png) | ![screenshot_2021-04-19_13-33-02](https://user-images.githubusercontent.com/43217/115300206-894ee900-a114-11eb-876c-c862b4323cdb.png)

# Testing
1. Open CowSwap in one tab and Uniswap in another tab
2. Connect the same wallet in the same network on both apps
3. Select the same token and amounts on both apps

- [x] The `Price impact` should be the same
