### PR TITLE
Hotfix/0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "CowSwap - Gnosis Protocol",
   "homepage": ".",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "status": "Alpha",
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",

--- a/src/custom/constants/lists.ts
+++ b/src/custom/constants/lists.ts
@@ -13,7 +13,7 @@ const WRAPPED_LIST = 'wrapped.tokensoft.eth'
 const SET_LIST = 'https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/main/set.tokenlist.json'
 const OPYN_LIST = 'https://raw.githubusercontent.com/opynfinance/opyn-tokenlist/master/opyn-v1.tokenlist.json'
 const ROLL_LIST = 'https://app.tryroll.com/tokens.json'
-const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
+// const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
 const CMC_ALL_LIST = 'defi.cmc.eth'
 const CMC_STABLECOIN = 'stablecoin.cmc.eth'
 const KLEROS_LIST = 't2crtokens.eth'
@@ -56,7 +56,7 @@ export const DEFAULT_LIST_OF_LISTS_BY_NETWORK: NetworkLists = {
       SET_LIST,
       OPYN_LIST,
       ROLL_LIST,
-      COINGECKO_LIST,
+      // COINGECKO_LIST,
       CMC_ALL_LIST,
       CMC_STABLECOIN,
       KLEROS_LIST,


### PR DESCRIPTION
# Summary

Disables CoinGecko token list as it's currently causing the app to become non-responsive due to a duplicate token.