### PR TITLE
Enhance ETH wrap styling.

### DIFF
--- a/src/custom/components/swap/EthWethWrap/WrapCard.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrapCard.tsx
@@ -18,6 +18,7 @@ const WrapCardWrapper = styled.div`
   justify-content: center;
   flex: 1;
   padding: 8px;
+  border-radius: 0 6px 6px 0;
 
   > img {
     width: 32px;

--- a/src/custom/components/swap/EthWethWrap/WrapCard.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrapCard.tsx
@@ -60,7 +60,7 @@ export const WrapCardContainer = styled.div`
     width: 24px;
     height: 24px;
     border-radius: 24px;
-      padding: 3px;
+    padding: 3px;
   }
 `
 

--- a/src/custom/components/swap/EthWethWrap/WrapCard.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrapCard.tsx
@@ -7,18 +7,9 @@ import { DEFAULT_PRECISION } from 'constants/index'
 const BalanceLabel = styled.p<{ background?: string }>`
   display: flex;
   justify-content: center;
-  margin: 8px 0;
+  margin: 0 0 4px;
+  font-size: 13px;
   width: 100%;
-
-  border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
-
-  background: ${({ background = 'initial' }) => background};
-
-  > span {
-    &:first-child {
-      margin-right: 3.2px;
-    }
-  }
 `
 
 const WrapCardWrapper = styled.div`
@@ -27,36 +18,48 @@ const WrapCardWrapper = styled.div`
   justify-content: center;
   flex: 1;
   padding: 8px;
+
+  > img {
+    width: 32px;
+    height: 32px;
+    margin: 0 0 14px;
+    box-shadow: none;
+  }
 `
 
 export const WrapCardContainer = styled.div`
   position: relative;
   ${({ theme }) => theme.flexRowNoWrap}
-  border: 2.4px solid ${({ theme }) => theme.bg1};
+  border: 2px solid ${({ theme }) => theme.bg1};
   border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
-  margin: 11.2px 0;
+  margin: 12px 0;
   width: 100%;
+  min-height: 140px;
 
   > ${WrapCardWrapper} {
     &:nth-of-type(even) {
       background-color: ${({ theme }) => theme.bg1};
     }
 
-    > ${BalanceLabel}:last-child {
+    > ${BalanceLabel}:last-of-type{
       margin: 0;
+      font-size: 12px;
     }
   }
 
   // arrow
   > svg {
     position: absolute;
-    left: calc(50% - 15px);
-    top: calc(50% - 15px);
-    border-radius: 100%;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    margin: auto;
     background: ${({ theme }) => theme.white};
-    width: 30px;
-    height: 30px;
-    padding: 5px;
+    width: 24px;
+    height: 24px;
+    border-radius: 24px;
+      padding: 3px;
   }
 `
 
@@ -80,10 +83,7 @@ export function WrapCard(props: WrapCardProps) {
         </strong>
       </BalanceLabel>
       {/* user balance */}
-      <BalanceLabel>
-        <span>Balance: </span>
-        <span>{balance?.toSignificant(DEFAULT_PRECISION) || '-'}</span>
-      </BalanceLabel>
+      <BalanceLabel>Balance: {balance?.toSignificant(DEFAULT_PRECISION) || '-'}</BalanceLabel>
     </WrapCardWrapper>
   )
 }

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -62,8 +62,9 @@ const WarningWrapper = styled(Wrapper)`
 const BalanceLabel = styled.p<{ background?: string }>`
   display: flex;
   justify-content: space-between;
-  width: 90%;
-  padding: 8px 11.2px;
+  text-align: center;
+  width: 100%;
+  padding: 12px;
   margin: 8px 0;
   border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
   background: ${({ background = 'initial' }) => background};

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -20,18 +20,17 @@ const Wrapper = styled.div`
   background: ${({ theme }) => theme.bg2};
   align-items: center;
   justify-content: center;
-  margin: 4.8px auto 0;
-  padding: 16px;
+  margin: 24px auto 0;
+  padding: 14px 14px 22px;
   width: 100%;
-
   border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
   font-size: smaller;
 
   > ${ButtonPrimary} {
       background: #62d9ff;
-      width: 75%;
-      padding: 6.4px;
-      margin-top: 4.8px;
+      width: 100%;
+      padding: 6px;
+      margin: 6px auto 0;
 
       &:disabled {
         background-color: ${({ theme }) => theme.disabled}
@@ -41,14 +40,14 @@ const Wrapper = styled.div`
 const WarningWrapper = styled(Wrapper)`
   ${({ theme }) => theme.flexRowNoWrap}
   padding: 0;
-
-  color: ${({ theme }) => theme.red1};
-  font-weight: 600;
+  margin: 0;
+  color: ${({ theme }) => theme.redShade};
+  font-weight: bold;
   font-size: small;
 
   // warning logo
   > svg {
-    margin-right: 8px;
+    margin: 0 8px 0 0;
   }
 
   // warning text
@@ -56,7 +55,7 @@ const WarningWrapper = styled(Wrapper)`
     ${({ theme }) => theme.flexColumnNoWrap}
     align-items: flex-start;
     justify-content: center;
-    font-size: 90%;
+    font-size: 14px;
   }
 `
 
@@ -66,29 +65,27 @@ const BalanceLabel = styled.p<{ background?: string }>`
   width: 90%;
   padding: 8px 11.2px;
   margin: 8px 0;
-
   border-radius: ${({ theme }) => theme.buttonPrimary.borderRadius};
-
   background: ${({ background = 'initial' }) => background};
 
   > span {
-    &:first-child {
+    &:first-of-type {
       margin-right: auto;
     }
   }
 `
 
 const ErrorWrapper = styled(BalanceLabel)`
-  font-size: x-small;
-  background-color: #ff000040;
-  color: ${({ theme }) => theme.red1};
+  width: 100%;
+  margin: 12px auto 0;
+  font-size: 12px;
+  background-color: #ffefea;
+  color: ${({ theme }) => theme.redShade};
 `
 
 const ErrorMessage = ({ error }: { error: Error }) => (
   <ErrorWrapper>
-    <i>
-      <strong>{error.message}</strong>
-    </i>
+    <strong>{error.message}</strong>
   </ErrorWrapper>
 )
 
@@ -137,9 +134,7 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
       <WarningWrapper>
         <AlertTriangle size={25} />
         <div>
-          <span>
-            To sell {nativeSymbol}, first wrap or switch to {wrappedSymbol}
-          </span>
+          Wrap your {nativeSymbol} first or switch to {wrappedSymbol}!
         </div>
       </WarningWrapper>
       {error && <ErrorMessage error={error} />}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -470,16 +470,16 @@ export default function Swap({
                     </RowBetween>
                   )}
                   {isFeeGreater && fee && <FeeGreaterMessage fee={fee} />}
-                  {isNativeIn && onWrap && (
-                    <EthWethWrapMessage
-                      account={account ?? undefined}
-                      native={native}
-                      userInput={parsedAmount}
-                      wrapped={wrappedToken}
-                      wrapCallback={onWrap}
-                    />
-                  )}
                 </AutoColumn>
+                {isNativeIn && onWrap && (
+                  <EthWethWrapMessage
+                    account={account ?? undefined}
+                    native={native}
+                    userInput={parsedAmount}
+                    wrapped={wrappedToken}
+                    wrapCallback={onWrap}
+                  />
+                )}
               </Card>
             )}
           </AutoColumn>

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -51,7 +51,8 @@ export function colors(darkMode: boolean): Colors {
     blue1: '#3F77FF',
     purple: '#8958FF',
     border: darkMode ? '#3a3b5a' : 'rgb(58 59 90 / 10%)',
-    disabled: darkMode ? '#31323e' : 'rgb(237, 238, 242)'
+    disabled: darkMode ? '#31323e' : 'rgb(237, 238, 242)',
+    redShade: darkMode ? '#AE2C00' : '#AE2C00'
   }
 }
 

--- a/src/custom/theme/styled.d.ts
+++ b/src/custom/theme/styled.d.ts
@@ -5,6 +5,7 @@ export { Color, Grids } from '@src/theme/styled'
 // Override colors
 export interface Colors extends ColorsUniswap {
   purple: Color
+  redShade: Color
   border: Color
   disabled: Color
 }


### PR DESCRIPTION
Enhances styling of the ETH wrap component created by @W3stside :
<img width="399" alt="Screen Shot 2021-04-22 at 17 23 24" src="https://user-images.githubusercontent.com/31534717/115740954-99bec800-a38f-11eb-992d-3ca89f2c158f.png">
<img width="528" alt="Screen Shot 2021-04-22 at 17 19 07" src="https://user-images.githubusercontent.com/31534717/115740965-9b888b80-a38f-11eb-9986-614309590edd.png">
