### PR TITLE
422/api prod urls

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -26,9 +26,12 @@ REACT_APP_FORTMATIC_KEY="pk_live_F937DF033A1666BF"
 REACT_APP_GOOGLE_ANALYTICS_ID="UA-190948266-1"
 
 # API
-#REACT_APP_API_BASE_URL_MAINNET=https://protocol-mainnet.dev.gnosisdev.com/api/v1
-#REACT_APP_API_BASE_URL_RINKEBY=https://protocol-rinkeby.dev.gnosisdev.com/api/v1
-#REACT_APP_API_BASE_URL_XDAI=https://protocol-xdai.dev.gnosisdev.com/api/v1
+#REACT_APP_API_URL_PROD_MAINNET=https://protocol-mainnet.gnosis.io/api
+#REACT_APP_API_URL_PROD_RINKEBY=https://protocol-rinkeby.gnosis.io/api
+#REACT_APP_API_URL_PROD_XDAI=https://protocol-xdai.gnosis.io/api
+#REACT_APP_API_URL_STAGING_MAINNET=https://protocol-mainnet.dev.gnosisdev.com/api
+#REACT_APP_API_URL_STAGING_RINKEBY=https://protocol-rinkeby.dev.gnosisdev.com/api
+#REACT_APP_API_URL_STAGING_XDAI=https://protocol-xdai.dev.gnosisdev.com/api
 
 # EXPLORER
 #REACT_APP_EXPLORER_URL_DEV=https://protocol-explorer.dev.gnosisdev.com

--- a/README.md
+++ b/README.md
@@ -70,14 +70,17 @@ To have the interface default to a different network when a wallet is not connec
 1. Make a copy of `.env` named `.env.local`
 2. Change `REACT_APP_NETWORK_ID` to `"{YOUR_NETWORK_ID}"`. This will be your default network id
 3. Define your own list of supported networks:
+
 ```ini
 REACT_APP_SUPPORTED_CHAIN_IDS="1,4,100"
 REACT_APP_NETWORK_URL_1=https://mainnet.infura.io/v3/{YOUR_INFURA_KEY}
 REACT_APP_NETWORK_URL_4=https://rinkeby.infura.io/v3/{YOUR_INFURA_KEY}
 REACT_APP_NETWORK_URL_100=https://rpc.xdaichain.com
-``` 
+```
+
 4. Change `REACT_APP_ID` Ask for your id at [chat.gnosis.io](https://chat.gnosis.io)
-5. Change `REACT_APP_API_BASE_URL_{XDAI|RINKEBY|MAINNET}` to e.g. `"http://localhost:8080/api/v1"` when running the services locally.
+5. Change `REACT_APP_API_STAGING_URL_{XDAI|RINKEBY|MAINNET}` to e.g. `"http://localhost:8080/api"` when running the services locally.
 
 For production:
+
 6. Get your own `App Id` in <https://discord.gg/egGzDDctuC>, and set it in `REACT_APP_ID`.

--- a/src/custom/utils/environments.ts
+++ b/src/custom/utils/environments.ts
@@ -1,6 +1,6 @@
-export function checkEnvironment(host: string) {
-  const getRegex = (regex: string | undefined) => (regex ? new RegExp(regex) : undefined)
+const getRegex = (regex: string | undefined) => (regex ? new RegExp(regex) : undefined)
 
+export function checkEnvironment(host: string) {
   const domainDevRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_DEV)
   const domainStagingRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_STAGING)
   const domainProdRegex = getRegex(process.env.REACT_APP_DOMAIN_REGEX_PROD)

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -2,18 +2,28 @@ import { ChainId, ETHER, WETH } from '@uniswap/sdk'
 import { getSigningSchemeApiValue, OrderCreation } from 'utils/signatures'
 import { APP_ID } from 'constants/index'
 import { registerOnWindow } from './misc'
+import { isProd, isStaging } from './environments'
 import { FeeInformation } from 'state/fee/reducer'
 
-/**
- * See Swagger documentation:
- *    https://protocol-rinkeby.dev.gnosisdev.com/api/
- */
-const API_BASE_URL: Partial<Record<ChainId, string>> = {
-  [ChainId.MAINNET]: process.env.REACT_APP_API_BASE_URL_MAINNET || 'https://protocol-mainnet.dev.gnosisdev.com/api/v1',
-  [ChainId.RINKEBY]: process.env.REACT_APP_API_BASE_URL_RINKEBY || 'https://protocol-rinkeby.dev.gnosisdev.com/api/v1',
-  [ChainId.XDAI]: process.env.REACT_APP_API_BASE_URL_XDAI || 'https://protocol-xdai.dev.gnosisdev.com/api/v1'
+function getOperatorUrl(): Partial<Record<ChainId, string>> {
+  if (isProd || isStaging) {
+    return {
+      [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'https://protocol-mainnet.gnosis.io/api',
+      [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'https://protocol-rinkeby.gnosis.io/api',
+      [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'https://protocol-xdai.gnosis.io/api'
+    }
+  } else {
+    return {
+      [ChainId.MAINNET]:
+        process.env.REACT_APP_API_URL_STAGING_MAINNET || 'https://protocol-mainnet.dev.gnosisdev.com/api',
+      [ChainId.RINKEBY]:
+        process.env.REACT_APP_API_URL_STAGING_RINKEBY || 'https://protocol-rinkeby.dev.gnosisdev.com/api',
+      [ChainId.XDAI]: process.env.REACT_APP_API_URL_STAGING_XDAI || 'https://protocol-xdai.dev.gnosisdev.com/api'
+    }
+  }
 }
-console.log('[util:operator] API_BASE_URL', API_BASE_URL)
+
+const API_BASE_URL = getOperatorUrl()
 
 const DEFAULT_HEADERS = {
   'Content-Type': 'application/json',
@@ -59,7 +69,7 @@ function _getApiBaseUrl(chainId: ChainId): string {
   if (!baseUrl) {
     throw new Error('Unsupported Network. The operator API is not deployed in the Network ' + chainId)
   } else {
-    return baseUrl
+    return baseUrl + '/v1'
   }
 }
 


### PR DESCRIPTION
# Summary

Closes #422 

Follow up to #421
Same thing as https://github.com/gnosis/gp-ui/pull/385, but for CowSwap

Uses a different operator api endpoint url according to the deployed environment.

Defaults to staging operator api endpoint.

# Testing

Open the version deployed in this PR and verify that calls to operator API go to their staging, which depending on the network will be:

```
https://protocol-mainnet.dev.gnosisdev.com/api
https://protocol-rinkeby.dev.gnosisdev.com/api
https://protocol-xdai.dev.gnosisdev.com/api
```

The next step is can only be tested when deployed to staging/prod.
Verify calls to operator API go to their prod:

```
https://protocol-mainnet.gnosis.io/api
https://protocol-rinkeby.gnosis.io/api
https://protocol-xdai.gnosis.io/api
```
