### PR TITLE
Pr comments use trade inputamount

### DIFF
--- a/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
@@ -14,24 +14,24 @@ const WrappingVisualisation = ({
   wrapped,
   wrappedBalance,
   wrappedSymbol,
-  userInput
+  nativeInput
 }: {
   nativeSymbol: string
   nativeBalance: CurrencyAmount | undefined
   native: Currency
-  userInput: CurrencyAmount | undefined
+  nativeInput: CurrencyAmount | undefined
   wrappedBalance: CurrencyAmount | undefined
   wrappedSymbol: string
   wrapped: Currency
 }) => (
   <WrapCardContainer>
     {/* To Wrap */}
-    <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={userInput} />
+    <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={nativeInput} />
 
     <ArrowRight size={18} color={COLOUR_SHEET.primary1} />
 
     {/* Wrap Outcome */}
-    <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={userInput} />
+    <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={nativeInput} />
   </WrapCardContainer>
 )
 

--- a/src/custom/components/swap/EthWethWrap/helpers.ts
+++ b/src/custom/components/swap/EthWethWrap/helpers.ts
@@ -13,31 +13,31 @@ export const _setNativeLowBalanceError = (nativeSymbol: string) =>
 export function _isLowBalanceCheck({
   threshold,
   txCost,
-  userInput,
+  nativeInput,
   balance
 }: {
   threshold: CurrencyAmount
   txCost: CurrencyAmount
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   balance?: CurrencyAmount
 }) {
-  if (!userInput || !balance || userInput.add(txCost).greaterThan(balance)) return true
+  if (!nativeInput || !balance || nativeInput.add(txCost).greaterThan(balance)) return true
   // OK if: users_balance - (amt_input + 1_tx_cost) > low_balance_threshold
-  return balance.subtract(userInput.add(txCost)).lessThan(threshold)
+  return balance.subtract(nativeInput.add(txCost)).lessThan(threshold)
 }
 
 export const _getAvailableTransactions = ({
   nativeBalance,
-  userInput,
+  nativeInput,
   singleTxCost
 }: {
   nativeBalance?: CurrencyAmount
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   singleTxCost: CurrencyAmount
 }) => {
-  if (!nativeBalance || !userInput || nativeBalance.lessThan(userInput.add(singleTxCost))) return null
+  if (!nativeBalance || !nativeInput || nativeBalance.lessThan(nativeInput.add(singleTxCost))) return null
 
   // USER_BALANCE - (USER_WRAP_AMT + 1_TX_CST) / 1_TX_COST = AVAILABLE_TXS
-  const txsAvailable = nativeBalance.subtract(userInput.add(singleTxCost)).divide(singleTxCost)
+  const txsAvailable = nativeBalance.subtract(nativeInput.add(singleTxCost)).divide(singleTxCost)
   return txsAvailable.lessThan('1') ? null : txsAvailable.toSignificant(1)
 }

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -130,12 +130,12 @@ const WarningLabel = ({ children }: { children?: ReactNode }) => (
 export interface Props {
   account?: string
   native: Currency
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   wrapped: Token
   wrapCallback: () => Promise<TransactionResponse>
 }
 
-export default function EthWethWrap({ account, native, userInput, wrapped, wrapCallback }: Props) {
+export default function EthWethWrap({ account, native, nativeInput, wrapped, wrapCallback }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [modalOpen, setModalOpen] = useState<boolean>(false)
@@ -168,13 +168,13 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
     () => ({
       isLowBalance: _isLowBalanceCheck({
         threshold: multiTxCost,
-        userInput,
+        nativeInput,
         balance: nativeBalance,
         txCost: singleTxCost
       }),
-      txsRemaining: _getAvailableTransactions({ nativeBalance, userInput, singleTxCost })
+      txsRemaining: _getAvailableTransactions({ nativeBalance, nativeInput, singleTxCost })
     }),
-    [multiTxCost, nativeBalance, singleTxCost, userInput]
+    [multiTxCost, nativeBalance, singleTxCost, nativeInput]
   )
 
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
@@ -241,7 +241,7 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
             wrapped={wrapped}
             wrappedBalance={wrappedBalance}
             wrappedSymbol={wrappedSymbol}
-            userInput={userInput}
+            nativeInput={nativeInput}
           />
           <ButtonWrapper>
             <ButtonSecondary padding="0.5rem" maxWidth="30%" onClick={(): void => setModalOpen(false)}>
@@ -269,7 +269,7 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
         wrapped={wrapped}
         wrappedBalance={wrappedBalance}
         wrappedSymbol={wrappedSymbol}
-        userInput={userInput}
+        nativeInput={nativeInput}
       />
       {/* Wrap CTA */}
       <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handlePrimaryAction}>


### PR DESCRIPTION
Merges into #562 addresses comments from there

`nativeInput` - constant set in `swapMod` that, depending on the type of trade, returns our `native token amount` to pass to both the `EthWethWrap` container AND the amt that is set inside the `onWrap` callback when time to wrap `ETH`.

For `sell` orders we use the amount as is input, but for `buy` orders however, we need to adjust the `sell` amount for `fee` AND `slippage` adjustments not only in the `EthWethWrap` comp but also in the signing modal. The data for the signing of the wrapping comes from the `onWrap` cb spit out by `useWrapCallback`

**Proof**
### Sell
![Screenshot from 2021-04-29 14-50-35](https://user-images.githubusercontent.com/21335563/116561685-739ea800-a8fa-11eb-9a52-9418bc9ab6d9.png)

### Buy (notice dropdown `Maximum out` and the signing amount are the samesies
![Screenshot from 2021-04-29 14-50-52](https://user-images.githubusercontent.com/21335563/116561659-6d103080-a8fa-11eb-8a87-21a02d44be87.png)

