### PR TITLE
Fix blank page for buy orders wrapEth

### DIFF
--- a/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
@@ -14,24 +14,24 @@ const WrappingVisualisation = ({
   wrapped,
   wrappedBalance,
   wrappedSymbol,
-  userInput
+  nativeInput
 }: {
   nativeSymbol: string
   nativeBalance: CurrencyAmount | undefined
   native: Currency
-  userInput: CurrencyAmount | undefined
+  nativeInput: CurrencyAmount | undefined
   wrappedBalance: CurrencyAmount | undefined
   wrappedSymbol: string
   wrapped: Currency
 }) => (
   <WrapCardContainer>
     {/* To Wrap */}
-    <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={userInput} />
+    <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={nativeInput} />
 
     <ArrowRight size={18} color={COLOUR_SHEET.primary1} />
 
     {/* Wrap Outcome */}
-    <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={userInput} />
+    <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={nativeInput} />
   </WrapCardContainer>
 )
 

--- a/src/custom/components/swap/EthWethWrap/helpers.ts
+++ b/src/custom/components/swap/EthWethWrap/helpers.ts
@@ -13,31 +13,31 @@ export const _setNativeLowBalanceError = (nativeSymbol: string) =>
 export function _isLowBalanceCheck({
   threshold,
   txCost,
-  userInput,
+  nativeInput,
   balance
 }: {
   threshold: CurrencyAmount
   txCost: CurrencyAmount
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   balance?: CurrencyAmount
 }) {
-  if (!userInput || !balance || userInput.add(txCost).greaterThan(balance)) return true
+  if (!nativeInput || !balance || nativeInput.add(txCost).greaterThan(balance)) return true
   // OK if: users_balance - (amt_input + 1_tx_cost) > low_balance_threshold
-  return balance.subtract(userInput.add(txCost)).lessThan(threshold)
+  return balance.subtract(nativeInput.add(txCost)).lessThan(threshold)
 }
 
 export const _getAvailableTransactions = ({
   nativeBalance,
-  userInput,
+  nativeInput,
   singleTxCost
 }: {
   nativeBalance?: CurrencyAmount
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   singleTxCost: CurrencyAmount
 }) => {
-  if (!nativeBalance || !userInput || nativeBalance.lessThan(userInput.add(singleTxCost))) return null
+  if (!nativeBalance || !nativeInput || nativeBalance.lessThan(nativeInput.add(singleTxCost))) return null
 
   // USER_BALANCE - (USER_WRAP_AMT + 1_TX_CST) / 1_TX_COST = AVAILABLE_TXS
-  const txsAvailable = nativeBalance.subtract(userInput.add(singleTxCost)).divide(singleTxCost)
+  const txsAvailable = nativeBalance.subtract(nativeInput.add(singleTxCost)).divide(singleTxCost)
   return txsAvailable.lessThan('1') ? null : txsAvailable.toSignificant(1)
 }

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -130,12 +130,12 @@ const WarningLabel = ({ children }: { children?: ReactNode }) => (
 export interface Props {
   account?: string
   native: Currency
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   wrapped: Token
   wrapCallback: () => Promise<TransactionResponse>
 }
 
-export default function EthWethWrap({ account, native, userInput, wrapped, wrapCallback }: Props) {
+export default function EthWethWrap({ account, native, nativeInput, wrapped, wrapCallback }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [modalOpen, setModalOpen] = useState<boolean>(false)
@@ -168,13 +168,13 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
     () => ({
       isLowBalance: _isLowBalanceCheck({
         threshold: multiTxCost,
-        userInput,
+        nativeInput,
         balance: nativeBalance,
         txCost: singleTxCost
       }),
-      txsRemaining: _getAvailableTransactions({ nativeBalance, userInput, singleTxCost })
+      txsRemaining: _getAvailableTransactions({ nativeBalance, nativeInput, singleTxCost })
     }),
-    [multiTxCost, nativeBalance, singleTxCost, userInput]
+    [multiTxCost, nativeBalance, singleTxCost, nativeInput]
   )
 
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
@@ -241,7 +241,7 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
             wrapped={wrapped}
             wrappedBalance={wrappedBalance}
             wrappedSymbol={wrappedSymbol}
-            userInput={userInput}
+            nativeInput={nativeInput}
           />
           <ButtonWrapper>
             <ButtonSecondary padding="0.5rem" maxWidth="30%" onClick={(): void => setModalOpen(false)}>
@@ -269,7 +269,7 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
         wrapped={wrapped}
         wrappedBalance={wrappedBalance}
         wrappedSymbol={wrappedSymbol}
-        userInput={userInput}
+        nativeInput={nativeInput}
       />
       {/* Wrap CTA */}
       <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handlePrimaryAction}>

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -3,7 +3,6 @@ import { getChainCurrencySymbols } from 'utils/xdai/hack'
 import { Currency, CurrencyAmount, currencyEquals, ETHER, WETH } from '@uniswap/sdk'
 import { Contract } from 'ethers'
 import { useMemo } from 'react'
-import { tryParseAmount } from 'state/swap/hooks'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { useCurrencyBalance } from 'state/wallet/hooks'
 import { useActiveWeb3React } from 'hooks/index'
@@ -90,14 +89,13 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
 export default function useWrapCallback(
   inputCurrency: Currency | undefined,
   outputCurrency: Currency | undefined,
-  typedValue: string | undefined,
+  inputAmount: CurrencyAmount | undefined,
   isEthTradeOverride?: boolean
 ): WrapUnwrapCallback {
   const { chainId, account } = useActiveWeb3React()
   const wethContract = useWETHContract()
   const balance = useCurrencyBalance(account ?? undefined, inputCurrency)
   // we can always parse the amount typed as the input currency, since wrapping is 1:1
-  const inputAmount = useMemo(() => tryParseAmount(typedValue, inputCurrency), [inputCurrency, typedValue])
   const addTransaction = useTransactionAdder()
 
   return useMemo(() => {

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -471,11 +471,11 @@ export default function Swap({
                   )}
                   {isFeeGreater && fee && <FeeGreaterMessage fee={fee} />}
                 </AutoColumn>
-                {isNativeIn && onWrap && (
+                {isNativeIn && trade && onWrap && (
                   <EthWethWrapMessage
                     account={account ?? undefined}
                     native={native}
-                    userInput={parsedAmount}
+                    userInput={trade.inputAmountWithFee}
                     wrapped={wrappedToken}
                     wrapCallback={onWrap}
                   />

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -125,22 +125,22 @@ export default function Swap({
   // Is fee greater than input?
   const { isFeeGreater, fee } = useIsFeeGreaterThanInput({ chainId, address: INPUT.currencyId, parsedAmount })
 
-  const { wrapType, execute: onWrap, inputError: wrapInputError } = useWrapCallback(
-    currencies[Field.INPUT],
-    currencies[Field.OUTPUT],
-    typedValue,
-    // should override and get wrapCallback?
-    isNativeInSwap
-  )
-
-  const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
-  const { address: recipientAddress } = useENSAddress(recipient)
   const toggledVersion = useToggledVersion()
   const tradesByVersion = {
     [Version.v1]: v1Trade,
     [Version.v2]: v2Trade
   }
-  const trade = showWrap ? undefined : tradesByVersion[toggledVersion]
+  const tradeCurrentVersion = tradesByVersion[toggledVersion]
+  const { wrapType, execute: onWrap, inputError: wrapInputError } = useWrapCallback(
+    currencies[Field.INPUT],
+    currencies[Field.OUTPUT],
+    tradeCurrentVersion?.inputAmountWithFee,
+    // should override and get wrapCallback?
+    isNativeInSwap
+  )
+  const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
+  const { address: recipientAddress } = useENSAddress(recipient)
+  const trade = showWrap ? undefined : tradeCurrentVersion
   const defaultTrade = showWrap ? undefined : tradesByVersion[DEFAULT_VERSION]
 
   const betterTradeLinkV2: Version | undefined =


### PR DESCRIPTION
Closes #557 

Makes the app not to break for buy orders where ETH is the sell token.

It doesn't include the ETH wrapper tool, for that #560 

The issue was basically, it was using the typed amount instead of always the input for doing the check of low balance. Then it was operating using amounts of two tokens that were not related (ETH and DAI), so it was breaking the invariant.

## Test
Try to type a buy order with ETH as the sell token. You won't seel the ETH wrapper message/tool, but the app won't break either. 

@W3stside this needs careful testing. I need to jump into a call now, but I appreciate if you can bullet proof test these two prs.