### PR TITLE
Add cowswap dev domains

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -13,8 +13,8 @@ REACT_APP_PORTIS_ID="c0e2bf01-4b08-4fd5-ac7b-8e26b58cd236"
 REACT_APP_FORTMATIC_KEY="pk_live_F937DF033A1666BF"
 
 # Domain
-REACT_APP_DOMAIN_REGEX_DEV="^(:?cow-trade\.dev|localhost:\d{2,5}|pr\\d+--gpswapui\.review)"
-REACT_APP_DOMAIN_REGEX_STAGING="^cow-trade\.staging"
+REACT_APP_DOMAIN_REGEX_DEV="^(:?cowswap\.dev|cow-trade\.dev|localhost:\d{2,5}|pr\\d+--gpswapui\.review)"
+REACT_APP_DOMAIN_REGEX_STAGING="^(:?cowswap\.staging|cow-trade\.staging)"
 REACT_APP_DOMAIN_REGEX_PROD="^cowswap\.exchange$"
 REACT_APP_DOMAIN_REGEX_ENS="^cowswap\.eth"
 

--- a/src/custom/utils/operator.ts
+++ b/src/custom/utils/operator.ts
@@ -2,17 +2,11 @@ import { ChainId, ETHER, WETH } from '@uniswap/sdk'
 import { getSigningSchemeApiValue, OrderCreation } from 'utils/signatures'
 import { APP_ID } from 'constants/index'
 import { registerOnWindow } from './misc'
-import { isProd, isStaging } from './environments'
+import { isDev } from './environments'
 import { FeeInformation } from 'state/fee/reducer'
 
 function getOperatorUrl(): Partial<Record<ChainId, string>> {
-  if (isProd || isStaging) {
-    return {
-      [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'https://protocol-mainnet.gnosis.io/api',
-      [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'https://protocol-rinkeby.gnosis.io/api',
-      [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'https://protocol-xdai.gnosis.io/api'
-    }
-  } else {
+  if (isDev) {
     return {
       [ChainId.MAINNET]:
         process.env.REACT_APP_API_URL_STAGING_MAINNET || 'https://protocol-mainnet.dev.gnosisdev.com/api',
@@ -20,6 +14,13 @@ function getOperatorUrl(): Partial<Record<ChainId, string>> {
         process.env.REACT_APP_API_URL_STAGING_RINKEBY || 'https://protocol-rinkeby.dev.gnosisdev.com/api',
       [ChainId.XDAI]: process.env.REACT_APP_API_URL_STAGING_XDAI || 'https://protocol-xdai.dev.gnosisdev.com/api'
     }
+  }
+
+  // Production, staging, ens, ...
+  return {
+    [ChainId.MAINNET]: process.env.REACT_APP_API_URL_PROD_MAINNET || 'https://protocol-mainnet.gnosis.io/api',
+    [ChainId.RINKEBY]: process.env.REACT_APP_API_URL_PROD_RINKEBY || 'https://protocol-rinkeby.gnosis.io/api',
+    [ChainId.XDAI]: process.env.REACT_APP_API_URL_PROD_XDAI || 'https://protocol-xdai.gnosis.io/api'
   }
 }
 


### PR DESCRIPTION
This PR does two things:
- Prepares for the domain changes devops is working on https://gnosisinc.slack.com/archives/C6Z2XNL5Q/p1619423324478900 . This will rename the DEV, STAGING domains
- Fixes a coherence issue witht he Explorer link and the API


The coherence issue was that, is explained in #520 
- Basically, we will use for DEV (local, Praul, DEV) the development endpoints
- For everything else, we will use the production ones