### PR TITLE
[🏴‍☠️ RELEASE 🏴‍☠️] 0.11.0

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# App Id, get yours at https://discord.gg/egGzDDctuC
+# App Id, get yours at https://chat.cowswap.exchange
 REACT_APP_ID="0"
 
 # Nodes

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-# App Id, get yours at https://discord.gg/egGzDDctuC
+# App Id, get yours at https://chat.cowswap.exchange
 REACT_APP_ID=1
 
 # Node

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An open source fork of Uniswap to Swap in Gnosis Protocol v2 -- a protocol for d
 
 - Twitter: [@gnosisPM](https://twitter.com/gnosisPM)
 - Reddit: [/r/gnosisPM](https://www.reddit.com/r/gnosisPM)
-- Discord: [Gnosis Protocol Channel](https://discord.gg/egGzDDctuC)
+- Discord: <https://chat.cowswap.exchange>
 
 Please see the:
 
@@ -87,4 +87,4 @@ REACT_APP_NETWORK_URL_100=https://rpc.xdaichain.com
 
 For production:
 
-6. Get your own `App Id` in <https://discord.gg/egGzDDctuC>, and set it in `REACT_APP_ID`.
+6. Get your own `App Id` in <chat.cowswap.exchange>, and set it in `REACT_APP_ID`.

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -1,3 +1,4 @@
+import { WithClassName } from '@src/custom/types'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -34,19 +35,19 @@ const StyledToggle = styled.button<{ isActive?: boolean; activeElement?: boolean
   padding: 0;
 `
 
-export interface ToggleProps {
+export interface ToggleProps extends WithClassName {
   id?: string
   isActive: boolean
   toggle: () => void
 }
 
-export default function Toggle({ id, isActive, toggle }: ToggleProps) {
+export default function Toggle({ id, isActive, toggle, className }: ToggleProps) {
   return (
-    <StyledToggle id={id} isActive={isActive} onClick={toggle}>
+    <StyledToggle id={id} isActive={isActive} onClick={toggle} className={className}>
       <ToggleElement isActive={isActive} isOnSwitch={true}>
         On
       </ToggleElement>
-      <ToggleElement isActive={!isActive} isOnSwitch={false}>
+      <ToggleElement isActive={!isActive} isOnSwitch={false} className={isActive ? '' : 'disabled'}>
         Off
       </ToggleElement>
     </StyledToggle>

--- a/src/custom/components/Footer/index.tsx
+++ b/src/custom/components/Footer/index.tsx
@@ -7,6 +7,13 @@ import Version from '../Version'
 const FooterVersion = styled(Version)`
   margin-right: auto;
   min-width: max-content;
+  color: ${({ theme }) => theme.greenShade};
+
+  > div {
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 0 8px;
+    `}
+  }
 `
 
 const Wrapper = styled.div`
@@ -15,13 +22,14 @@ const Wrapper = styled.div`
   justify-content: space-evenly;
   margin: auto 96px 0 32px;
   width: 100%;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    margin: 0 auto 150px;
+  `}
 `
 
 const FooterWrapper = styled.div`
   width: 100%;
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    display: none;
-  `}
 `
 
 export default function Footer({ children }: { children?: React.ReactChildren }) {

--- a/src/custom/components/Settings/SettingsMod.tsx
+++ b/src/custom/components/Settings/SettingsMod.tsx
@@ -8,8 +8,8 @@ import { useModalOpen, useToggleSettingsMenu } from 'state/application/hooks'
 import {
   useExpertModeManager,
   useUserTransactionTTL,
-  useUserSlippageTolerance,
-  useUserSingleHopOnly
+  useUserSlippageTolerance
+  // useUserSingleHopOnly
 } from 'state/user/hooks'
 import { TYPE } from 'theme'
 import { ButtonError } from 'components/Button'
@@ -132,7 +132,7 @@ export default function SettingsTab({ className, SettingsButton }: SettingsTabPr
 
   const [expertMode, toggleExpertMode] = useExpertModeManager()
 
-  const [singleHopOnly, setSingleHopOnly] = useUserSingleHopOnly()
+  // const [singleHopOnly, setSingleHopOnly] = useUserSingleHopOnly()
 
   // show confirmation view before turning on
   const [showConfirmation, setShowConfirmation] = useState(false)
@@ -230,7 +230,7 @@ export default function SettingsTab({ className, SettingsButton }: SettingsTabPr
                 }
               />
             </RowBetween>
-            <RowBetween>
+            {/* <RowBetween>
               <RowFixed>
                 <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
                   Disable Multihops
@@ -242,7 +242,7 @@ export default function SettingsTab({ className, SettingsButton }: SettingsTabPr
                 isActive={singleHopOnly}
                 toggle={() => (singleHopOnly ? setSingleHopOnly(false) : setSingleHopOnly(true))}
               />
-            </RowBetween>
+            </RowBetween> */}
           </AutoColumn>
         </MenuFlyout>
       )}

--- a/src/custom/components/Settings/SettingsMod.tsx
+++ b/src/custom/components/Settings/SettingsMod.tsx
@@ -17,7 +17,7 @@ import { AutoColumn } from 'components/Column'
 import Modal from 'components/Modal'
 import QuestionHelper from 'components/QuestionHelper'
 import { RowBetween, RowFixed } from 'components/Row'
-import Toggle from 'components/Toggle'
+import Toggle from '@src/custom/components/Toggle'
 import TransactionSettings from 'components/TransactionSettings'
 import { SettingsTabProp } from '.'
 

--- a/src/custom/components/Toggle/index.tsx
+++ b/src/custom/components/Toggle/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import styled from 'styled-components'
+import ToggleUni, { ToggleProps as TogglePropsUni } from '@src/components/Toggle'
+
+export type ToggleProps = TogglePropsUni
+
+const Wrapper = styled(ToggleUni)`
+  .disabled {
+    color: ${({ theme }) => theme.white};
+  }
+`
+
+export default function Toggle(props: ToggleProps) {
+  return <Wrapper {...props} />
+}

--- a/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
@@ -169,6 +169,7 @@ export default function SlippageTabs({
                   The slippage you pick here enables a resubmission of your order in case of unfavourable price
                   movements.
                 </p>
+                <p>{INPUT_OUTPUT_EXPLANATION}</p>
               </>
             }
           />

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -61,21 +61,18 @@ const StyledPolling = styled.div`
   display: flex;
   flex-flow: column nowrap;
   align-items: flex-start;
-
-  padding: 1rem;
-
+  padding: 16px;
+  transition: opacity 0.25s ease;
   color: ${({ theme }) => theme.version};
   opacity: 0.5;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    opacity: 1;
+  `}
 
   &:hover {
     opacity: 1;
   }
-
-  transition: opacity 0.25s ease;
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    display: none;
-  `}
 `
 
 const VersionsExternalLink = styled(ExternalLink)<{ isUnclickable?: boolean }>`

--- a/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { ArrowRight } from 'react-feather'
+import { CurrencyAmount, Currency } from '@uniswap/sdk'
+import { WrapCardContainer, WrapCard } from './WrapCard'
+
+import { colors } from 'theme'
+
+const COLOUR_SHEET = colors(false)
+
+const WrappingVisualisation = ({
+  nativeSymbol,
+  nativeBalance,
+  native,
+  wrapped,
+  wrappedBalance,
+  wrappedSymbol,
+  userInput
+}: {
+  nativeSymbol: string
+  nativeBalance: CurrencyAmount | undefined
+  native: Currency
+  userInput: CurrencyAmount | undefined
+  wrappedBalance: CurrencyAmount | undefined
+  wrappedSymbol: string
+  wrapped: Currency
+}) => (
+  <WrapCardContainer>
+    {/* To Wrap */}
+    <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={userInput} />
+
+    <ArrowRight size={18} color={COLOUR_SHEET.primary1} />
+
+    {/* Wrap Outcome */}
+    <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={userInput} />
+  </WrapCardContainer>
+)
+
+export default WrappingVisualisation

--- a/src/custom/components/swap/EthWethWrap/helpers.ts
+++ b/src/custom/components/swap/EthWethWrap/helpers.ts
@@ -1,0 +1,43 @@
+import { parseUnits } from 'ethers/lib/utils'
+import { CurrencyAmount } from '@uniswap/sdk'
+
+export const MINIMUM_TXS = '10'
+export const AVG_APPROVE_COST_GWEI = '50000'
+export const DEFAULT_GAS_FEE = parseUnits('50', 'gwei')
+
+export const _setNativeLowBalanceError = (nativeSymbol: string) =>
+  new Error(
+    `This ${nativeSymbol} wrapping operation may leave insufficient funds to cover any future on-chain transaction costs.`
+  )
+
+export function _isLowBalanceCheck({
+  threshold,
+  txCost,
+  userInput,
+  balance
+}: {
+  threshold: CurrencyAmount
+  txCost: CurrencyAmount
+  userInput?: CurrencyAmount
+  balance?: CurrencyAmount
+}) {
+  if (!userInput || !balance || userInput.add(txCost).greaterThan(balance)) return true
+  // OK if: users_balance - (amt_input + 1_tx_cost) > low_balance_threshold
+  return balance.subtract(userInput.add(txCost)).lessThan(threshold)
+}
+
+export const _getAvailableTransactions = ({
+  nativeBalance,
+  userInput,
+  singleTxCost
+}: {
+  nativeBalance?: CurrencyAmount
+  userInput?: CurrencyAmount
+  singleTxCost: CurrencyAmount
+}) => {
+  if (!nativeBalance || !userInput || nativeBalance.lessThan(userInput.add(singleTxCost))) return null
+
+  // USER_BALANCE - (USER_WRAP_AMT + 1_TX_CST) / 1_TX_COST = AVAILABLE_TXS
+  const txsAvailable = nativeBalance.subtract(userInput.add(singleTxCost)).divide(singleTxCost)
+  return txsAvailable.lessThan('1') ? null : txsAvailable.toSignificant(1)
+}

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -1,20 +1,28 @@
-import React, { useState, useCallback, useMemo, useEffect } from 'react'
+import React, { useState, useCallback, useMemo, useEffect, ReactNode } from 'react'
 import styled from 'styled-components'
 import { TransactionResponse } from '@ethersproject/providers'
-import { ArrowRight, AlertTriangle } from 'react-feather'
+import { AlertTriangle } from 'react-feather'
 import { Currency, Token, CurrencyAmount } from '@uniswap/sdk'
 
-import { ButtonPrimary } from 'components/Button'
+import { ButtonSecondary, ButtonPrimary } from 'components/Button'
 import Loader from 'components/Loader'
-import { WrapCardContainer, WrapCard } from './WrapCard'
+import WrappingVisualisation from './WrappingVisualisation'
 
 import { useCurrencyBalances } from 'state/wallet/hooks'
 import { useIsTransactionPending } from 'state/transactions/hooks'
 
-import { colors } from 'theme'
-import { LOW_NATIVE_BALANCE_THRESHOLD, DEFAULT_PRECISION } from 'constants/index'
-
-const COLOUR_SHEET = colors(false)
+import Modal from 'components/Modal'
+import { useGasPrices } from 'state/gas/hooks'
+import { useActiveWeb3React } from 'hooks'
+import { BigNumber } from 'ethers'
+import {
+  DEFAULT_GAS_FEE,
+  MINIMUM_TXS,
+  AVG_APPROVE_COST_GWEI,
+  _isLowBalanceCheck,
+  _setNativeLowBalanceError,
+  _getAvailableTransactions
+} from './helpers'
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap}
@@ -38,6 +46,18 @@ const Wrapper = styled.div`
       }
   }
 `
+
+const ModalMessage = styled.p`
+  display: flex;
+  flex-flow: row wrap;
+  padding: 0 8px;
+  width: 100%;
+`
+
+const ModalWrapper = styled(Wrapper)`
+  margin: 0 auto;
+`
+
 const WarningWrapper = styled(Wrapper)`
   ${({ theme }) => theme.flexRowNoWrap}
   padding: 0;
@@ -85,10 +105,26 @@ const ErrorWrapper = styled(BalanceLabel)`
   color: ${({ theme }) => theme.redShade};
 `
 
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+  gap: 16px;
+  width: 100%;
+  margin-top: 8px;
+`
+
 const ErrorMessage = ({ error }: { error: Error }) => (
   <ErrorWrapper>
     <strong>{error.message}</strong>
   </ErrorWrapper>
+)
+
+const WarningLabel = ({ children }: { children?: ReactNode }) => (
+  <WarningWrapper>
+    <AlertTriangle size={25} />
+    <div>{children}</div>
+  </WarningWrapper>
 )
 
 export interface Props {
@@ -99,29 +135,47 @@ export interface Props {
   wrapCallback: () => Promise<TransactionResponse>
 }
 
-const setNativeLowBalanceError = (nativeSymbol: string) =>
-  new Error(
-    `WARNING! After wrapping your ${nativeSymbol}, your balance will fall below < ${LOW_NATIVE_BALANCE_THRESHOLD.toSignificant(
-      DEFAULT_PRECISION
-    )} ${nativeSymbol}. As a result you may not have sufficient ${nativeSymbol} left to cover future on-chain transaction costs.`
-  )
-
-function checkUserBalance(userInput?: CurrencyAmount, balance?: CurrencyAmount) {
-  if (!userInput || !balance || userInput.greaterThan(balance)) return true
-
-  return balance.subtract(userInput).lessThan(LOW_NATIVE_BALANCE_THRESHOLD)
-}
-
 export default function EthWethWrap({ account, native, userInput, wrapped, wrapCallback }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
+  const [modalOpen, setModalOpen] = useState<boolean>(false)
   const [pendingHash, setPendingHash] = useState<string | undefined>()
+
+  const { chainId } = useActiveWeb3React()
+  const gasPrice = useGasPrices(chainId)
+
+  // returns the cost of 1 tx and multi txs
+  const { multiTxCost, singleTxCost } = useMemo(() => {
+    // TODO: should use DEFAULT_GAS_FEE from backup source
+    // when/if implemented
+    const gas = gasPrice?.standard || DEFAULT_GAS_FEE
+
+    const amount = BigNumber.from(gas)
+      .mul(MINIMUM_TXS)
+      .mul(AVG_APPROVE_COST_GWEI)
+
+    return {
+      multiTxCost: CurrencyAmount.ether(amount.toString()),
+      singleTxCost: CurrencyAmount.ether(amount.div(MINIMUM_TXS).toString())
+    }
+  }, [gasPrice])
 
   const isWrapPending = useIsTransactionPending(pendingHash)
   const [nativeBalance, wrappedBalance] = useCurrencyBalances(account, [native, wrapped])
 
   // does the user have a lower than set threshold balance? show error
-  const isLowBalance = useMemo(() => checkUserBalance(userInput, nativeBalance), [nativeBalance, userInput])
+  const { isLowBalance, txsRemaining } = useMemo(
+    () => ({
+      isLowBalance: _isLowBalanceCheck({
+        threshold: multiTxCost,
+        userInput,
+        balance: nativeBalance,
+        txCost: singleTxCost
+      }),
+      txsRemaining: _getAvailableTransactions({ nativeBalance, userInput, singleTxCost })
+    }),
+    [multiTxCost, nativeBalance, singleTxCost, userInput]
+  )
 
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
   const nativeSymbol = native.symbol || 'native token'
@@ -144,30 +198,81 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
 
       setError(error)
       setLoading(false)
+    } finally {
+      setModalOpen(false)
     }
   }, [wrapCallback])
 
+  // if low balance, clicking CTA opens modal, else opens wallet prompt
+  const handlePrimaryAction = isLowBalance ? () => setModalOpen(true) : handleWrap
+
   return (
     <Wrapper>
-      <WarningWrapper>
-        <AlertTriangle size={25} />
-        <div>
-          Wrap your {nativeSymbol} first or switch to {wrappedSymbol}!
-        </div>
-      </WarningWrapper>
-      {isLowBalance && <ErrorMessage error={setNativeLowBalanceError(nativeSymbol)} />}
+      {/* Conditional Confirmation modal */}
+      <Modal isOpen={modalOpen} onDismiss={() => setModalOpen(false)}>
+        <ModalWrapper>
+          <h2>Confirm {nativeSymbol} wrap</h2>
+          <ModalMessage>
+            <span>
+              Cow Swap is a gasless exchange. <strong>{nativeSymbol}</strong> however, is required for paying{' '}
+              <strong>
+                on-chain transaction costs associated with enabling tokens and the wrapping/unwrapping of {nativeSymbol}
+                /{wrappedSymbol}
+              </strong>
+              , respectively.
+            </span>
+          </ModalMessage>
+          <ModalMessage>
+            <span>
+              At current gas prices, your remaining {nativeSymbol} balance after confirmation would be{' '}
+              {!txsRemaining ? (
+                <strong>insufficient for any further on-chain transactions.</strong>
+              ) : (
+                <>
+                  sufficient for <strong>up to {txsRemaining} wrapping, unwrapping, or enabling operation(s)</strong>.
+                </>
+              )}
+            </span>
+          </ModalMessage>
+          <WrappingVisualisation
+            nativeSymbol={nativeSymbol}
+            nativeBalance={nativeBalance}
+            native={native}
+            wrapped={wrapped}
+            wrappedBalance={wrappedBalance}
+            wrappedSymbol={wrappedSymbol}
+            userInput={userInput}
+          />
+          <ButtonWrapper>
+            <ButtonSecondary padding="0.5rem" maxWidth="30%" onClick={(): void => setModalOpen(false)}>
+              Cancel
+            </ButtonSecondary>
+            <ButtonPrimary disabled={loading} padding="0.5rem" maxWidth="70%" onClick={handleWrap}>
+              {loading ? <Loader /> : `Wrap my ${nativeSymbol} anyways`}
+            </ButtonPrimary>
+          </ButtonWrapper>
+        </ModalWrapper>
+      </Modal>
+      {/* Primary warning label */}
+      <WarningLabel>
+        Wrap your {nativeSymbol} first or switch to {wrappedSymbol}!
+      </WarningLabel>
+      {/* Low Balance Error */}
+      {isLowBalance && <ErrorMessage error={_setNativeLowBalanceError(nativeSymbol)} />}
+      {/* Async Error */}
       {error && <ErrorMessage error={error} />}
-      <WrapCardContainer>
-        {/* To Wrap */}
-        <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={userInput} />
-
-        <ArrowRight size={18} color={COLOUR_SHEET.primary1} />
-
-        {/* Wrap Outcome */}
-        <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={userInput} />
-      </WrapCardContainer>
-
-      <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handleWrap}>
+      {/* Wrapping cards */}
+      <WrappingVisualisation
+        nativeSymbol={nativeSymbol}
+        nativeBalance={nativeBalance}
+        native={native}
+        wrapped={wrapped}
+        wrappedBalance={wrappedBalance}
+        wrappedSymbol={wrappedSymbol}
+        userInput={userInput}
+      />
+      {/* Wrap CTA */}
+      <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handlePrimaryAction}>
         {loading ? <Loader /> : `Wrap my ${nativeSymbol}`}
       </ButtonPrimary>
     </Wrapper>

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -66,7 +66,7 @@ export const XDAI_LOGO_URI =
 export const LOW_NATIVE_BALANCE_THRESHOLD = new Fraction('1', '10')
 export const CONTRACTS_CODE_LINK = 'https://github.com/gnosis/gp-v2-contracts'
 export const CODE_LINK = 'https://github.com/gnosis/gp-swap-ui'
-export const DISCORD_LINK = 'https://discord.gg/egGzDDctuC'
+export const DISCORD_LINK = 'https://chat.cowswap.exchange'
 export const DUNE_DASHBOARD_LINK = 'https://duneanalytics.com/gnosis.protocol/Gnosis-Protocol-V2'
 
 // 30 minutes

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -73,12 +73,12 @@ export default function About() {
           </span>
         </p>
 
-        <h3 id="mev">Maximal Extractable Value (MEV)</h3>
+        <h3 id="mev">Maximum Extractable Value (MEV)</h3>
         <p>
-          <img src={mevIMG} alt="CowSwap - Maximal Extractable Value" />
+          <img src={mevIMG} alt="CowSwap - Maximum Extractable Value" />
         </p>
         <p>
-          Heard about Maximal Extractable Value yet? It’s scary. To date more than{' '}
+          Heard about Maximum Extractable Value yet? It’s scary. To date more than{' '}
           <a href="https://explore.flashbots.net/" target="_blank" rel="noopener noreferrer">
             USD 390M
           </a>{' '}

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -126,7 +126,7 @@ export default function Faq() {
           </h3>
 
           <p>
-            <a href="https://research.paradigm.xyz/MEV">Defined</a> by the Paradigm research team, Maximal Extractable
+            <a href="https://research.paradigm.xyz/MEV">Defined</a> by the Paradigm research team, Maximum Extractable
             Value (MEV) is “a measure of the profit a miner (or validator, sequencer, etc.) can make through their
             ability to arbitrarily include, exclude, or re-order transactions within the blocks they produce.”
           </p>

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -50,6 +50,7 @@ export function colors(darkMode: boolean): Colors {
     // ****** other ******
     blue1: '#3F77FF',
     purple: '#8958FF',
+    greenShade: '#376c57',
     border: darkMode ? '#3a3b5a' : 'rgb(58 59 90 / 10%)',
     disabled: darkMode ? '#31323e' : 'rgb(237, 238, 242)',
     redShade: darkMode ? '#AE2C00' : '#AE2C00'

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -56,8 +56,6 @@ export function colors(darkMode: boolean): Colors {
     secondary3: darkMode ? '#17000b26' : 'rgba(137,88,255,0.6)',
 
     // ****** other ******
-    blue1: '#3F77FF',
-    purple: '#8958FF',
     border: darkMode ? '#000000' : '#000000',
     disabled: darkMode ? '#afcbda' : '#afcbda'
   }

--- a/src/custom/theme/styled.d.ts
+++ b/src/custom/theme/styled.d.ts
@@ -6,6 +6,7 @@ export { Color, Grids } from '@src/theme/styled'
 export interface Colors extends ColorsUniswap {
   purple: Color
   redShade: Color
+  greenShade: Color
   border: Color
   disabled: Color
 }


### PR DESCRIPTION
# MERGE, DO NOT SQUASH

## :construction_worker_woman:  QA
### c1ff8ed7 [ETH/WETH] Confirmation Modal (#425)
- **SELL ORDER**
  - Sell = ETH, buy = ERC20 (not WETH)
  - when low balance in native token after inputting amount (e.g 5 ETH balance, user input = 4.9 ETH), should see a warning on swap page and when clicking "Wrap my ETH" should see a Confirmation modal 
  - **Screenshots**
  - ![Screenshot from 2021-04-29 13-20-46](https://user-images.githubusercontent.com/21335563/116549773-cfaeff80-a8ed-11eb-90ed-66394a10dc3e.png)
  - ![Screenshot from 2021-04-29 13-20-51](https://user-images.githubusercontent.com/21335563/116549789-d473b380-a8ed-11eb-9855-79166cefd249.png)

- **BUY ORDER**
  - Sell = ETH, buy = ERC20 (not WETH)
  - This time, set an amount in the "TO" input field to trigger a buy order, making sure the "FROM" field spits back out an amount within your balance threshold
  - make sure the amount shown in the ETH wrapping component below is the **same** as the "Maximum sold" amount in the dropdown
  - **Screenshots**
  - ![Screenshot from 2021-04-29 14-03-30](https://user-images.githubusercontent.com/21335563/116554962-b5782000-a8f3-11eb-80d2-00d787df1221.png)



## :notebook:  Changelog 
e81b1907 Use chat link (#548)
f3d14371 Disable off button style (#555)
d778435c Disable hops (#554)
c1ff8ed7 [ETH/WETH] Confirmation Modal (#550)
20c72633 Replaced `Maximal` with `Maximum` (#546)
bcba26cf Show footer contracts on mobile. (#539)