### PR TITLE
[🔥 HOTFIX 🔥] 0.11.2

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -144,7 +144,7 @@ export default function Swap({
     currencies[Field.INPUT],
     currencies[Field.OUTPUT],
     // if native input !== NATIVE_TOKEN, validation fails
-    nativeInput,
+    nativeInput || parsedAmount,
     // should override and get wrapCallback?
     isNativeInSwap
   )


### PR DESCRIPTION
## Summary/QA
Seems `Mainnet` is unaffected, though `Rinkeby` suffers this issue. Maybe this hotfix is not required, will test a bit more

### Notes
In production/staging/everywhere but here:
1. select ETH<>WETH or vice versa
2. enter an amount within your balance
3. observe
4. shows `Enter an amount` which is a bug
![Screenshot from 2021-05-05 11-44-57](https://user-images.githubusercontent.com/21335563/117130112-805a4a80-ad97-11eb-9839-219e479fb511.png)

Fixed in this PR