### PR TITLE
350/min max received tooltip

### DIFF
--- a/src/custom/components/swap/SwapModalFooter/SwapModalFooterMod.tsx
+++ b/src/custom/components/swap/SwapModalFooter/SwapModalFooterMod.tsx
@@ -19,6 +19,7 @@ import FormattedPriceImpact from 'components/swap/FormattedPriceImpact'
 import { StyledBalanceMaxMini, SwapCallbackError } from 'components/swap/styleds'
 import { TradeWithFee } from 'state/swap/extension'
 import { DEFAULT_PRECISION, SHORT_PRECISION } from 'constants/index'
+import { getMinimumReceivedTooltip } from 'utils/tooltips'
 
 export interface SwapModalFooterProps {
   trade: TradeWithFee
@@ -50,6 +51,8 @@ export default function SwapModalFooter({
   //   const { priceImpactWithoutFee , realizedLPFee } = useMemo(() => computeTradePriceBreakdown(trade), [trade])
   const severity = warningSeverity(priceImpactWithoutFee)
 
+  const isExactIn = trade.tradeType === TradeType.EXACT_INPUT
+
   return (
     <>
       <AutoColumn gap="0px">
@@ -79,9 +82,9 @@ export default function SwapModalFooter({
         <RowBetween>
           <RowFixed>
             <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
-              {trade.tradeType === TradeType.EXACT_INPUT ? 'Minimum received' : 'Maximum sold'}
+              {isExactIn ? 'Minimum received' : 'Maximum sold'}
             </TYPE.black>
-            <QuestionHelper text="Your transaction will expire if there is a large, unfavorable price movement before it is confirmed." />
+            <QuestionHelper text={getMinimumReceivedTooltip(allowedSlippage, isExactIn)} />
           </RowFixed>
           <RowFixed>
             <TYPE.black fontSize={14}>

--- a/src/custom/components/swap/TradeSummary.tsx
+++ b/src/custom/components/swap/TradeSummary.tsx
@@ -2,18 +2,18 @@ import React, { useContext } from 'react'
 import { ThemeContext } from 'styled-components'
 import { CurrencyAmount, Percent, TradeType } from '@uniswap/sdk'
 
-import { Field } from '@src/state/swap/actions'
-import { TYPE } from '@src/theme'
+import { Field } from 'state/swap/actions'
+import { TYPE } from 'theme'
 import {
   computeSlippageAdjustedAmounts,
   computeTradePriceBreakdown as computeTradePriceBreakdownUni
-} from '@src/utils/prices'
+} from 'utils/prices'
 import { getMinimumReceivedTooltip } from 'utils/tooltips'
 
-import { AutoColumn } from '@src/components/Column'
-import QuestionHelper from '@src/components/QuestionHelper'
-import { RowBetween, RowFixed } from '@src/components/Row'
-import FormattedPriceImpact from '@src/components/swap/FormattedPriceImpact'
+import { AutoColumn } from 'components/Column'
+import QuestionHelper from 'components/QuestionHelper'
+import { RowBetween, RowFixed } from 'components/Row'
+import FormattedPriceImpact from 'components/swap/FormattedPriceImpact'
 import { TradeWithFee } from 'state/swap/extension'
 import { DEFAULT_PRECISION } from 'constants/index'
 

--- a/src/custom/components/swap/TradeSummary.tsx
+++ b/src/custom/components/swap/TradeSummary.tsx
@@ -8,6 +8,7 @@ import {
   computeSlippageAdjustedAmounts,
   computeTradePriceBreakdown as computeTradePriceBreakdownUni
 } from '@src/utils/prices'
+import { getMinimumReceivedTooltip } from 'utils/tooltips'
 
 import { AutoColumn } from '@src/components/Column'
 import QuestionHelper from '@src/components/QuestionHelper'
@@ -48,7 +49,7 @@ export default function TradeSummary({ trade, allowedSlippage }: { trade: TradeW
             <TYPE.black fontSize={14} fontWeight={400} color={theme.text2}>
               {isExactIn ? 'Minimum received' : 'Maximum sold'}
             </TYPE.black>
-            <QuestionHelper text="Your transaction will expire if there is a large, unfavorable price movement before it is confirmed." />
+            <QuestionHelper text={getMinimumReceivedTooltip(allowedSlippage, isExactIn)} />
           </RowFixed>
           <RowFixed>
             <TYPE.black color={theme.text1} fontSize={14}>

--- a/src/custom/utils/tooltips.ts
+++ b/src/custom/utils/tooltips.ts
@@ -1,0 +1,13 @@
+import { Percent } from '@uniswap/sdk'
+
+import { BIPS_BASE, RADIX_DECIMAL } from 'constants/index'
+
+export function getMinimumReceivedTooltip(allowedSlippage: number, isExactIn: boolean): string {
+  const slippagePercent = new Percent(allowedSlippage.toString(RADIX_DECIMAL), BIPS_BASE)
+
+  return `${
+    isExactIn ? "Minimum tokens you'll receive." : "Maximum tokens you'll sell."
+  } This accounts for the current price and your chosen slippage (${slippagePercent.toSignificant(
+    3
+  )}%). If the price moves beyond your slippage, you won't trade but also you won't pay any fees or gas.`
+}


### PR DESCRIPTION
# Summary

Closes #350 

Updated _Minimum received_ / _Maximum sold_ tooltip as requested on 2 places:

1. Main swap page
2. Confirmation modal

# Testing

1. Fill all required fields (both tokens and input amount)
- [ ] Verify the `Minimum received` tooltip matches the text on the issue #350 for `sell` orders
- [ ] Verify the selected slippage is correctly displayed (defaults to `0.5%`)
Example: 
![screenshot_2021-04-26_14-29-57](https://user-images.githubusercontent.com/43217/116154626-c0d20e00-a69d-11eb-9904-d21ec6d7d512.png)

2. Click on swap
- [ ] On the confirmation modal, verify the same as the previous step
(No need to submit the order)
Example:
![screenshot_2021-04-26_14-31-05](https://user-images.githubusercontent.com/43217/116154633-c596c200-a69d-11eb-82b5-99c81f8a2fcb.png)


3. This time, keep all fields as they are and fill in the `To` field, creating a `buy` order
- [ ] Verify the `Maximum sold` field matches the text on the issue #350 for `buy` orders
- [ ] Verify the selected slippage is correctly displayed (defaults to `0.5%`)

4. Go to settings
5. Set a different slippage. 30% for example
6. Repeat steps 1 to 3.