### PR TITLE
Gas Prices by ChainId in global state

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -67,3 +67,17 @@ export const LOW_NATIVE_BALANCE_THRESHOLD = new Fraction('1', '10')
 export const CODE_LINK = 'https://github.com/gnosis/gp-v2-contracts'
 export const DISCORD_LINK = 'https://discord.gg/egGzDDctuC'
 export const DUNE_DASHBOARD_LINK = 'https://duneanalytics.com/gnosis.protocol/Gnosis-Protocol-V2'
+
+// 30 minutes
+export const GAS_PRICE_UPDATE_THRESHOLD = 30 * 60 * 1000
+export const GAS_FEE_ENDPOINTS = {
+  [ChainId.MAINNET]: 'https://safe-relay.gnosis.io/api/v1/gas-station/',
+  // No ropsten = main
+  [ChainId.ROPSTEN]: 'https://safe-relay.gnosis.io/api/v1/gas-station/',
+  [ChainId.RINKEBY]: 'https://safe-relay.rinkeby.gnosis.io/api/v1/gas-station/',
+  [ChainId.GÖRLI]: 'https://safe-relay.goerli.gnosis.io/api/v1/gas-station/',
+  // no kovan = main
+  [ChainId.KOVAN]: 'https://safe-relay.kovan.gnosis.io/api/v1/gas-station/',
+  // TODO: xdai? = main
+  [ChainId.XDAI]: 'https://safe-relay.gnosis.io/api/v1/gas-station/'
+}

--- a/src/custom/state/gas/actions.ts
+++ b/src/custom/state/gas/actions.ts
@@ -1,0 +1,7 @@
+import { createAction } from '@reduxjs/toolkit'
+import { WithChainId } from '../lists/actions'
+import { GasFeeEndpointResponse } from './hooks'
+
+export type UpdateGasPrices = GasFeeEndpointResponse & WithChainId
+
+export const updateGasPrices = createAction<UpdateGasPrices>('gas/updateGasPrices')

--- a/src/custom/state/gas/hooks.ts
+++ b/src/custom/state/gas/hooks.ts
@@ -1,0 +1,34 @@
+import { ChainId } from '@uniswap/sdk'
+import { useCallback } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { GasState } from './reducer'
+import { updateGasPrices, UpdateGasPrices } from './actions'
+import { AppDispatch } from 'state'
+import { AppState } from '..'
+import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
+import { GAS_FEE_ENDPOINTS } from 'constants/index'
+
+export interface GasFeeEndpointResponse {
+  lastUpdate: string
+  lowest: string
+  safeLow: string
+  standard: string
+  fast: string
+  fastest: string
+}
+
+export async function getGasPrices(chainId: ChainId = DEFAULT_NETWORK_FOR_LISTS): Promise<GasFeeEndpointResponse> {
+  const response = await fetch(GAS_FEE_ENDPOINTS[chainId])
+  return response.json()
+}
+
+export function useGasPrices(chainId?: ChainId) {
+  return useSelector<AppState, GasState[ChainId] | null>(state => {
+    return chainId ? state.gas[chainId] : null
+  })
+}
+
+export function useUpdateGasPrices() {
+  const dispatch = useDispatch<AppDispatch>()
+  return useCallback((gasParams: UpdateGasPrices) => dispatch(updateGasPrices(gasParams)), [dispatch])
+}

--- a/src/custom/state/gas/reducer.ts
+++ b/src/custom/state/gas/reducer.ts
@@ -1,0 +1,19 @@
+import { ChainId } from '@uniswap/sdk'
+import { createReducer } from '@reduxjs/toolkit'
+import { updateGasPrices, UpdateGasPrices } from './actions'
+
+export type GasState = {
+  readonly [chainId in ChainId]?: UpdateGasPrices
+}
+
+const initialState: GasState = {}
+
+export default createReducer(initialState, builder =>
+  builder.addCase(updateGasPrices, (state, action) => {
+    const { chainId, ...rest } = action.payload
+
+    if (chainId) {
+      state[chainId] = rest
+    }
+  })
+)

--- a/src/custom/state/gas/updater.tsx
+++ b/src/custom/state/gas/updater.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { useGasPrices, useUpdateGasPrices, getGasPrices } from './hooks'
+import { useActiveWeb3React } from 'hooks'
+import { GAS_PRICE_UPDATE_THRESHOLD } from 'constants/index'
+
+function needsGasUpdate(now: number, lastUpdated: number, threshold: number) {
+  return now - lastUpdated > threshold
+}
+
+export default function GasUpdater(): null {
+  const { chainId } = useActiveWeb3React()
+  const gas = useGasPrices(chainId)
+  const updateGasPrices = useUpdateGasPrices()
+
+  useEffect(() => {
+    const now = Date.now()
+    const updated = gas ? Date.parse(gas.lastUpdate) : null
+
+    // if no gas in local/redux state OR time threshold has passed
+    // since last update, then:
+    if (!updated || needsGasUpdate(now, updated, GAS_PRICE_UPDATE_THRESHOLD)) {
+      getGasPrices(chainId)
+        .then(gas => {
+          updateGasPrices({
+            ...gas,
+            chainId
+          })
+        })
+        // on error we log and keep state as it was
+        .catch(console.error)
+    }
+  }, [chainId, gas, updateGasPrices])
+
+  return null
+}

--- a/src/custom/state/index.ts
+++ b/src/custom/state/index.ts
@@ -13,6 +13,7 @@ import multicall from '@src/state/multicall/reducer'
 import lists from './lists/reducer'
 import orders from './orders/reducer'
 import fee from './fee/reducer'
+import gas from 'state/gas/reducer'
 import { updateVersion } from 'state/global/actions'
 
 import { popupMiddleware, soundMiddleware } from './orders/middleware'
@@ -32,10 +33,11 @@ const reducers = {
   ...UNISWAP_REDUCERS,
   lists,
   orders,
-  fee
+  fee,
+  gas
 }
 
-const PERSISTED_KEYS: string[] = ['user', 'transactions', 'orders', 'lists']
+const PERSISTED_KEYS: string[] = ['user', 'transactions', 'orders', 'lists', 'gas']
 
 const store = configureStore({
   reducer: reducers,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import TransactionUpdater from './state/transactions/updater'
 import UserUpdater from './state/user/updater'
 import FeesUpdater from 'state/fee/updater'
 import XdaiUpdater from 'state/network/updater'
+import GasUpdater from 'state/gas/updater'
 import { ExpiredOrdersWatcher, EventUpdater } from 'state/orders/updater'
 // import { EventUpdater } from 'state/orders/mocks'
 import ThemeProvider, { FixedGlobalStyle, ThemedGlobalStyle } from 'theme'
@@ -65,6 +66,7 @@ function Updaters() {
       <EventUpdater />
       <ExpiredOrdersWatcher />
       <FeesUpdater />
+      <GasUpdater />
     </>
   )
 }


### PR DESCRIPTION
### Adds gas prices by `chainId` to redux global state and storage

Not sure this is strictly that required but i figured adding gas prices by `chainId` to a centralised location would/could be useful

### Why?
- want to use this globally with an updater to extrapolate away from EthWethWrap component
- use inside nested components more easily
- centralising this may come in handy later