### PR TITLE
Streamline styles for the swap container.

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -64,7 +64,8 @@ export default function Swap({
   EthWethWrapMessage,
   SwitchToWethBtn,
   FeesExceedFromAmountMessage,
-  BottomGrouping
+  BottomGrouping,
+  className
 }: SwapProps) {
   const loadedUrlParams = useDefaultsFromURLSearch()
 
@@ -362,7 +363,7 @@ export default function Swap({
         onDismiss={handleDismissTokenWarning}
       />
       <SwapPoolTabs active={'swap'} />
-      <AppBody>
+      <AppBody className={className}>
         <SwapHeader />
         <Wrapper id="swap-page">
           <ConfirmSwapModal
@@ -379,7 +380,9 @@ export default function Swap({
             onDismiss={handleConfirmDismiss}
           />
 
-          <AutoColumn gap={'md'}>
+          <AutoColumn
+          // gap={'sm'}
+          >
             <CurrencyInputPanel
               label={
                 <FeeInformationTooltip
@@ -405,7 +408,10 @@ export default function Swap({
               id="swap-currency-input"
             />
             <AutoColumn justify="space-between">
-              <AutoRow justify={isExpertMode ? 'space-between' : 'center'} style={{ padding: '0 1rem' }}>
+              <AutoRow
+                justify={isExpertMode ? 'space-between' : 'center'}
+                // style={{ padding: '0 1rem' }}
+              >
                 <ArrowWrapper clickable>
                   <ArrowDown
                     size="16"

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -14,6 +14,7 @@ import {
   ArrowWrapper as ArrowWrapperUni
 } from 'components/swap/styleds'
 import { AutoColumn } from 'components/Column'
+import Card from 'components/Card'
 import QuestionHelper from 'components/QuestionHelper'
 import { ButtonError, ButtonPrimary } from 'components/Button'
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
@@ -44,6 +45,10 @@ const SwapModWrapper = styled(SwapMod)`
 
     ${AutoColumn} {
       grid-row-gap: 3px;
+    }
+
+    ${Card} > ${AutoColumn} {
+      margin: 6px auto 0;
     }
 
     ${ArrowWrapperUni} {

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -8,7 +8,12 @@ import { ButtonSize, TYPE } from 'theme/index'
 
 import SwapMod from './SwapMod'
 import { RowBetween, RowFixed } from 'components/Row'
-import { BottomGrouping as BottomGroupingUni } from 'components/swap/styleds'
+import {
+  BottomGrouping as BottomGroupingUni,
+  Wrapper as WrapperUni,
+  ArrowWrapper as ArrowWrapperUni
+} from 'components/swap/styleds'
+import { AutoColumn } from 'components/Column'
 import QuestionHelper from 'components/QuestionHelper'
 import { ButtonError, ButtonPrimary } from 'components/Button'
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
@@ -24,12 +29,57 @@ const BottomGrouping = styled(BottomGroupingUni)`
   }
 `
 
+const SwapModWrapper = styled(SwapMod)`
+  ${props => props.className} {
+    // For now to target <SwapHeader /> without copying files...
+    > div:first-child {
+      padding: 0 12px 4px;
+      max-width: 100%;
+      margin: 0;
+    }
+
+    ${WrapperUni} {
+      padding: 4px 4px 0;
+    }
+
+    ${AutoColumn} {
+      grid-row-gap: 3px;
+    }
+
+    ${ArrowWrapperUni} {
+      position: absolute;
+      z-index: 2;
+      background: ${({ theme }) => theme.white};
+      border-radius: 9px;
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: 2px solid ${({ theme }) => theme.disabled};
+
+      &:hover {
+        opacity: 1;
+
+        > svg {
+          stroke: ${({ theme }) => theme.black};
+        }
+      }
+
+      > svg {
+        stroke: #000000b8;
+      }
+    }
+  }
+`
+
 export interface SwapProps extends RouteComponentProps {
   FeeGreaterMessage: React.FC<FeeGreaterMessageProp>
   EthWethWrapMessage: React.FC<EthWethWrapProps>
   SwitchToWethBtn: React.FC<SwitchToWethBtnProps>
   FeesExceedFromAmountMessage: React.FC
   BottomGrouping: React.FC
+  className?: string
 }
 
 function FeeGreaterMessage({ fee }: FeeGreaterMessageProp) {
@@ -99,7 +149,7 @@ function FeesExceedFromAmountMessage() {
 
 export default function Swap(props: RouteComponentProps) {
   return (
-    <SwapMod
+    <SwapModWrapper
       FeeGreaterMessage={FeeGreaterMessage}
       EthWethWrapMessage={EthWethWrapMessage}
       SwitchToWethBtn={SwitchToWethBtn}

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -110,7 +110,7 @@ function themeVariables(colorsTheme: Colors) {
       `,
       fontWeight: '800',
       border: `4px solid ${colorsTheme.black}`,
-      borderRadius: '9px',
+      borderRadius: '16px',
       boxShadow: `4px 4px 0px ${colorsTheme.black}`
     },
     buttonOutlined: {
@@ -120,7 +120,7 @@ function themeVariables(colorsTheme: Colors) {
       `,
       fontWeight: '800',
       border: `4px solid ${colorsTheme.black}`,
-      borderRadius: '9px',
+      borderRadius: '16px',
       boxShadow: `4px 4px 0px ${colorsTheme.black}`
     },
     buttonLight: {

--- a/src/custom/theme/cowSwapTheme.tsx
+++ b/src/custom/theme/cowSwapTheme.tsx
@@ -88,13 +88,13 @@ function themeVariables(colorsTheme: Colors) {
       `
     },
     appBody: {
-      boxShadow: `6px 6px 0px ${colorsTheme.black}`,
-      borderRadius: '8px',
-      border: `4px solid ${colorsTheme.black}`,
+      boxShadow: `4px 4px 0px ${colorsTheme.black}`,
+      borderRadius: '16px',
+      border: `3px solid ${colorsTheme.black}`,
       padding: '12px 6px',
       maxWidth: {
-        normal: '420px',
-        content: '620px'
+        normal: '460px',
+        content: '680px'
       }
     },
     header: {
@@ -132,7 +132,7 @@ function themeVariables(colorsTheme: Colors) {
     currencyInput: {
       background: `${colorsTheme.white}`,
       color: `${colorsTheme.text1}`,
-      border: `4px solid ${colorsTheme.black}`
+      border: `2px solid ${colorsTheme.disabled}`
     },
     buttonCurrencySelect: {
       background: `${colorsTheme.bg1}`,


### PR DESCRIPTION
- Streamlined the Swap container
- Width is now a bit larger => 460px
- Content page width now a bit larger => 680px
- On mobile it's a clear improvement in terms of the Swap container taking a bit less real estate.

Todo:
- Move the MAX button to the BALANCE line. This leaves more room for the input amount (especially on mobile).

Side by side comparison:
<img width="400" alt="Screen Shot 2021-05-07 at 13 50 33" src="https://user-images.githubusercontent.com/31534717/117445629-3742fb80-af3b-11eb-9952-905832c2f28d.png"><img width="400" alt="Screen Shot 2021-05-07 at 13 50 17" src="https://user-images.githubusercontent.com/31534717/117445640-3a3dec00-af3b-11eb-84b3-e9aff9863955.png">


https://user-images.githubusercontent.com/31534717/117445048-889ebb00-af3a-11eb-80da-c811cc9e8a11.mov

https://user-images.githubusercontent.com/31534717/117445175-b1bf4b80-af3a-11eb-9254-c25fdf49b60c.mov

