### PR TITLE
Fee re-fetch improvements

### DIFF
--- a/src/custom/hooks/useRefetchFee.ts
+++ b/src/custom/hooks/useRefetchFee.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react'
+import { useAddFee, useClearFee } from '../state/fee/hooks'
+import { registerOnWindow } from '../utils/misc'
+import { FeeQuoteParams, getFeeQuote } from '../utils/operator'
+
+/**
+ * @returns callback that fetches a new quote and update the state
+ */
+export function useRefetchFeeCallback() {
+  const addFee = useAddFee()
+  const clearFee = useClearFee()
+  registerOnWindow({ addFee })
+
+  return useCallback(
+    async ({ sellToken, buyToken, amount, kind, chainId }: FeeQuoteParams) => {
+      // Get a new quote
+      const fee = await getFeeQuote({ chainId, sellToken, buyToken, amount, kind }).catch(err => {
+        console.error(new Error(err))
+        return null
+      })
+
+      if (fee) {
+        // Update quote
+        addFee({ sellToken, buyToken, amount, fee, chainId })
+      } else {
+        // Clear the fee
+        clearFee({ chainId, token: sellToken })
+      }
+    },
+    [addFee, clearFee]
+  )
+}

--- a/src/custom/state/fee/actions.ts
+++ b/src/custom/state/fee/actions.ts
@@ -1,6 +1,13 @@
 import { createAction } from '@reduxjs/toolkit'
 import { ChainId } from '@uniswap/sdk'
-import { FeeInformation } from './reducer'
+import { FeeInformationObject } from './reducer'
 
-export const updateFee = createAction<{ token: string; fee: FeeInformation; chainId: ChainId }>('fee/updateFee')
+export type AddFeeParams = FeeInformationObject
+
+export interface ClearFeeParams {
+  token: string // token address,
+  chainId: ChainId
+}
+
+export const updateFee = createAction<AddFeeParams>('fee/updateFee')
 export const clearFee = createAction<{ token: string; chainId: ChainId }>('fee/clearFee')

--- a/src/custom/state/fee/hooks.ts
+++ b/src/custom/state/fee/hooks.ts
@@ -1,18 +1,9 @@
-import { ChainId } from '@uniswap/sdk'
 import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { AppDispatch, AppState } from 'state'
-import { updateFee, clearFee } from './actions'
+import { updateFee, clearFee, AddFeeParams, ClearFeeParams } from './actions'
 import { FeeInformation, FeesMap } from './reducer'
-
-interface AddFeeParams extends ClearFeeParams {
-  fee: FeeInformation
-}
-interface ClearFeeParams {
-  token: string // token address,
-  chainId: ChainId
-}
 
 type AddFeeCallback = (addTokenParams: AddFeeParams) => void
 type ClearFeeCallback = (clearTokenParams: ClearFeeParams) => void

--- a/src/custom/state/fee/hooks.ts
+++ b/src/custom/state/fee/hooks.ts
@@ -5,8 +5,8 @@ import { AppDispatch, AppState } from 'state'
 import { updateFee, clearFee, AddFeeParams, ClearFeeParams } from './actions'
 import { FeeInformation, FeesMap } from './reducer'
 
-type AddFeeCallback = (addTokenParams: AddFeeParams) => void
-type ClearFeeCallback = (clearTokenParams: ClearFeeParams) => void
+type AddFeeCallback = (addFeeParams: AddFeeParams) => void
+type ClearFeeCallback = (clearFeeParams: ClearFeeParams) => void
 
 export const useAllFees = ({ chainId }: Partial<Pick<ClearFeeParams, 'chainId'>>): Partial<FeesMap> | undefined => {
   return useSelector<AppState, Partial<FeesMap> | undefined>(state => {

--- a/src/custom/state/fee/reducer.ts
+++ b/src/custom/state/fee/reducer.ts
@@ -3,6 +3,7 @@ import { ChainId } from '@uniswap/sdk'
 import { updateFee, clearFee } from './actions'
 import { Writable } from 'custom/types'
 import { PrefillStateRequired } from '../orders/reducer'
+import { FeeQuoteParams } from '@src/custom/utils/operator'
 
 export const EMPTY_FEE = {
   feeAsCurrency: undefined,
@@ -14,8 +15,7 @@ export interface FeeInformation {
   amount: string
 }
 
-export interface FeeInformationObject {
-  token: string // token address
+export interface FeeInformationObject extends Omit<FeeQuoteParams, 'kind'> {
   fee: FeeInformation
 }
 
@@ -46,8 +46,9 @@ export default createReducer(initialState, builder =>
   builder
     .addCase(updateFee, (state, action) => {
       prefillState(state, action)
-      const { token, fee, chainId } = action.payload
-      state[chainId][token] = { fee, token }
+
+      const { sellToken, chainId } = action.payload
+      state[chainId][sellToken] = action.payload
     })
     .addCase(clearFee, (state, action) => {
       prefillState(state, action)

--- a/src/custom/state/fee/updater.ts
+++ b/src/custom/state/fee/updater.ts
@@ -1,22 +1,62 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useActiveWeb3React } from 'hooks'
-import { useAddFee, useAllFees } from './hooks'
 import { useSwapState, tryParseAmount } from 'state/swap/hooks'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
-import { FeesMap } from './reducer'
-import { getFeeQuote, FeeQuoteParams } from 'utils/operator'
-import { registerOnWindow } from 'utils/misc'
 import { Field } from 'state/swap/actions'
 import { useCurrency } from 'hooks/Tokens'
 import useDebounce from 'hooks/useDebounce'
-
-function isDateLater(dateA: string, dateB: string): boolean {
-  const [parsedDateA, parsedDateB] = [Date.parse(dateA), Date.parse(dateB)]
-
-  return parsedDateA > parsedDateB
-}
+import { useAllFees } from './hooks'
+import { useRefetchFeeCallback } from '@src/custom/hooks/useRefetchFee'
+import { FeeQuoteParams } from '@src/custom/utils/operator'
+import { FeeInformationObject } from './reducer'
 
 const DEBOUNCE_TIME = 350
+const REFETCH_FEE_CHECK_INTERVAL = 15000 // Every 15s
+const RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME = 30000 // Will renew the quote if there's less than 30 seconds left for the quote to expire
+
+/**
+ * Returns true if the fee quote expires soon (in less than RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME milliseconds)
+ */
+function isExpiringSoon(quoteExpirationIsoDate: string): boolean {
+  const quoteExpirationDate = Date.parse(quoteExpirationIsoDate)
+  // const secondsLeft = (quoteExpirationDate.valueOf() - Date.now()) / 1000
+  // console.log(
+  //   `[state:fee:updater] Fee isExpiring in ${secondsLeft}. Refetch?`,
+  //   quoteExpirationDate <= Date.now() + RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME
+  // )
+
+  return quoteExpirationDate <= Date.now() + RENEW_FEE_QUOTES_BEFORE_EXPIRATION_TIME
+}
+
+/**
+ * Checks if the parameters for the current quote are correct
+ *
+ * Quotes are only valid for a given token-pair and amount. If any of these parameter change, the fee needs to be re-fetched
+ */
+function feeMatchesCurrentParameters(currentParams: FeeQuoteParams, feeInfo: FeeInformationObject): boolean {
+  const { amount: currentAmount, sellToken: currentSellToken, buyToken: currentBuyToken } = currentParams
+  const { amount, buyToken, sellToken } = feeInfo
+
+  return sellToken === currentSellToken && buyToken === currentBuyToken && amount === currentAmount
+}
+
+/**
+ *  Decides if we need to refetch the fee information given the current parameters (selected by the user), and the current feeInfo (in the state)
+ */
+function isRefetchQuoteRequired(currentParams: FeeQuoteParams, feeInfo?: FeeInformationObject): boolean {
+  if (feeInfo) {
+    // If the current parameters don't match the fee, the fee information is invalid and needs to be re-fetched
+    if (!feeMatchesCurrentParameters(currentParams, feeInfo)) {
+      return true
+    }
+
+    // Re-fetch if the quote is expiring soon
+    return isExpiringSoon(feeInfo.fee.expirationDate)
+  } else {
+    // If there's no fee information, we always re-fetch
+    return true
+  }
+}
 
 export default function FeesUpdater(): null {
   const { chainId } = useActiveWeb3React()
@@ -26,75 +66,62 @@ export default function FeesUpdater(): null {
     independentField,
     typedValue: rawTypedValue
   } = useSwapState()
-  // debounce the typed value as to not overkill the useEffect
-  // fee API calculation/call
+
+  // Debounce the typed value to not refetch the fee too often
+  // Fee API calculation/call
   const typedValue = useDebounce(rawTypedValue, DEBOUNCE_TIME)
 
-  // to not rerun useEffect and check if amount really changed
-  const typedValueRef = useRef(typedValue)
+  // Keep the typed value for the last refetch of the fee
+  // const lastTypedValueUsedRef = useRef(typedValue)
 
   const sellCurrency = useCurrency(sellToken)
   const buyCurrency = useCurrency(buyToken)
+  const feesMap = useAllFees({ chainId })
+  const quoteInfo = feesMap && sellToken ? feesMap[sellToken] : undefined
 
-  const stateFeesMap = useAllFees({ chainId })
-  const addFee = useAddFee()
-
+  const refetchFee = useRefetchFeeCallback()
   const windowVisible = useIsWindowVisible()
 
-  const now = new Date().toISOString()
-
+  // Update if any parameter is changing
   useEffect(() => {
-    if (!stateFeesMap || !chainId || !sellToken || !buyToken || !typedValue || !windowVisible) return
-
-    registerOnWindow({ addFee })
+    // Don't refetch if window is not visible, or some parameter is missing
+    if (!chainId || !sellToken || !buyToken || !typedValue || !windowVisible) return
 
     const kind = independentField === Field.INPUT ? 'sell' : 'buy'
     const amount = tryParseAmount(typedValue, (kind === 'sell' ? sellCurrency : buyCurrency) ?? undefined)
 
-    // type check...
+    // Don't refetch if the amount is missing
     if (!amount) return
 
-    async function runFeeHook({
-      feesMap,
-      chainId,
-      sellToken,
-      buyToken,
-      amount,
-      kind
-    }: FeeQuoteParams & { feesMap: Partial<FeesMap> }) {
-      const currentFee = feesMap[sellToken]?.fee
-      const isFeeDateValid = currentFee && isDateLater(currentFee.expirationDate, now)
-
-      if (typedValueRef.current !== typedValue || !isFeeDateValid || !currentFee) {
-        const fee = await getFeeQuote({ chainId, sellToken, buyToken, amount, kind }).catch(err => {
-          console.error(new Error(err))
-          return null
-        })
-
-        typedValueRef.current = typedValue
-
-        fee &&
-          addFee({
-            token: sellToken,
-            fee,
-            chainId
-          })
+    // Callback to re-fetch (when required)
+    const refetchFeeIfRequired = () => {
+      const quoteParams = { buyToken, chainId, sellToken, kind, amount: amount.raw.toString() }
+      if (isRefetchQuoteRequired(quoteParams, quoteInfo)) {
+        refetchFee(quoteParams).catch(error => console.error('Error re-fetching the fee', error))
       }
     }
 
-    runFeeHook({ feesMap: stateFeesMap, sellToken, buyToken, chainId, kind, amount: amount.raw.toString() })
+    // Refetch fee if any parameter changes
+    refetchFeeIfRequired()
+
+    // Periodically re-fetch the fee, even if the user don't change the parameters
+    // Note that refetchFee won't refresh if it doesn't need to (i.e. the quote is valid for a long time)
+    const intervalId = setInterval(() => {
+      refetchFeeIfRequired()
+    }, REFETCH_FEE_CHECK_INTERVAL)
+
+    return () => clearInterval(intervalId)
   }, [
     windowVisible,
     chainId,
-    now,
-    addFee,
-    stateFeesMap,
     sellToken,
     buyToken,
     independentField,
     typedValue,
     sellCurrency,
-    buyCurrency
+    buyCurrency,
+    quoteInfo,
+    refetchFee
   ])
 
   return null

--- a/src/custom/state/fee/updater.ts
+++ b/src/custom/state/fee/updater.ts
@@ -6,7 +6,7 @@ import { Field } from 'state/swap/actions'
 import { useCurrency } from 'hooks/Tokens'
 import useDebounce from 'hooks/useDebounce'
 import { useAllFees } from './hooks'
-import { useRefetchFeeCallback } from '@src/custom/hooks/useRefetchFee'
+import { useRefetchFeeCallback } from 'hooks/useRefetchFee'
 import { FeeQuoteParams } from '@src/custom/utils/operator'
 import { FeeInformationObject } from './reducer'
 

--- a/src/custom/state/fee/updater.ts
+++ b/src/custom/state/fee/updater.ts
@@ -71,9 +71,6 @@ export default function FeesUpdater(): null {
   // Fee API calculation/call
   const typedValue = useDebounce(rawTypedValue, DEBOUNCE_TIME)
 
-  // Keep the typed value for the last refetch of the fee
-  // const lastTypedValueUsedRef = useRef(typedValue)
-
   const sellCurrency = useCurrency(sellToken)
   const buyCurrency = useCurrency(buyToken)
   const feesMap = useAllFees({ chainId })

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -178,16 +178,10 @@ export type FeeQuoteParams = Pick<OrderMetaData, 'sellToken' | 'buyToken' | 'kin
   chainId: ChainId
 }
 
-export async function getFeeQuote({
-  sellToken,
-  buyToken,
-  amount,
-  kind,
-  chainId
-}: FeeQuoteParams): Promise<FeeInformation> {
-  const independentToken = kind === 'buy' ? buyToken : sellToken
+export async function getFeeQuote(params: FeeQuoteParams): Promise<FeeInformation> {
+  const { sellToken, buyToken, amount, kind, chainId } = params
   const [checkedSellAddress, checkedBuyAddress] = [checkIfEther(sellToken, chainId), checkIfEther(buyToken, chainId)]
-  console.log('[util:operator] Get fee for ', chainId, independentToken)
+  console.log('[util:operator] Get fee from API', params)
 
   let response: Response | undefined
   try {


### PR DESCRIPTION
## Description
This PR tries to improve the updater of the state for the fee.

There was some issues that motivated this PR (Closes #456, Closes #472)

Additionally, there were some errors reported that the when we sign the transaction, the API doesn't accept the fee amount anymore, this is because the quote expires while the user is signing the trade. To reduce these cases, and to give early feedback to the user, this PR also **Re-fetch a new quote when there's less than 30 seconds left for it's expiration**

## Summary of the new logic
* Makes sure we don't re-fetch the fee if the quote parameters don't change
* ...unless, the quote is about to expire (<30 seconds)
* Adds a periodic check (every 15seconds)

## Some technical hints on the changes
* Refactors the updater. 
   * Same logic is executed for the periodic checks, or for the change of parameters `refetchFeeIfRequired` function 
   * The part of actually making the API call and updating the state was removed from the updater logic. Now it has it's own hook `useRefetchFeeCallback`
   * `isExpiringSoon` and `feeMatchesCurrentParameters` are functions used by the updater to decide if the current quote is still valid.
* The new hook `useRefetchFeeCallback`, now also clears the fee if the API returns `null`. We never notice, but is my understanding that this should be the behaviour


## Changes of state
I notice that the state only had the fee information per sellToken. I included all the other parameters that are required for the API, because now this is actually used to assess if the token information in the state is valid for the current parameters selected in the swap widget.

This is used in `feeMatchesCurrentParameters` in the updater
