### PR TITLE
Release/0.11

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# App Id, get yours at https://discord.gg/egGzDDctuC
+# App Id, get yours at https://chat.cowswap.exchange
 REACT_APP_ID="0"
 
 # Nodes

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-# App Id, get yours at https://discord.gg/egGzDDctuC
+# App Id, get yours at https://chat.cowswap.exchange
 REACT_APP_ID=1
 
 # Node

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An open source fork of Uniswap to Swap in Gnosis Protocol v2 -- a protocol for d
 
 - Twitter: [@gnosisPM](https://twitter.com/gnosisPM)
 - Reddit: [/r/gnosisPM](https://www.reddit.com/r/gnosisPM)
-- Discord: [Gnosis Protocol Channel](https://discord.gg/egGzDDctuC)
+- Discord: <https://chat.cowswap.exchange>
 
 Please see the:
 
@@ -87,4 +87,4 @@ REACT_APP_NETWORK_URL_100=https://rpc.xdaichain.com
 
 For production:
 
-6. Get your own `App Id` in <https://discord.gg/egGzDDctuC>, and set it in `REACT_APP_ID`.
+6. Get your own `App Id` in <chat.cowswap.exchange>, and set it in `REACT_APP_ID`.

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -1,3 +1,4 @@
+import { WithClassName } from '@src/custom/types'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -34,19 +35,19 @@ const StyledToggle = styled.button<{ isActive?: boolean; activeElement?: boolean
   padding: 0;
 `
 
-export interface ToggleProps {
+export interface ToggleProps extends WithClassName {
   id?: string
   isActive: boolean
   toggle: () => void
 }
 
-export default function Toggle({ id, isActive, toggle }: ToggleProps) {
+export default function Toggle({ id, isActive, toggle, className }: ToggleProps) {
   return (
-    <StyledToggle id={id} isActive={isActive} onClick={toggle}>
+    <StyledToggle id={id} isActive={isActive} onClick={toggle} className={className}>
       <ToggleElement isActive={isActive} isOnSwitch={true}>
         On
       </ToggleElement>
-      <ToggleElement isActive={!isActive} isOnSwitch={false}>
+      <ToggleElement isActive={!isActive} isOnSwitch={false} className={isActive ? '' : 'disabled'}>
         Off
       </ToggleElement>
     </StyledToggle>

--- a/src/custom/components/ContentLink/index.tsx
+++ b/src/custom/components/ContentLink/index.tsx
@@ -10,12 +10,19 @@ export interface Props {
 export function ContentLink(props: Props): JSX.Element {
   const { href, children, smooth = true } = props
   const isExternalLink = /^(https?:)?\/\//.test(href)
+
+  const scrollWithOffset = (el: HTMLElement) => {
+    const yCoordinate = el.getBoundingClientRect().top + window.pageYOffset
+    const yOffset = -24
+    window.scrollTo({ top: yCoordinate + yOffset, behavior: 'smooth' })
+  }
+
   return isExternalLink ? (
     <a target="_blank" href={href} rel="noopener noreferrer">
       {props.children}
     </a>
   ) : (
-    <HashLink smooth={smooth} to={href}>
+    <HashLink smooth={smooth} to={href} scroll={el => scrollWithOffset(el)}>
       {children}
     </HashLink>
   )

--- a/src/custom/components/Footer/index.tsx
+++ b/src/custom/components/Footer/index.tsx
@@ -7,6 +7,13 @@ import Version from '../Version'
 const FooterVersion = styled(Version)`
   margin-right: auto;
   min-width: max-content;
+  color: ${({ theme }) => theme.greenShade};
+
+  > div {
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 0 8px;
+    `}
+  }
 `
 
 const Wrapper = styled.div`
@@ -15,13 +22,14 @@ const Wrapper = styled.div`
   justify-content: space-evenly;
   margin: auto 96px 0 32px;
   width: 100%;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    margin: 0 auto 150px;
+  `}
 `
 
 const FooterWrapper = styled.div`
   width: 100%;
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    display: none;
-  `}
 `
 
 export default function Footer({ children }: { children?: React.ReactChildren }) {

--- a/src/custom/components/Settings/SettingsMod.tsx
+++ b/src/custom/components/Settings/SettingsMod.tsx
@@ -8,8 +8,8 @@ import { useModalOpen, useToggleSettingsMenu } from 'state/application/hooks'
 import {
   useExpertModeManager,
   useUserTransactionTTL,
-  useUserSlippageTolerance,
-  useUserSingleHopOnly
+  useUserSlippageTolerance
+  // useUserSingleHopOnly
 } from 'state/user/hooks'
 import { TYPE } from 'theme'
 import { ButtonError } from 'components/Button'
@@ -132,7 +132,7 @@ export default function SettingsTab({ className, SettingsButton }: SettingsTabPr
 
   const [expertMode, toggleExpertMode] = useExpertModeManager()
 
-  const [singleHopOnly, setSingleHopOnly] = useUserSingleHopOnly()
+  // const [singleHopOnly, setSingleHopOnly] = useUserSingleHopOnly()
 
   // show confirmation view before turning on
   const [showConfirmation, setShowConfirmation] = useState(false)
@@ -230,7 +230,7 @@ export default function SettingsTab({ className, SettingsButton }: SettingsTabPr
                 }
               />
             </RowBetween>
-            <RowBetween>
+            {/* <RowBetween>
               <RowFixed>
                 <TYPE.black fontWeight={400} fontSize={14} color={theme.text2}>
                   Disable Multihops
@@ -242,7 +242,7 @@ export default function SettingsTab({ className, SettingsButton }: SettingsTabPr
                 isActive={singleHopOnly}
                 toggle={() => (singleHopOnly ? setSingleHopOnly(false) : setSingleHopOnly(true))}
               />
-            </RowBetween>
+            </RowBetween> */}
           </AutoColumn>
         </MenuFlyout>
       )}

--- a/src/custom/components/Settings/SettingsMod.tsx
+++ b/src/custom/components/Settings/SettingsMod.tsx
@@ -17,7 +17,7 @@ import { AutoColumn } from 'components/Column'
 import Modal from 'components/Modal'
 import QuestionHelper from 'components/QuestionHelper'
 import { RowBetween, RowFixed } from 'components/Row'
-import Toggle from 'components/Toggle'
+import Toggle from '@src/custom/components/Toggle'
 import TransactionSettings from 'components/TransactionSettings'
 import { SettingsTabProp } from '.'
 

--- a/src/custom/components/Toggle/index.tsx
+++ b/src/custom/components/Toggle/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import styled from 'styled-components'
+import ToggleUni, { ToggleProps as TogglePropsUni } from '@src/components/Toggle'
+
+export type ToggleProps = TogglePropsUni
+
+const Wrapper = styled(ToggleUni)`
+  .disabled {
+    color: ${({ theme }) => theme.white};
+  }
+`
+
+export default function Toggle(props: ToggleProps) {
+  return <Wrapper {...props} />
+}

--- a/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
+++ b/src/custom/components/TransactionSettings/TransactionSetttingsMod.tsx
@@ -169,6 +169,7 @@ export default function SlippageTabs({
                   The slippage you pick here enables a resubmission of your order in case of unfavourable price
                   movements.
                 </p>
+                <p>{INPUT_OUTPUT_EXPLANATION}</p>
               </>
             }
           />

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -61,21 +61,18 @@ const StyledPolling = styled.div`
   display: flex;
   flex-flow: column nowrap;
   align-items: flex-start;
-
-  padding: 1rem;
-
+  padding: 16px;
+  transition: opacity 0.25s ease;
   color: ${({ theme }) => theme.version};
   opacity: 0.5;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    opacity: 1;
+  `}
 
   &:hover {
     opacity: 1;
   }
-
-  transition: opacity 0.25s ease;
-
-  ${({ theme }) => theme.mediaWidth.upToMedium`
-    display: none;
-  `}
 `
 
 const VersionsExternalLink = styled(ExternalLink)<{ isUnclickable?: boolean }>`

--- a/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { ArrowRight } from 'react-feather'
+import { CurrencyAmount, Currency } from '@uniswap/sdk'
+import { WrapCardContainer, WrapCard } from './WrapCard'
+
+import { colors } from 'theme'
+
+const COLOUR_SHEET = colors(false)
+
+const WrappingVisualisation = ({
+  nativeSymbol,
+  nativeBalance,
+  native,
+  wrapped,
+  wrappedBalance,
+  wrappedSymbol,
+  userInput
+}: {
+  nativeSymbol: string
+  nativeBalance: CurrencyAmount | undefined
+  native: Currency
+  userInput: CurrencyAmount | undefined
+  wrappedBalance: CurrencyAmount | undefined
+  wrappedSymbol: string
+  wrapped: Currency
+}) => (
+  <WrapCardContainer>
+    {/* To Wrap */}
+    <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={userInput} />
+
+    <ArrowRight size={18} color={COLOUR_SHEET.primary1} />
+
+    {/* Wrap Outcome */}
+    <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={userInput} />
+  </WrapCardContainer>
+)
+
+export default WrappingVisualisation

--- a/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
+++ b/src/custom/components/swap/EthWethWrap/WrappingVisualisation.tsx
@@ -14,24 +14,24 @@ const WrappingVisualisation = ({
   wrapped,
   wrappedBalance,
   wrappedSymbol,
-  userInput
+  nativeInput
 }: {
   nativeSymbol: string
   nativeBalance: CurrencyAmount | undefined
   native: Currency
-  userInput: CurrencyAmount | undefined
+  nativeInput: CurrencyAmount | undefined
   wrappedBalance: CurrencyAmount | undefined
   wrappedSymbol: string
   wrapped: Currency
 }) => (
   <WrapCardContainer>
     {/* To Wrap */}
-    <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={userInput} />
+    <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={nativeInput} />
 
     <ArrowRight size={18} color={COLOUR_SHEET.primary1} />
 
     {/* Wrap Outcome */}
-    <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={userInput} />
+    <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={nativeInput} />
   </WrapCardContainer>
 )
 

--- a/src/custom/components/swap/EthWethWrap/helpers.ts
+++ b/src/custom/components/swap/EthWethWrap/helpers.ts
@@ -13,31 +13,31 @@ export const _setNativeLowBalanceError = (nativeSymbol: string) =>
 export function _isLowBalanceCheck({
   threshold,
   txCost,
-  userInput,
+  nativeInput,
   balance
 }: {
   threshold: CurrencyAmount
   txCost: CurrencyAmount
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   balance?: CurrencyAmount
 }) {
-  if (!userInput || !balance || userInput.add(txCost).greaterThan(balance)) return true
+  if (!nativeInput || !balance || nativeInput.add(txCost).greaterThan(balance)) return true
   // OK if: users_balance - (amt_input + 1_tx_cost) > low_balance_threshold
-  return balance.subtract(userInput.add(txCost)).lessThan(threshold)
+  return balance.subtract(nativeInput.add(txCost)).lessThan(threshold)
 }
 
 export const _getAvailableTransactions = ({
   nativeBalance,
-  userInput,
+  nativeInput,
   singleTxCost
 }: {
   nativeBalance?: CurrencyAmount
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   singleTxCost: CurrencyAmount
 }) => {
-  if (!nativeBalance || !userInput || nativeBalance.lessThan(userInput.add(singleTxCost))) return null
+  if (!nativeBalance || !nativeInput || nativeBalance.lessThan(nativeInput.add(singleTxCost))) return null
 
   // USER_BALANCE - (USER_WRAP_AMT + 1_TX_CST) / 1_TX_COST = AVAILABLE_TXS
-  const txsAvailable = nativeBalance.subtract(userInput.add(singleTxCost)).divide(singleTxCost)
+  const txsAvailable = nativeBalance.subtract(nativeInput.add(singleTxCost)).divide(singleTxCost)
   return txsAvailable.lessThan('1') ? null : txsAvailable.toSignificant(1)
 }

--- a/src/custom/components/swap/EthWethWrap/helpers.ts
+++ b/src/custom/components/swap/EthWethWrap/helpers.ts
@@ -1,0 +1,43 @@
+import { parseUnits } from 'ethers/lib/utils'
+import { CurrencyAmount } from '@uniswap/sdk'
+
+export const MINIMUM_TXS = '10'
+export const AVG_APPROVE_COST_GWEI = '50000'
+export const DEFAULT_GAS_FEE = parseUnits('50', 'gwei')
+
+export const _setNativeLowBalanceError = (nativeSymbol: string) =>
+  new Error(
+    `This ${nativeSymbol} wrapping operation may leave insufficient funds to cover any future on-chain transaction costs.`
+  )
+
+export function _isLowBalanceCheck({
+  threshold,
+  txCost,
+  userInput,
+  balance
+}: {
+  threshold: CurrencyAmount
+  txCost: CurrencyAmount
+  userInput?: CurrencyAmount
+  balance?: CurrencyAmount
+}) {
+  if (!userInput || !balance || userInput.add(txCost).greaterThan(balance)) return true
+  // OK if: users_balance - (amt_input + 1_tx_cost) > low_balance_threshold
+  return balance.subtract(userInput.add(txCost)).lessThan(threshold)
+}
+
+export const _getAvailableTransactions = ({
+  nativeBalance,
+  userInput,
+  singleTxCost
+}: {
+  nativeBalance?: CurrencyAmount
+  userInput?: CurrencyAmount
+  singleTxCost: CurrencyAmount
+}) => {
+  if (!nativeBalance || !userInput || nativeBalance.lessThan(userInput.add(singleTxCost))) return null
+
+  // USER_BALANCE - (USER_WRAP_AMT + 1_TX_CST) / 1_TX_COST = AVAILABLE_TXS
+  const txsAvailable = nativeBalance.subtract(userInput.add(singleTxCost)).divide(singleTxCost)
+  return txsAvailable.lessThan('1') ? null : txsAvailable.toSignificant(1)
+}

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -1,20 +1,28 @@
-import React, { useState, useCallback, useMemo, useEffect } from 'react'
+import React, { useState, useCallback, useMemo, useEffect, ReactNode } from 'react'
 import styled from 'styled-components'
 import { TransactionResponse } from '@ethersproject/providers'
-import { ArrowRight, AlertTriangle } from 'react-feather'
+import { AlertTriangle } from 'react-feather'
 import { Currency, Token, CurrencyAmount } from '@uniswap/sdk'
 
-import { ButtonPrimary } from 'components/Button'
+import { ButtonSecondary, ButtonPrimary } from 'components/Button'
 import Loader from 'components/Loader'
-import { WrapCardContainer, WrapCard } from './WrapCard'
+import WrappingVisualisation from './WrappingVisualisation'
 
 import { useCurrencyBalances } from 'state/wallet/hooks'
 import { useIsTransactionPending } from 'state/transactions/hooks'
 
-import { colors } from 'theme'
-import { LOW_NATIVE_BALANCE_THRESHOLD, DEFAULT_PRECISION } from 'constants/index'
-
-const COLOUR_SHEET = colors(false)
+import Modal from 'components/Modal'
+import { useGasPrices } from 'state/gas/hooks'
+import { useActiveWeb3React } from 'hooks'
+import { BigNumber } from 'ethers'
+import {
+  DEFAULT_GAS_FEE,
+  MINIMUM_TXS,
+  AVG_APPROVE_COST_GWEI,
+  _isLowBalanceCheck,
+  _setNativeLowBalanceError,
+  _getAvailableTransactions
+} from './helpers'
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap}
@@ -38,6 +46,18 @@ const Wrapper = styled.div`
       }
   }
 `
+
+const ModalMessage = styled.p`
+  display: flex;
+  flex-flow: row wrap;
+  padding: 0 8px;
+  width: 100%;
+`
+
+const ModalWrapper = styled(Wrapper)`
+  margin: 0 auto;
+`
+
 const WarningWrapper = styled(Wrapper)`
   ${({ theme }) => theme.flexRowNoWrap}
   padding: 0;
@@ -85,10 +105,26 @@ const ErrorWrapper = styled(BalanceLabel)`
   color: ${({ theme }) => theme.redShade};
 `
 
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+  gap: 16px;
+  width: 100%;
+  margin-top: 8px;
+`
+
 const ErrorMessage = ({ error }: { error: Error }) => (
   <ErrorWrapper>
     <strong>{error.message}</strong>
   </ErrorWrapper>
+)
+
+const WarningLabel = ({ children }: { children?: ReactNode }) => (
+  <WarningWrapper>
+    <AlertTriangle size={25} />
+    <div>{children}</div>
+  </WarningWrapper>
 )
 
 export interface Props {
@@ -99,29 +135,47 @@ export interface Props {
   wrapCallback: () => Promise<TransactionResponse>
 }
 
-const setNativeLowBalanceError = (nativeSymbol: string) =>
-  new Error(
-    `WARNING! After wrapping your ${nativeSymbol}, your balance will fall below < ${LOW_NATIVE_BALANCE_THRESHOLD.toSignificant(
-      DEFAULT_PRECISION
-    )} ${nativeSymbol}. As a result you may not have sufficient ${nativeSymbol} left to cover future on-chain transaction costs.`
-  )
-
-function checkUserBalance(userInput?: CurrencyAmount, balance?: CurrencyAmount) {
-  if (!userInput || !balance || userInput.greaterThan(balance)) return true
-
-  return balance.subtract(userInput).lessThan(LOW_NATIVE_BALANCE_THRESHOLD)
-}
-
 export default function EthWethWrap({ account, native, userInput, wrapped, wrapCallback }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
+  const [modalOpen, setModalOpen] = useState<boolean>(false)
   const [pendingHash, setPendingHash] = useState<string | undefined>()
+
+  const { chainId } = useActiveWeb3React()
+  const gasPrice = useGasPrices(chainId)
+
+  // returns the cost of 1 tx and multi txs
+  const { multiTxCost, singleTxCost } = useMemo(() => {
+    // TODO: should use DEFAULT_GAS_FEE from backup source
+    // when/if implemented
+    const gas = gasPrice?.standard || DEFAULT_GAS_FEE
+
+    const amount = BigNumber.from(gas)
+      .mul(MINIMUM_TXS)
+      .mul(AVG_APPROVE_COST_GWEI)
+
+    return {
+      multiTxCost: CurrencyAmount.ether(amount.toString()),
+      singleTxCost: CurrencyAmount.ether(amount.div(MINIMUM_TXS).toString())
+    }
+  }, [gasPrice])
 
   const isWrapPending = useIsTransactionPending(pendingHash)
   const [nativeBalance, wrappedBalance] = useCurrencyBalances(account, [native, wrapped])
 
   // does the user have a lower than set threshold balance? show error
-  const isLowBalance = useMemo(() => checkUserBalance(userInput, nativeBalance), [nativeBalance, userInput])
+  const { isLowBalance, txsRemaining } = useMemo(
+    () => ({
+      isLowBalance: _isLowBalanceCheck({
+        threshold: multiTxCost,
+        userInput,
+        balance: nativeBalance,
+        txCost: singleTxCost
+      }),
+      txsRemaining: _getAvailableTransactions({ nativeBalance, userInput, singleTxCost })
+    }),
+    [multiTxCost, nativeBalance, singleTxCost, userInput]
+  )
 
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
   const nativeSymbol = native.symbol || 'native token'
@@ -144,30 +198,81 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
 
       setError(error)
       setLoading(false)
+    } finally {
+      setModalOpen(false)
     }
   }, [wrapCallback])
 
+  // if low balance, clicking CTA opens modal, else opens wallet prompt
+  const handlePrimaryAction = isLowBalance ? () => setModalOpen(true) : handleWrap
+
   return (
     <Wrapper>
-      <WarningWrapper>
-        <AlertTriangle size={25} />
-        <div>
-          Wrap your {nativeSymbol} first or switch to {wrappedSymbol}!
-        </div>
-      </WarningWrapper>
-      {isLowBalance && <ErrorMessage error={setNativeLowBalanceError(nativeSymbol)} />}
+      {/* Conditional Confirmation modal */}
+      <Modal isOpen={modalOpen} onDismiss={() => setModalOpen(false)}>
+        <ModalWrapper>
+          <h2>Confirm {nativeSymbol} wrap</h2>
+          <ModalMessage>
+            <span>
+              Cow Swap is a gasless exchange. <strong>{nativeSymbol}</strong> however, is required for paying{' '}
+              <strong>
+                on-chain transaction costs associated with enabling tokens and the wrapping/unwrapping of {nativeSymbol}
+                /{wrappedSymbol}
+              </strong>
+              , respectively.
+            </span>
+          </ModalMessage>
+          <ModalMessage>
+            <span>
+              At current gas prices, your remaining {nativeSymbol} balance after confirmation would be{' '}
+              {!txsRemaining ? (
+                <strong>insufficient for any further on-chain transactions.</strong>
+              ) : (
+                <>
+                  sufficient for <strong>up to {txsRemaining} wrapping, unwrapping, or enabling operation(s)</strong>.
+                </>
+              )}
+            </span>
+          </ModalMessage>
+          <WrappingVisualisation
+            nativeSymbol={nativeSymbol}
+            nativeBalance={nativeBalance}
+            native={native}
+            wrapped={wrapped}
+            wrappedBalance={wrappedBalance}
+            wrappedSymbol={wrappedSymbol}
+            userInput={userInput}
+          />
+          <ButtonWrapper>
+            <ButtonSecondary padding="0.5rem" maxWidth="30%" onClick={(): void => setModalOpen(false)}>
+              Cancel
+            </ButtonSecondary>
+            <ButtonPrimary disabled={loading} padding="0.5rem" maxWidth="70%" onClick={handleWrap}>
+              {loading ? <Loader /> : `Wrap my ${nativeSymbol} anyways`}
+            </ButtonPrimary>
+          </ButtonWrapper>
+        </ModalWrapper>
+      </Modal>
+      {/* Primary warning label */}
+      <WarningLabel>
+        Wrap your {nativeSymbol} first or switch to {wrappedSymbol}!
+      </WarningLabel>
+      {/* Low Balance Error */}
+      {isLowBalance && <ErrorMessage error={_setNativeLowBalanceError(nativeSymbol)} />}
+      {/* Async Error */}
       {error && <ErrorMessage error={error} />}
-      <WrapCardContainer>
-        {/* To Wrap */}
-        <WrapCard symbol={nativeSymbol} balance={nativeBalance} currency={native} amountToWrap={userInput} />
-
-        <ArrowRight size={18} color={COLOUR_SHEET.primary1} />
-
-        {/* Wrap Outcome */}
-        <WrapCard symbol={wrappedSymbol} balance={wrappedBalance} currency={wrapped} amountToWrap={userInput} />
-      </WrapCardContainer>
-
-      <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handleWrap}>
+      {/* Wrapping cards */}
+      <WrappingVisualisation
+        nativeSymbol={nativeSymbol}
+        nativeBalance={nativeBalance}
+        native={native}
+        wrapped={wrapped}
+        wrappedBalance={wrappedBalance}
+        wrappedSymbol={wrappedSymbol}
+        userInput={userInput}
+      />
+      {/* Wrap CTA */}
+      <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handlePrimaryAction}>
         {loading ? <Loader /> : `Wrap my ${nativeSymbol}`}
       </ButtonPrimary>
     </Wrapper>

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -130,12 +130,12 @@ const WarningLabel = ({ children }: { children?: ReactNode }) => (
 export interface Props {
   account?: string
   native: Currency
-  userInput?: CurrencyAmount
+  nativeInput?: CurrencyAmount
   wrapped: Token
   wrapCallback: () => Promise<TransactionResponse>
 }
 
-export default function EthWethWrap({ account, native, userInput, wrapped, wrapCallback }: Props) {
+export default function EthWethWrap({ account, native, nativeInput, wrapped, wrapCallback }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [modalOpen, setModalOpen] = useState<boolean>(false)
@@ -168,13 +168,13 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
     () => ({
       isLowBalance: _isLowBalanceCheck({
         threshold: multiTxCost,
-        userInput,
+        nativeInput,
         balance: nativeBalance,
         txCost: singleTxCost
       }),
-      txsRemaining: _getAvailableTransactions({ nativeBalance, userInput, singleTxCost })
+      txsRemaining: _getAvailableTransactions({ nativeBalance, nativeInput, singleTxCost })
     }),
-    [multiTxCost, nativeBalance, singleTxCost, userInput]
+    [multiTxCost, nativeBalance, singleTxCost, nativeInput]
   )
 
   const wrappedSymbol = wrapped.symbol || 'wrapped native token'
@@ -241,7 +241,7 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
             wrapped={wrapped}
             wrappedBalance={wrappedBalance}
             wrappedSymbol={wrappedSymbol}
-            userInput={userInput}
+            nativeInput={nativeInput}
           />
           <ButtonWrapper>
             <ButtonSecondary padding="0.5rem" maxWidth="30%" onClick={(): void => setModalOpen(false)}>
@@ -269,7 +269,7 @@ export default function EthWethWrap({ account, native, userInput, wrapped, wrapC
         wrapped={wrapped}
         wrappedBalance={wrappedBalance}
         wrappedSymbol={wrappedSymbol}
-        userInput={userInput}
+        nativeInput={nativeInput}
       />
       {/* Wrap CTA */}
       <ButtonPrimary disabled={loading} padding="0.5rem" onClick={handlePrimaryAction}>

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -66,7 +66,7 @@ export const XDAI_LOGO_URI =
 export const LOW_NATIVE_BALANCE_THRESHOLD = new Fraction('1', '10')
 export const CONTRACTS_CODE_LINK = 'https://github.com/gnosis/gp-v2-contracts'
 export const CODE_LINK = 'https://github.com/gnosis/gp-swap-ui'
-export const DISCORD_LINK = 'https://discord.gg/egGzDDctuC'
+export const DISCORD_LINK = 'https://chat.cowswap.exchange'
 export const DUNE_DASHBOARD_LINK = 'https://duneanalytics.com/gnosis.protocol/Gnosis-Protocol-V2'
 
 // 30 minutes

--- a/src/custom/hooks/useRefetchFee.ts
+++ b/src/custom/hooks/useRefetchFee.ts
@@ -21,7 +21,7 @@ export function useRefetchFeeCallback() {
 
       if (fee) {
         // Update quote
-        addFee({ sellToken, buyToken, amount, fee, chainId })
+        addFee({ sellToken, buyToken, amount, fee, chainId, lastCheck: Date.now() })
       } else {
         // Clear the fee
         clearFee({ chainId, token: sellToken })

--- a/src/custom/hooks/useWrapCallback.ts
+++ b/src/custom/hooks/useWrapCallback.ts
@@ -3,7 +3,6 @@ import { getChainCurrencySymbols } from 'utils/xdai/hack'
 import { Currency, CurrencyAmount, currencyEquals, ETHER, WETH } from '@uniswap/sdk'
 import { Contract } from 'ethers'
 import { useMemo } from 'react'
-import { tryParseAmount } from 'state/swap/hooks'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { useCurrencyBalance } from 'state/wallet/hooks'
 import { useActiveWeb3React } from 'hooks/index'
@@ -90,14 +89,13 @@ function _getWrapUnwrapCallback(params: GetWrapUnwrapCallback): WrapUnwrapCallba
 export default function useWrapCallback(
   inputCurrency: Currency | undefined,
   outputCurrency: Currency | undefined,
-  typedValue: string | undefined,
+  inputAmount: CurrencyAmount | undefined,
   isEthTradeOverride?: boolean
 ): WrapUnwrapCallback {
   const { chainId, account } = useActiveWeb3React()
   const wethContract = useWETHContract()
   const balance = useCurrencyBalance(account ?? undefined, inputCurrency)
   // we can always parse the amount typed as the input currency, since wrapping is 1:1
-  const inputAmount = useMemo(() => tryParseAmount(typedValue, inputCurrency), [inputCurrency, typedValue])
   const addTransaction = useTransactionAdder()
 
   return useMemo(() => {

--- a/src/custom/pages/About/index.tsx
+++ b/src/custom/pages/About/index.tsx
@@ -73,12 +73,12 @@ export default function About() {
           </span>
         </p>
 
-        <h3 id="mev">Maximal Extractable Value (MEV)</h3>
+        <h3 id="mev">Maximum Extractable Value (MEV)</h3>
         <p>
-          <img src={mevIMG} alt="CowSwap - Maximal Extractable Value" />
+          <img src={mevIMG} alt="CowSwap - Maximum Extractable Value" />
         </p>
         <p>
-          Heard about Maximal Extractable Value yet? It’s scary. To date more than{' '}
+          Heard about Maximum Extractable Value yet? It’s scary. To date more than{' '}
           <a href="https://explore.flashbots.net/" target="_blank" rel="noopener noreferrer">
             USD 390M
           </a>{' '}

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -15,6 +15,35 @@ const Wrapper = styled.div`
   }
 
   ${Content} {
+    > div a {
+      color: ${({ theme }) => theme.text1};
+      transition: color 0.2s ease-in-out;
+
+      &:hover {
+        color: ${({ theme }) => theme.redShade};
+      }
+    }
+
+    > div > a {
+      font-size: 16px;
+      font-weight: bold;
+    }
+
+    > div > ul {
+      margin: 12px 0 24px;
+      padding: 0 0 0 20px;
+      color: ${({ theme }) => theme.primary1};
+      line-height: 1.2;
+    }
+
+    > div > ul > li {
+      margin: 0 0 12px;
+    }
+
+    > p a {
+      color: ${({ theme }) => theme.redShade};
+    }
+
     > h3 {
       margin: 0;
 
@@ -202,9 +231,8 @@ export default function Faq() {
           </p>
 
           <p>
-            Finding the orders best settlement is a challenging task, which may have its own{' '}
-            <a href="https://forum.gnosis.io/t/gpv2-road-to-decentralization/1245">decentralized competition</a> very
-            soon
+            Finding the best settlement for orders is a challenging task, which very soon may have its own{' '}
+            <a href="https://forum.gnosis.io/t/gpv2-road-to-decentralization/1245">decentralized competition</a>.
           </p>
 
           <h3 id="is-cowswap-secure-to-use">Is CowSwap secure to use?</h3>
@@ -290,7 +318,7 @@ export default function Faq() {
 
           <p>At the moment, only limit sell and buy orders (fill-or-kill) are enabled. </p>
 
-          <h3 id="what-token-pairs-does-cowswap-allow-to-trade">What token pairs does CowSwap allow to trade?</h3>
+          <h3 id="what-token-pairs-does-cowswap-allow-to-trade">What token pairs does CowSwap allow you to trade?</h3>
 
           <p>Any valid ERC20 token pair for which there is some basic liquidity on a DEX (like Uniswap or Balancer).</p>
 
@@ -357,7 +385,7 @@ export default function Faq() {
 
           <p>
             When an order is executed, the settlement contract withdraws the sell amount from the trader’s token balance
-            via the Allowance Manager (for more information cf
+            via the Allowance Manager (for more information read{' '}
             <a href="https://github.com/gnosis/gp-v2-contracts">Smart Contract Architecture</a>). In order to allow that
             to happen, the trader has to first approve the Allowance Manager contract to spend tokens on their behalf.
             The smart contract logic ensures that no token can be spent without deliberately signing an order for it.

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -126,7 +126,7 @@ export default function Faq() {
           </h3>
 
           <p>
-            <a href="https://research.paradigm.xyz/MEV">Defined</a> by the Paradigm research team, Maximal Extractable
+            <a href="https://research.paradigm.xyz/MEV">Defined</a> by the Paradigm research team, Maximum Extractable
             Value (MEV) is “a measure of the profit a miner (or validator, sequencer, etc.) can make through their
             ability to arbitrarily include, exclude, or re-order transactions within the blocks they produce.”
           </p>

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -1,4 +1,4 @@
-import { CurrencyAmount, JSBI, Token, Trade } from '@uniswap/sdk'
+import { CurrencyAmount, JSBI, Token, Trade, TradeType } from '@uniswap/sdk'
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { ArrowDown } from 'react-feather'
 import ReactGA from 'react-ga'
@@ -43,7 +43,7 @@ import {
 import { useExpertModeManager, useUserSlippageTolerance, useUserSingleHopOnly } from 'state/user/hooks'
 import { LinkStyledButton, ButtonSize, TYPE } from 'theme'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
-import { computeTradePriceBreakdown, warningSeverity } from 'utils/prices'
+import { computeTradePriceBreakdown, warningSeverity, computeSlippageAdjustedAmounts } from 'utils/prices'
 import AppBody from 'pages/AppBody'
 import { ClickableText } from 'pages/Pool/styleds'
 import Loader from 'components/Loader'
@@ -125,22 +125,32 @@ export default function Swap({
   // Is fee greater than input?
   const { isFeeGreater, fee } = useIsFeeGreaterThanInput({ chainId, address: INPUT.currencyId, parsedAmount })
 
-  const { wrapType, execute: onWrap, inputError: wrapInputError } = useWrapCallback(
-    currencies[Field.INPUT],
-    currencies[Field.OUTPUT],
-    typedValue,
-    // should override and get wrapCallback?
-    isNativeInSwap
-  )
-
-  const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
-  const { address: recipientAddress } = useENSAddress(recipient)
   const toggledVersion = useToggledVersion()
   const tradesByVersion = {
     [Version.v1]: v1Trade,
     [Version.v2]: v2Trade
   }
-  const trade = showWrap ? undefined : tradesByVersion[toggledVersion]
+  const tradeCurrentVersion = tradesByVersion[toggledVersion]
+
+  // nativeInput only applies to useWrapCallback and any function that is native
+  // currency specific - use slippage/fee adjusted native currency for exactOUT orders
+  // and direct input for exactIn orders
+  const nativeInput = !!(tradeCurrentVersion?.tradeType === TradeType.EXACT_INPUT)
+    ? tradeCurrentVersion.inputAmount
+    : // else use the slippage + fee adjusted amount
+      computeSlippageAdjustedAmounts(tradeCurrentVersion, allowedSlippage).INPUT
+
+  const { wrapType, execute: onWrap, inputError: wrapInputError } = useWrapCallback(
+    currencies[Field.INPUT],
+    currencies[Field.OUTPUT],
+    // if native input !== NATIVE_TOKEN, validation fails
+    nativeInput,
+    // should override and get wrapCallback?
+    isNativeInSwap
+  )
+  const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
+  const { address: recipientAddress } = useENSAddress(recipient)
+  const trade = showWrap ? undefined : tradeCurrentVersion
   const defaultTrade = showWrap ? undefined : tradesByVersion[DEFAULT_VERSION]
 
   const betterTradeLinkV2: Version | undefined =
@@ -471,11 +481,12 @@ export default function Swap({
                   )}
                   {isFeeGreater && fee && <FeeGreaterMessage fee={fee} />}
                 </AutoColumn>
+                {/* ETH exactIn && wrapCallback returned us cb */}
                 {isNativeIn && onWrap && (
                   <EthWethWrapMessage
                     account={account ?? undefined}
                     native={native}
-                    userInput={parsedAmount}
+                    nativeInput={nativeInput}
                     wrapped={wrappedToken}
                     wrapCallback={onWrap}
                   />

--- a/src/custom/state/fee/reducer.ts
+++ b/src/custom/state/fee/reducer.ts
@@ -17,6 +17,7 @@ export interface FeeInformation {
 
 export interface FeeInformationObject extends Omit<FeeQuoteParams, 'kind'> {
   fee: FeeInformation
+  lastCheck: number
 }
 
 // {token address => FeeInformationObject} mapping

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -50,6 +50,7 @@ export function colors(darkMode: boolean): Colors {
     // ****** other ******
     blue1: '#3F77FF',
     purple: '#8958FF',
+    greenShade: '#376c57',
     border: darkMode ? '#3a3b5a' : 'rgb(58 59 90 / 10%)',
     disabled: darkMode ? '#31323e' : 'rgb(237, 238, 242)',
     redShade: darkMode ? '#AE2C00' : '#AE2C00'

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -191,4 +191,9 @@ export const ThemedGlobalStyle = createGlobalStyle`
     background-repeat: no-repeat;
     background-image: initial;
   }
+
+  ::selection { 
+    background: ${({ theme }) => theme.primary1};
+    color: ${({ theme }) => theme.text1};
+  }
 `

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -56,8 +56,6 @@ export function colors(darkMode: boolean): Colors {
     secondary3: darkMode ? '#17000b26' : 'rgba(137,88,255,0.6)',
 
     // ****** other ******
-    blue1: '#3F77FF',
-    purple: '#8958FF',
     border: darkMode ? '#000000' : '#000000',
     disabled: darkMode ? '#afcbda' : '#afcbda'
   }

--- a/src/custom/theme/styled.d.ts
+++ b/src/custom/theme/styled.d.ts
@@ -6,6 +6,7 @@ export { Color, Grids } from '@src/theme/styled'
 export interface Colors extends ColorsUniswap {
   purple: Color
   redShade: Color
+  greenShade: Color
   border: Color
   disabled: Color
 }


### PR DESCRIPTION
## Do not Squash 🥒, just normal merge

```
# To get commits used in the description (useful for next releases) 
git log master..HEAD --oneline --decorate=0
```

# Release notes (QA instructions)
*  Prevent to check fee too often: See #573
* Use chat link (#548)
* Improve how the switch buttons look in the settings (#555)
* Disable hops option in the settings (#554)
* Adds a confirmation modal that warn users when they Wrap, if they wrap too much leaving a low ETH balance (#550)
* FAQ: Replaced `Maximal` with `Maximum` in MEV (#546)
* Show footer contracts on mobile. (#539)

Some more details on how to test the low ETH balance check and the confirmation window:

- **SELL ORDER**
  - Sell = ETH, buy = ERC20 (not WETH)
  - when low balance in native token after inputting amount (e.g 5 ETH balance, user input = 4.9 ETH), should see a warning on swap page and when clicking "Wrap my ETH" should see a Confirmation modal 
  - **Screenshots**
  - ![Screenshot from 2021-04-29 13-20-46](https://user-images.githubusercontent.com/21335563/116549773-cfaeff80-a8ed-11eb-90ed-66394a10dc3e.png)
  - ![Screenshot from 2021-04-29 13-20-51](https://user-images.githubusercontent.com/21335563/116549789-d473b380-a8ed-11eb-9855-79166cefd249.png)


- **BUY ORDER**
  - Sell = ETH, buy = ERC20 (not WETH)
  - This time, set an amount in the "TO" input field to trigger a buy order, making sure the "FROM" field spits back out an amount within your balance threshold
  - make sure the amount shown in the ETH wrapping component below is the **same** as the "Maximum sold" amount in the dropdown
  - **Screenshots**
  - ![Screenshot from 2021-04-29 14-03-30](https://user-images.githubusercontent.com/21335563/116554962-b5782000-a8f3-11eb-80d2-00d787df1221.png)

# Changelog

8ff5964d Improve the FAQ page content/styles. (#567)
e9a44376 Fix blank page for buy orders wrapEth (#559)
907b2a83 Merge branch 'hotfix/0.10.1' into release/0.11
80d1d0b3 Prevent to check fee too often (#573)
e81b1907 Use chat link (#548)
f3d14371 Disable off button style (#555)
d778435c Disable hops (#554)
c1ff8ed7 [ETH/WETH] Confirmation Modal (#550)
20c72633 Replaced `Maximal` with `Maximum` (#546)
bcba26cf Show footer contracts on mobile. (#539)