### PR TITLE
486/about fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Cow Swap - Gnosis Protocol",
   "homepage": ".",
   "private": true,
-  "version": "0.10.0-rc.2",
+  "version": "0.10.0-rc.3",
   "status": "Alpha",
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -29,7 +29,7 @@ export default function About() {
           can’t be settled with other CowSwap traders are sent to the underlying AMMs.
           <br />
           <br />
-          This economic phenomenon is known as <b>Coincidence Of Wants (COW)</b>.
+          This economic phenomenon is known as <b>Coincidence Of Wants (CoW)</b>.
         </p>
 
         <h3 id="gas-free">Gas Free Transactions</h3>

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -24,7 +24,7 @@ export default function About() {
           <img src={diagramIMG} alt="CowSwap vs. AMM's" />
         </p>
         <p>
-          Everytime you and another trader each hold an asset the other wants, your trade is settled directly without
+          Every time you and another trader each hold an asset the other wants, your trade is settled directly without
           using an AMM and therefore without incurring any slippage + fees. Only amounts that can’t be settled with
           other CowSwap traders are sent to the underlying AMMs.
           <br />

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -18,7 +18,7 @@ export default function About() {
 
       <Content>
         <h2>
-          <b>C</b>oincidence <b>O</b>f <b>W</b>ants
+          <b>C</b>oincidence <b>o</b>f <b>W</b>ants
         </h2>
         <p>
           <img src={diagramIMG} alt="CowSwap vs. AMM's" />

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Page, { Title, Content, GdocsListStyle } from 'components/Page'
 import styled from 'styled-components'
+import { Link } from 'react-router-dom'
 
 // Assets
 import diagramIMG from 'assets/cow-swap/cowswap-diagram.png'
@@ -83,6 +84,11 @@ export default function About() {
           <br />
           CowSwap is the first DEX Aggregator offering some protection against it: COWs enable tight slippages and can
           even avoid settlement on AMMs altogether.
+        </p>
+
+        <h3>Do you want to know more?</h3>
+        <p>
+          Head over to the <Link to="/faq">FAQ</Link>
         </p>
       </Content>
     </Wrapper>

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -12,6 +12,10 @@ const Wrapper = styled(Page)`
   ${GdocsListStyle}
 `
 
+const Emoji = styled.span`
+  font-size: 1.8em;
+`
+
 export default function About() {
   return (
     <Wrapper>
@@ -64,9 +68,9 @@ export default function About() {
         <p>
           Why? This helps you to save on gas, slippage &amp; protocol fees. You might receive a larger amount than
           anticipated{' '}
-          <span role="img" aria-label="happy cow face">
+          <Emoji role="img" aria-label="happy cow face">
             🐮
-          </span>
+          </Emoji>
         </p>
 
         <h3 id="mev">Maximal Extractable Value (MEV)</h3>

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -47,7 +47,6 @@ export default function About() {
           <li>
             <p>CowSwap’s off-chain service optimizes your trade’s execution by considering:</p>
             <ul>
-              {' '}
               <li>
                 <p>Coincidence Of Wants</p>
               </li>

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -25,8 +25,8 @@ export default function About() {
         </p>
         <p>
           Every time you and another trader each hold an asset the other wants, your trade is settled directly without
-          using an AMM and therefore without incurring any slippage + fees. Only amounts that can’t be settled with
-          other CowSwap traders are sent to the underlying AMMs.
+          using an AMM (Automated Market Maker) and therefore without incurring any slippage + fees. Only amounts that
+          can’t be settled with other CowSwap traders are sent to the underlying AMMs.
           <br />
           <br />
           This economic phenomenon is known as <b>Coincidence Of Wants (COW)</b>.

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -63,7 +63,10 @@ export default function About() {
         </ol>
         <p>
           Why? This helps you to save on gas, slippage &amp; protocol fees. You might receive a larger amount than
-          anticipated :)
+          anticipated{' '}
+          <span role="img" aria-label="happy cow face">
+            🐮
+          </span>
         </p>
 
         <h3 id="mev">Miner-Extractable Value (MEV)</h3>

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -69,9 +69,9 @@ export default function About() {
           </span>
         </p>
 
-        <h3 id="mev">Miner-Extractable Value (MEV)</h3>
+        <h3 id="mev">Maximal Extractable Value (MEV)</h3>
         <p>
-          <img src={mevIMG} alt="CowSwap - Miner-Extractable Value" />
+          <img src={mevIMG} alt="CowSwap - Maximal Extractable Value" />
         </p>
         <p>
           Heard about Maximal Extractable Value yet? It’s scary. To date more than{' '}


### PR DESCRIPTION
# Summary

Closes #486 

About page fixes.

Also added a new section to the end of the About:
![screenshot_2021-04-26_16-05-08](https://user-images.githubusercontent.com/43217/116161719-25469a80-a6a9-11eb-9303-4d472a3f22c7.png)

Happy to change the text to whatever is best.

# Testing

Make sure whatever is listed on #486 is fixed in this PR
