### PR TITLE
Deduct fee from the quoted price

### DIFF
--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -1,16 +1,44 @@
+import { BigNumber } from '@ethersproject/bignumber'
 import { useCallback } from 'react'
 import { useClearQuote, useUpdateQuote } from 'state/price/hooks'
 import { getCanonicalMarket, registerOnWindow } from 'utils/misc'
 import { FeeQuoteParams, getFeeQuote, getPriceQuote } from 'utils/operator'
+import { FeeInformation, PriceInformation } from '../state/price/reducer'
 
 export interface RefetchQuoteCallbackParmams {
   quoteParams: FeeQuoteParams
   fetchFee: boolean
+  previousFee?: FeeInformation
 }
 
-function handleError(err: any): undefined {
-  console.error('Error fetching price/fee', err)
-  return undefined
+async function getQuote({
+  quoteParams,
+  fetchFee,
+  previousFee
+}: RefetchQuoteCallbackParmams): Promise<[PriceInformation, FeeInformation]> {
+  const { sellToken, buyToken, amount, kind, chainId } = quoteParams
+  const { baseToken, quoteToken } = getCanonicalMarket({ sellToken, buyToken, kind })
+
+  // Get a new fee quote (if required)
+  const feePromise =
+    fetchFee || !previousFee ? getFeeQuote({ chainId, sellToken, buyToken, amount, kind }) : previousFee
+
+  // Get a new price quote
+  let exchangeAmount
+  if (kind === 'sell') {
+    // Sell orders need to deduct the fee from the swapped amount
+    exchangeAmount = BigNumber.from(amount)
+      .sub((await feePromise).amount)
+      .toString()
+  } else {
+    // For buy orders, we swap the whole amount, then we add the fee on top
+    exchangeAmount = amount
+  }
+
+  // Get price for price estimation
+  const pricePromise = getPriceQuote({ chainId, baseToken, quoteToken, amount: exchangeAmount, kind })
+
+  return Promise.all([pricePromise, feePromise])
 }
 
 /**
@@ -22,20 +50,12 @@ export function useRefetchQuoteCallback() {
   registerOnWindow({ updateQuote })
 
   return useCallback(
-    async ({ quoteParams, fetchFee }: RefetchQuoteCallbackParmams) => {
-      const { sellToken, buyToken, amount, kind, chainId } = quoteParams
-      const { baseToken, quoteToken } = getCanonicalMarket({ sellToken, buyToken, kind })
+    async (params: RefetchQuoteCallbackParmams) => {
+      const { sellToken, buyToken, amount, chainId } = params.quoteParams
+      try {
+        // Get the quote
+        const [price, fee] = await getQuote(params)
 
-      // Get a new price quote
-      const pricePromise = getPriceQuote({ chainId, baseToken, quoteToken, amount, kind }).catch(handleError)
-
-      // Get a new fee quote (if required)
-      const feePromise = fetchFee
-        ? getFeeQuote({ chainId, sellToken, buyToken, amount, kind }).catch(handleError)
-        : undefined
-
-      const [fee, price] = await Promise.all([feePromise, pricePromise])
-      if ((fee || !fetchFee) && price) {
         // Update quote
         updateQuote({
           sellToken,
@@ -44,11 +64,12 @@ export function useRefetchQuoteCallback() {
           price,
           chainId,
           lastCheck: Date.now(),
-          // Fee is only updated when fetchFee=true
           fee
         })
-      } else {
-        // Clear the fee
+      } catch (error) {
+        console.error('Error getting the quote (price/fee)', error)
+
+        // Clear the quote
         clearQuote({ chainId, token: sellToken })
       }
     },

--- a/src/custom/state/price/actions.ts
+++ b/src/custom/state/price/actions.ts
@@ -1,11 +1,8 @@
 import { createAction } from '@reduxjs/toolkit'
 import { ChainId } from '@uniswap/sdk'
-import { FeeInformation, QuoteInformationObject } from './reducer'
+import { QuoteInformationObject } from './reducer'
 
-// UpdateQuoteParams is QuoteInformationObject but with the fee optional
-export type UpdateQuoteParams = Omit<QuoteInformationObject, 'fee'> & {
-  fee?: FeeInformation
-}
+export type UpdateQuoteParams = QuoteInformationObject
 
 export interface ClearQuoteParams {
   token: string // token address,

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -23,7 +23,7 @@ export interface PriceInformation {
 }
 
 export interface QuoteInformationObject extends Omit<FeeQuoteParams, 'kind'> {
-  fee?: FeeInformation
+  fee: FeeInformation
   price: PriceInformation
   lastCheck: number
 }
@@ -55,11 +55,7 @@ export default createReducer(initialState, builder =>
     .addCase(updateQuote, (state, action) => {
       initializeState(state, action)
       const { sellToken, chainId } = action.payload
-      state[chainId][sellToken] = {
-        ...state[chainId][sellToken],
-        ...action.payload,
-        fee: action.payload.fee || state[chainId][sellToken]?.fee
-      }
+      state[chainId][sellToken] = action.payload
     })
     .addCase(clearQuote, (state, action) => {
       initializeState(state, action)

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -129,7 +129,8 @@ export default function FeesUpdater(): null {
       if (refetchAll || refetchPrice) {
         refetchQuote({
           quoteParams,
-          fetchFee: refetchAll
+          fetchFee: refetchAll,
+          previousFee: quoteInfo?.fee
         }).catch(error => console.error('Error re-fetching the quote', error))
       }
     }

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -72,7 +72,7 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
 
   useEffect(() => {
     console.log('[useDerivedSwapInfo] Price quote: ', quote?.price.amount)
-    console.log('[useDerivedSwapInfo] Fee quote: ', quote?.fee?.amount)
+    console.log('[useDerivedSwapInfo] Fee quote: ', quote?.fee.amount)
   }, [quote])
 
   const bestTradeExactIn = useTradeExactInWithFee({


### PR DESCRIPTION
Deducts the fee amounts from the price estimation if necesary

## Motivation
Sell orders don't exchange the whole amount shown in the FROM. Some part of it goes to fees.

Therefore, when estimatimating the amount of tokens you receive, you need to first deduct the fee from the amount.

This is not the case for buy orders, where you really want to get a fixed amount of tokens. So you want to ask for how much does the exchange need from the sell token in order to get the fixed amount of tokens we want of the buy token.

## Example
For selling 100 DAI, if the fee is 20 DAI, you need to ask for the price of selling 80 DAI. This is what we show in the TO.

For buying 100 DAI for USDC, the fee is 20 USDC, you need to ask for the price of buying the 100 DAI, then you need to add the 20 USDC on top for showing it in the FROM

## Bonus
This PR improves how we model the quote. 
Now fee is not optional, which reflect the reality more. 

We can have a quote or not, but if we have it, we will have both the fee and the price .

## Test
This is a technical PR, so is a bit hard to test for QA, so these notes are meant for the dev team. 
QA can test in a later PR, when we connect this with the PR that displays the new price estimations.

We should make sure that now we ask for the right amount when we request a quote.

This should work for both buy/sell orders. 

Make sure you enable the debug level in the console, and check the request that it's being made.