### PR TITLE
Main menu responsive improvements.

### DIFF
--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { Code, MessageCircle /*PieChart*/ } from 'react-feather'
 
 import MenuMod, { MenuItem, InternalMenuItem, MenuFlyout as MenuFlyoutUni } from './MenuMod'
-import { ApplicationModal } from 'state/application/actions'
-import { useToggleModal } from 'state/application/hooks'
+import { useCloseModals } from 'state/application/hooks'
 import styled from 'styled-components'
 import { Separator as SeparatorBase } from 'components/swap/styleds'
 import { CONTRACTS_CODE_LINK, DISCORD_LINK } from 'constants/index'
@@ -124,13 +123,13 @@ export const CloseMenu = styled.button`
 `
 
 export function Menu() {
-  const toggle = useToggleModal(ApplicationModal.MENU)
+  const close = useCloseModals()
 
   return (
     <StyledMenu>
       <MenuFlyout>
-        <CloseMenu onClick={toggle} />
-        <InternalMenuItem to="/faq" onClick={toggle}>
+        <CloseMenu onClick={close} />
+        <InternalMenuItem to="/faq" onClick={close}>
           <Code size={14} />
           FAQ
         </InternalMenuItem>
@@ -141,13 +140,13 @@ export function Menu() {
         </MenuItem> */}
 
         <MenuItem id="link" href={CONTRACTS_CODE_LINK}>
-          <span onClick={toggle}>
+          <span onClick={close}>
             <Code size={14} />
             Code
           </span>
         </MenuItem>
         <MenuItem id="link" href={DISCORD_LINK}>
-          <span onClick={toggle}>
+          <span onClick={close}>
             <MessageCircle size={14} />
             Discord
           </span>
@@ -155,7 +154,7 @@ export function Menu() {
 
         <Separator />
 
-        <Policy to="/terms-and-conditions" onClick={toggle}>
+        <Policy to="/terms-and-conditions" onClick={close}>
           Terms and conditions
         </Policy>
         {/* 

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Code, MessageCircle /*PieChart*/ } from 'react-feather'
 
 import MenuMod, { MenuItem, InternalMenuItem, MenuFlyout as MenuFlyoutUni } from './MenuMod'
+import { ApplicationModal } from 'state/application/actions'
+import { useToggleModal } from 'state/application/hooks'
 import styled from 'styled-components'
 import { Separator as SeparatorBase } from 'components/swap/styleds'
 import { CONTRACTS_CODE_LINK, DISCORD_LINK } from 'constants/index'
@@ -22,19 +24,113 @@ const Policy = styled(InternalMenuItem).attrs(attrs => ({
 
 const MenuFlyout = styled(MenuFlyoutUni)`
   min-width: 11rem;
+  box-shadow: 0 0 100vh 100vw rgb(0 0 0 / 25%);
+  top: calc(100% + 16px);
+  order: 1;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    top: initial;
+    bottom: calc(100% + 32px);
+  `}
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    top: 0;
+    left: 0;
+    position: fixed;
+    height: 100vh;
+    width: 100vw;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 0;
+    overflow-y: auto;
+  `};
+
+  > a {
+    transition: background 0.2s ease-in-out;
+    display: flex;
+    align-items: center;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      flex: 0 1 auto;
+      padding: 16px;
+      font-size: 18px;
+        svg {
+          width: 18px;
+          height: 18px;
+          object-fit: contain;
+          margin: 0 8px 0 0;
+        }
+    `};
+
+    > span {
+      display: flex;
+      align-items: center;
+    }
+
+    > span > svg {
+      margin: 0 8px 0 0;
+    }
+  }
+  > a:hover {
+    background: ${({ theme }) => theme.disabled};
+    border-radius: 6px;
+  }
 `
 
 export const Separator = styled(SeparatorBase)`
-  background-color: #0000002e;
+  background-color: ${({ theme }) => theme.disabled};
   margin: 0.3rem auto;
   width: 90%;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    width: 100%;
+    margin: 24px auto;
+  `};
+`
+
+export const CloseMenu = styled.button`
+  display: grid;
+  justify-content: space-between;
+  align-items: center;
+  background: ${({ theme }) => theme.disabled};
+  border: 0;
+  color: ${({ theme }) => theme.black};
+  height: 36px;
+  position: sticky;
+  top: 0;
+  cursor: pointer;
+  border-radius: 6px;
+  justify-content: center;
+  padding: 0;
+  margin: 0 0 8px;
+
+  ${({ theme }) => theme.mediaWidth.upToSmall`
+    height: 48px;
+    border-radius: 0;
+    justify-content: flex-end;
+  `};
+
+  &::after {
+    content: '✕';
+    display: block;
+    font-size: 20px;
+    margin: 0;
+
+    ${({ theme }) => theme.mediaWidth.upToSmall`
+      margin: 0 14px 0 0;
+      font-size: 24px;
+    `};
+  }
 `
 
 export function Menu() {
+  const toggle = useToggleModal(ApplicationModal.MENU)
+
   return (
     <StyledMenu>
       <MenuFlyout>
-        <InternalMenuItem to="/faq">
+        <CloseMenu onClick={toggle} />
+        <InternalMenuItem to="/faq" onClick={toggle}>
           <Code size={14} />
           FAQ
         </InternalMenuItem>
@@ -45,17 +141,23 @@ export function Menu() {
         </MenuItem> */}
 
         <MenuItem id="link" href={CONTRACTS_CODE_LINK}>
-          <Code size={14} />
-          Code
+          <span onClick={toggle}>
+            <Code size={14} />
+            Code
+          </span>
         </MenuItem>
         <MenuItem id="link" href={DISCORD_LINK}>
-          <MessageCircle size={14} />
-          Discord
+          <span onClick={toggle}>
+            <MessageCircle size={14} />
+            Discord
+          </span>
         </MenuItem>
 
         <Separator />
 
-        <Policy to="/terms-and-conditions">Terms and conditions</Policy>
+        <Policy to="/terms-and-conditions" onClick={toggle}>
+          Terms and conditions
+        </Policy>
         {/* 
         <Policy to="/privacy-policy">Privacy policy</Policy>
         <Policy to="/cookie-policy">Cookie policy</Policy> 


### PR DESCRIPTION

- Addresses in part https://github.com/gnosis/gp-swap-ui/issues/503
- Improve options to hide the menu, by adding an explicit X button. Also now makes sure the menu is toggled off, whenever you click on any of the current menu items:

https://user-images.githubusercontent.com/31534717/116997098-a53db780-acdc-11eb-9cdd-9a5ea6f70c93.mov

- Tablet support

https://user-images.githubusercontent.com/31534717/116997128-aff84c80-acdc-11eb-8113-c9464e43fcb7.mov



- Mobile menu

https://user-images.githubusercontent.com/31534717/116997470-2006d280-acdd-11eb-9553-6278b267bb59.mov




- Mobile menu supports a long list of items:

https://user-images.githubusercontent.com/31534717/116997535-36149300-acdd-11eb-8e57-aa2b94972428.mov


