### PR TITLE
Show footer contracts on mobile.

### DIFF
--- a/src/custom/components/Footer/index.tsx
+++ b/src/custom/components/Footer/index.tsx
@@ -23,7 +23,7 @@ const Wrapper = styled.div`
   margin: auto 96px 0 32px;
   width: 100%;
 
-  ${({ theme }) => theme.mediaWidth.upToSmall`
+  ${({ theme }) => theme.mediaWidth.upToMedium`
     margin: 0 auto 150px;
   `}
 `

--- a/src/custom/components/Footer/index.tsx
+++ b/src/custom/components/Footer/index.tsx
@@ -7,6 +7,13 @@ import Version from '../Version'
 const FooterVersion = styled(Version)`
   margin-right: auto;
   min-width: max-content;
+  color: ${({ theme }) => theme.greenShade};
+
+  > div {
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 0 8px;
+    `}
+  }
 `
 
 const Wrapper = styled.div`
@@ -15,13 +22,14 @@ const Wrapper = styled.div`
   justify-content: space-evenly;
   margin: auto 96px 0 32px;
   width: 100%;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    margin: 0 auto 150px;
+  `}
 `
 
 const FooterWrapper = styled.div`
   width: 100%;
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    display: none;
-  `}
 `
 
 export default function Footer({ children }: { children?: React.ReactChildren }) {

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -61,21 +61,18 @@ const StyledPolling = styled.div`
   display: flex;
   flex-flow: column nowrap;
   align-items: flex-start;
-
-  padding: 1rem;
-
+  padding: 16px;
+  transition: opacity 0.25s ease;
   color: ${({ theme }) => theme.version};
   opacity: 0.5;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    opacity: 1;
+  `}
 
   &:hover {
     opacity: 1;
   }
-
-  transition: opacity 0.25s ease;
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    display: none;
-  `}
 `
 
 const VersionsExternalLink = styled(ExternalLink)<{ isUnclickable?: boolean }>`

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -50,6 +50,7 @@ export function colors(darkMode: boolean): Colors {
     // ****** other ******
     blue1: '#3F77FF',
     purple: '#8958FF',
+    greenShade: '#376c57',
     border: darkMode ? '#3a3b5a' : 'rgb(58 59 90 / 10%)',
     disabled: darkMode ? '#31323e' : 'rgb(237, 238, 242)',
     redShade: darkMode ? '#AE2C00' : '#AE2C00'

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -56,8 +56,6 @@ export function colors(darkMode: boolean): Colors {
     secondary3: darkMode ? '#17000b26' : 'rgba(137,88,255,0.6)',
 
     // ****** other ******
-    blue1: '#3F77FF',
-    purple: '#8958FF',
     border: darkMode ? '#000000' : '#000000',
     disabled: darkMode ? '#afcbda' : '#afcbda'
   }

--- a/src/custom/theme/styled.d.ts
+++ b/src/custom/theme/styled.d.ts
@@ -6,6 +6,7 @@ export { Color, Grids } from '@src/theme/styled'
 export interface Colors extends ColorsUniswap {
   purple: Color
   redShade: Color
+  greenShade: Color
   border: Color
   disabled: Color
 }


### PR DESCRIPTION
Addressing #310

- Shows the contract links on mobile.
- Changed text color from orange to dark green for better readability/contrast.

Notes:
- Noticed a 'phantom' element/button exists, which creates an artificial white space area. We need to address this in a separate PR. Seems to be component `</ButtonEmpty>` in `src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx`

<img width="375" alt="Screen Shot 2021-04-27 at 14 50 34" src="https://user-images.githubusercontent.com/31534717/116244404-30accb00-a768-11eb-99ba-0088d21090b3.png">

<img width="1018" alt="Screen Shot 2021-04-27 at 14 50 43" src="https://user-images.githubusercontent.com/31534717/116244400-2ee30780-a768-11eb-8d6d-84d233707cae.png">


<img width="1018" alt="Screen Shot 2021-04-27 at 14 50 50" src="https://user-images.githubusercontent.com/31534717/116244393-2d194400-a768-11eb-9c02-f2c0a42979d0.png">

Phantom element (likely `</ButtonEmpty>`)
<img width="1017" alt="Screen Shot 2021-04-27 at 14 44 17" src="https://user-images.githubusercontent.com/31534717/116244569-5508a780-a768-11eb-9d46-52b0377b21d7.png">
<img width="376" alt="Screen Shot 2021-04-27 at 14 42 41" src="https://user-images.githubusercontent.com/31534717/116244583-576b0180-a768-11eb-81ca-8191d312f53d.png">

