### PR TITLE
[443] Eth-Weth Flow: spinner fix + error message

### DIFF
--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -122,9 +122,10 @@ export default function EthWethWrap({ account, native, wrapped, wrapCallback }: 
   }, [isWrapPending])
 
   const handleWrap = useCallback(async () => {
-    try {
-      setError(null)
+    setError(null)
+    setLoading(true)
 
+    try {
       const txResponse = await wrapCallback()
       setPendingHash(txResponse.hash)
     } catch (error) {

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -132,6 +132,7 @@ export default function EthWethWrap({ account, native, wrapped, wrapCallback }: 
       console.error(error)
 
       setError(error)
+      setLoading(false)
     }
   }, [wrapCallback])
 

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -45,3 +45,8 @@ export const INPUT_OUTPUT_EXPLANATION = 'Only executed swaps incur fees.'
 export const DEFAULT_ORDER_DELAY = 20000 // 20s
 export const EXPIRED_ORDERS_BUFFER = 45 * 1000 // 45s
 export const CHECK_EXPIRED_ORDERS_INTERVAL = 10000 // 10 sec
+
+export const WETH_LOGO_URI =
+  'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png'
+export const XDAI_LOGO_URI =
+  'https://raw.githubusercontent.com/1Hive/default-token-list/master/src/assets/xdai/0xe91d153e0b41518a2ce8dd3d7944fa863463a97d/logo.png'

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -18,7 +18,7 @@ export enum WrapType {
 
 interface WrapUnwrapCallback {
   wrapType: WrapType
-  execute?: () => Promise<void>
+  execute?: () => Promise<TransactionResponse>
   inputError?: string
 }
 
@@ -46,7 +46,7 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
   const inputError = isZero ? `Enter an amount` : !sufficientBalance ? `Insufficient ${symbol} balance` : undefined
 
   // Create wrap/unwrap callback if sufficient balance
-  let wrapUnwrapCallback: (() => Promise<void>) | undefined
+  let wrapUnwrapCallback: (() => Promise<TransactionResponse>) | undefined
   if (sufficientBalance && inputAmount) {
     let wrapUnwrap: () => TransactionResponse
     let summary: string
@@ -63,9 +63,13 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
       try {
         const txReceipt = await wrapUnwrap()
         addTransaction(txReceipt, { summary })
+
+        return txReceipt
       } catch (error) {
         const actionName = WrapType.WRAP ? 'wrapping' : 'unwrapping'
         console.error(`Error ${actionName} ${symbol}`, error)
+
+        throw error.message ? error : new Error(error)
       }
     }
   }

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -24,6 +24,8 @@ import { SwapState } from 'state/swap/reducer'
 import { ParsedQs } from 'qs'
 import { BigNumber } from 'ethers'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
+import { WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
+import { WrappedTokenInfo } from '../lists/hooks'
 
 export * from '@src/state/swap/hooks'
 
@@ -229,10 +231,15 @@ interface CurrencyWithAddress {
 }
 
 export function useDetectNativeToken(input?: CurrencyWithAddress, output?: CurrencyWithAddress, chainId?: ChainId) {
-  const wrappedToken = WETH[chainId || DEFAULT_NETWORK_FOR_LISTS]
-  const native = ETHER
-
   return useMemo(() => {
+    const wrappedToken = new WrappedTokenInfo(
+      Object.assign(WETH[chainId || DEFAULT_NETWORK_FOR_LISTS], {
+        logoURI: chainId === ChainId.XDAI ? XDAI_LOGO_URI : WETH_LOGO_URI
+      } as WrappedTokenInfo['tokenInfo']),
+      []
+    )
+    const native = ETHER
+
     const [isNativeIn, isNativeOut] = [input?.currency === native, output?.currency === native]
     const [isWrappedIn, isWrappedOut] = [
       input?.address === wrappedToken.address,
@@ -247,7 +254,7 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
       wrappedToken,
       native
     }
-  }, [input, output, native, wrappedToken])
+  }, [input, output, chainId])
 }
 
 export function useIsFeeGreaterThanInput({


### PR DESCRIPTION
Part of #443 

Merges into base #462 

Changes:
1. waits for entire wrap flow disabling wrap button and showing spinner
  - relies on pending transactions hook
2. adds error handling and a message on reject/fail/error