### PR TITLE
Fix Footer width

### DIFF
--- a/src/custom/components/Footer/index.tsx
+++ b/src/custom/components/Footer/index.tsx
@@ -18,6 +18,7 @@ const Wrapper = styled.div`
 `
 
 const FooterWrapper = styled.div`
+  width: 100%;
   ${({ theme }) => theme.mediaWidth.upToMedium`
     display: none;
   `}


### PR DESCRIPTION
Footer got a new wrapper and needed 100% width

Before
![Screenshot from 2021-04-23 09-35-05](https://user-images.githubusercontent.com/21335563/115844396-aedf3980-a417-11eb-8bfa-4321fbb1f650.png)


After
![Screenshot from 2021-04-23 09-37-06](https://user-images.githubusercontent.com/21335563/115844359-a981ef00-a417-11eb-8b50-80e0fcc3127f.png)
