### PR TITLE
Rename the app to CowSwap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis/gp-v2-ui",
-  "description": "Cow Swap - Gnosis Protocol",
+  "description": "CowSwap - Gnosis Protocol",
   "homepage": ".",
   "private": true,
   "version": "0.10.0",

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-  <title>Cow Swap</title>
+  <title>CowSwap</title>
   <% if (process.env.NODE_ENV==='production' ) { %>
     <script async src="https://w.appzi.io/w.js?token=5ju0G"></script>
     <% } %>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -17,8 +17,8 @@
     }
   ],
   "orientation": "portrait",
-  "name": "Cow Swap",
-  "short_name": "Cow Swap",
+  "name": "CowSwap",
+  "short_name": "CowSwap",
   "start_url": ".",
   "theme_color": "#ff784a"
 }

--- a/src/custom/components/swap/EthWethWrap/index.tsx
+++ b/src/custom/components/swap/EthWethWrap/index.tsx
@@ -214,7 +214,7 @@ export default function EthWethWrap({ account, native, nativeInput, wrapped, wra
           <h2>Confirm {nativeSymbol} wrap</h2>
           <ModalMessage>
             <span>
-              Cow Swap is a gasless exchange. <strong>{nativeSymbol}</strong> however, is required for paying{' '}
+              CowSwap is a gasless exchange. <strong>{nativeSymbol}</strong> however, is required for paying{' '}
               <strong>
                 on-chain transaction costs associated with enabling tokens and the wrapping/unwrapping of {nativeSymbol}
                 /{wrappedSymbol}

--- a/src/custom/connectors/index.ts
+++ b/src/custom/connectors/index.ts
@@ -99,6 +99,6 @@ export const portis = new PortisConnector({
 // mainnet only
 export const walletlink = new WalletLinkConnector({
   url: rpcNetworks[NETWORK_CHAIN_ID],
-  appName: 'Cow Swap',
+  appName: 'CowSwap',
   appLogoUrl: 'https://raw.githubusercontent.com/gnosis/gp-swap-ui/develop/public/images/logo-square-512.png'
 })


### PR DESCRIPTION
This PR rename the App name to `CowSwap` in a few places.


## Details
![image](https://user-images.githubusercontent.com/2352112/116694970-3d2b6080-a9c0-11eb-8e52-c967790a4659.png)

I noticed in this message the name of the app is not right.

It should be CowSwap instead of "Cow Swap", see for example here:
![image](https://user-images.githubusercontent.com/2352112/116695086-5e8c4c80-a9c0-11eb-8875-b82b7a95c2c4.png)


