### PR TITLE
Refactor internal links

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,5 @@
     "@anxolin/walletconnect-connector": "6.1.9",
     "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.17",
     "@uniswap/default-token-list": "^2.0.0",
-    "react-router-hash-link": "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -144,6 +144,6 @@
   "dependencies": {
     "@anxolin/walletconnect-connector": "6.1.9",
     "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.17",
-    "@uniswap/default-token-list": "^2.0.0",
+    "@uniswap/default-token-list": "^2.0.0"
   }
 }

--- a/src/custom/components/ContentLink/index.tsx
+++ b/src/custom/components/ContentLink/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import HashLink from 'components/HashLink'
 
 export function ContentLink (props: { href: string; children: React.ReactNode }): JSX.Element {

--- a/src/custom/components/ContentLink/index.tsx
+++ b/src/custom/components/ContentLink/index.tsx
@@ -1,0 +1,14 @@
+import HashLink from 'components/HashLink'
+
+export function ContentLink (props: { href: string; children: React.ReactNode }): JSX.Element {
+  const isExternalLink = /^(https?:)?\/\//.test(props.href)
+  return isExternalLink ? (
+    <a target="_blank" href={props.href} rel="noopener noreferrer">
+      {props.children}
+    </a>
+  ) : (
+    <HashLink href={props.href} to={props.href}>
+      {props.children}
+    </HashLink>
+  )
+}

--- a/src/custom/components/MarkdownPage/index.tsx
+++ b/src/custom/components/MarkdownPage/index.tsx
@@ -2,8 +2,9 @@ import React, { ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown/with-html'
 import { ReactMarkdownPropsBase } from 'react-markdown'
 import useFetchFile from 'hooks/useFetchFile'
-import { HeadingRenderer, LinkRenderer } from './renderers'
+import { HeadingRenderer } from './renderers'
 import Page, { Title, Content } from 'components/Page'
+import { ContentLink } from 'components/ContentLink'
 import styled from 'styled-components'
 import { WithClassName } from 'types'
 // import ScrollToTop from '../ScrollToTop'
@@ -16,7 +17,7 @@ interface MarkdownParams extends WithClassName {
 export const Wrapper = styled(Page)``
 
 const CustomReactMarkdown = (props: ReactMarkdownPropsBase & { children: string }) => (
-  <ReactMarkdown {...props} renderers={{ heading: HeadingRenderer, link: LinkRenderer }} allowDangerousHtml />
+  <ReactMarkdown {...props} renderers={{ heading: HeadingRenderer, link: ContentLink }} allowDangerousHtml />
 )
 
 export default function Markdown({ content, title, className }: MarkdownParams) {

--- a/src/custom/components/MarkdownPage/renderers.tsx
+++ b/src/custom/components/MarkdownPage/renderers.tsx
@@ -2,8 +2,6 @@ import React, { ReactNode } from 'react'
 import visit from 'unist-util-visit'
 import { Node as MarkdownNode } from 'unist'
 
-import HashLink from 'components/HashLink'
-
 const constructId = (text: string): string => text.toLowerCase().replace(/\W/g, '-')
 
 const getTextFromMarkdownNode = (node: MarkdownNode): string => {
@@ -23,7 +21,7 @@ interface HeadingProps {
   children: ReactNode
   node: MarkdownNode & { type: 'heading' }
 }
-const HeadingRenderer = ({ level, children, node }: HeadingProps): JSX.Element => {
+export function HeadingRenderer ({ level, children, node }: HeadingProps): JSX.Element {
   // traverse markdown syntax tree node
   // and get text
   const nodeText = getTextFromMarkdownNode(node)
@@ -32,18 +30,3 @@ const HeadingRenderer = ({ level, children, node }: HeadingProps): JSX.Element =
   const HComp = ('h' + level) as keyof JSX.IntrinsicElements
   return <HComp id={id}>{children}</HComp>
 }
-
-const LinkRenderer = (props: { href: string; children: React.ReactNode }) => {
-  const isExternalLink = /^(https?:)?\/\//.test(props.href)
-  return isExternalLink ? (
-    <a target="_blank" href={props.href} rel="noopener noreferrer">
-      {props.children}
-    </a>
-  ) : (
-    <HashLink href={props.href} to={props.href}>
-      {props.children}
-    </HashLink>
-  )
-}
-
-export { HeadingRenderer, LinkRenderer }

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react'
 import Page, { Content, Title } from 'components/Page'
 import styled from 'styled-components'
-import { LinkRenderer } from 'components/MarkdownPage/renderers'
+import { ContentLink } from 'components/ContentLink'
 
 const Wrapper = styled.div`
   h2 {
@@ -90,11 +90,11 @@ export default function Faq() {
         <Content>
           {toc.map(({ section, items }) => (
             <div key={section.id}>
-              <LinkRenderer href={'#' + section.id}>{section.label}</LinkRenderer>
+              <ContentLink href={'#' + section.id}>{section.label}</ContentLink>
               <ul>
                 {items.map(tocItem => (
                   <li key={tocItem.id}>
-                    <LinkRenderer href={'#' + tocItem.id}>{tocItem.label}</LinkRenderer>
+                    <ContentLink href={'#' + tocItem.id}>{tocItem.label}</ContentLink>
                   </li>
                 ))}
               </ul>

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import Page, { Content, Title } from 'components/Page'
 import styled from 'styled-components'
-import { Link } from 'react-router-dom'
-import { HashLink } from 'react-router-hash-link'
+import { LinkRenderer } from 'components/MarkdownPage/renderers'
 
 const Wrapper = styled.div`
   h2 {
@@ -91,15 +90,11 @@ export default function Faq() {
         <Content>
           {toc.map(({ section, items }) => (
             <div key={section.id}>
-              <HashLink smooth to={'#' + section.id}>
-                {section.label}
-              </HashLink>
+              <LinkRenderer href={'#' + section.id}>{section.label}</LinkRenderer>
               <ul>
                 {items.map(tocItem => (
                   <li key={tocItem.id}>
-                    <HashLink smooth to={'#' + tocItem.id}>
-                      {tocItem.label}
-                    </HashLink>
+                    <LinkRenderer href={'#' + tocItem.id}>{tocItem.label}</LinkRenderer>
                   </li>
                 ))}
               </ul>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14325,13 +14325,6 @@ react-router-dom@^5.0.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router-hash-link@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-router-hash-link/-/react-router-hash-link-2.4.0.tgz#216045d9bb826e5f36f873dea8b04874a0708f83"
-  integrity sha512-HGbB9kfODHKsHvMVsPbqDr057V4xg4TNNRaQcezsFMKitwHaaU51cM2+gDyX45y9YLLPbovELz2rpNx2C3Frng==
-  dependencies:
-    prop-types "^15.7.2"
-
 react-router@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"


### PR DESCRIPTION
Tries to refactor and unify the internal links

Markdown component defined a custom content link, called `LinkRendered`

* This PR renames this component to `ContentLink` and moves it to its own component
* Makes FAQ use `ContentLink` instead
* `ContentLink` was delegating into our own `HashLink` wich now gets replaced by the one in the library. https://www.npmjs.com/package/react-router-hash-link

The library is quite nice! has over 100K weekly downloads, its simple and it gives us smooth scroll too (which this PR adds as the default for the `ContentLinks`.


## Test

You can test the links in thr FAQ, and also in the privacy policy (if you uncomment `pages/App/index.tsx`).
You will see now the privacy policy has this nice smooth scroll behaviour. 