### PR TITLE
[Price] Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
   "jest": {
     "moduleNameMapper": {
       "@src/(.*)": "<rootDir>/src/$1"
-    }
+    },
+    "coveragePathIgnorePatterns": ["<rootDir>/src/*/*.d.ts"]
   },
   "eslintConfig": {
     "extends": "react-app",

--- a/package.json
+++ b/package.json
@@ -121,8 +121,7 @@
   "jest": {
     "moduleNameMapper": {
       "@src/(.*)": "<rootDir>/src/$1"
-    },
-    "coveragePathIgnorePatterns": ["<rootDir>/src/*/*.d.ts"]
+    }
   },
   "eslintConfig": {
     "extends": "react-app",

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -1,0 +1,87 @@
+import { parseUnits } from '@ethersproject/units'
+import { getPriceQuote } from '@src/custom/utils/operator'
+import { basisPointsToPercent } from '@src/utils'
+import { ChainId, Fraction, JSBI, Pair, Route, Token, TokenAmount, Trade, TradeType, WETH } from '@uniswap/sdk'
+// import { BigNumber } from 'ethers'
+
+describe('Swap testing', () => {
+  const WETH_MAINNET = new Token(ChainId.MAINNET, WETH[1].address, 18)
+  const DAI = new Token(ChainId.MAINNET, '0x6b175474e89094c44da98b954eedeac495271d0f', 18)
+
+  const pair12 = new Pair(
+    new TokenAmount(WETH_MAINNET, JSBI.BigInt(1000000000)),
+    new TokenAmount(DAI, JSBI.BigInt(2000000000))
+  )
+  // 1 WETH
+  const amountIn = parseUnits('1').toString()
+  const currencyIn = new TokenAmount(WETH_MAINNET, amountIn)
+
+  describe('ExactIn: WETH/DAI', () => {
+    let inTrade, quote: any, extendedTradeIn: any
+
+    beforeEach(async () => {
+      inTrade = new Trade(new Route([pair12], WETH_MAINNET), currencyIn, TradeType.EXACT_INPUT)
+
+      quote = await getPriceQuote({
+        chainId: 1,
+        quoteToken: DAI.address,
+        baseToken: WETH_MAINNET.address,
+        amount: amountIn,
+        kind: 'sell'
+      })
+
+      extendedTradeIn = {
+        ...inTrade,
+        outputAmount: new TokenAmount(DAI, quote.amount),
+        maximumAmountIn: inTrade.maximumAmountIn,
+        minimumAmountOut: inTrade.minimumAmountOut
+      }
+    })
+
+    it('Expect FAIL: ExactIN swap: 0.5% Slippage', async () => {
+      // we expect a slippage of (1 - slippage) e.g 1 - 0.005 = 0.995
+      const expectedSlippage = new Fraction('995', '1000')
+      // let's check against the way Uni calculates it exactly using 0.5% slippage
+      const actualSlippage = new Fraction('1').add(basisPointsToPercent(50)).invert()
+
+      // Calculate our expected output
+      const expectedOutput = new Fraction(quote.amount).multiply(expectedSlippage)
+      // Actual:
+      const uniSlippageCalculation = extendedTradeIn.minimumAmountOut(basisPointsToPercent(50)).raw.toString()
+
+      console.log(
+        `
+            EXPECTED SLIPPAGE:  ${expectedSlippage.toFixed(12)}
+            ACTUAL SLIPPAGE:    ${actualSlippage.toFixed(12)}
+          `
+      )
+
+      console.log(
+        `
+            EXPECTED SLIPPAGE OUTPUT:  ${expectedOutput.quotient.toString()}
+            ACTUAL SLIPPAGE OUTPUT:    ${uniSlippageCalculation}
+          `
+      )
+
+      // slippage expected and actual slippage do not match..
+      expect(expectedSlippage.equalTo(actualSlippage)).toBeFalsy()
+      // there is a slight mismatch...
+      expect(uniSlippageCalculation).not.toEqual(expectedOutput.quotient.toString())
+    })
+
+    it('Expect PASS: ExactIN swap: 0.5% Slippage', async () => {
+      // calculate slippage EXACTLY as uni does
+      // first we convert basis points slippage 50 (0.005) to Percent
+      // then we add to Fraction(1) and INVERT
+      const slippage = basisPointsToPercent(50)
+      const expectedSlippage = new Fraction('1').add(slippage).invert()
+
+      // multiply our quoted amount by the expectedSlippage
+      const expectedOutput = new Fraction(quote.amount).multiply(expectedSlippage)
+      // Actual:
+      const uniSlippageCalculation = extendedTradeIn.minimumAmountOut(slippage).raw.toString()
+
+      expect(uniSlippageCalculation).toEqual(expectedOutput.quotient.toString())
+    })
+  })
+})

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -46,7 +46,7 @@ describe('Swap testing', () => {
       // Calculate our expected output
       const expectedOutput = new Fraction(quote.amount).multiply(expectedSlippage)
       // Actual:
-      const uniSlippageCalculation = extendedTradeIn.minimumAmountOut(basisPointsToPercent(50)).raw.toString()
+      const actualOutput = extendedTradeIn.minimumAmountOut(basisPointsToPercent(50)).raw.toString()
 
       console.log(
         `
@@ -58,29 +58,29 @@ describe('Swap testing', () => {
       console.log(
         `
             EXPECTED SLIPPAGE OUTPUT:  ${expectedOutput.quotient.toString()}
-            ACTUAL SLIPPAGE OUTPUT:    ${uniSlippageCalculation}
+            ACTUAL SLIPPAGE OUTPUT:    ${actualOutput}
           `
       )
 
       // slippage expected and actual slippage do not match..
       expect(expectedSlippage.equalTo(actualSlippage)).toBeFalsy()
       // there is a slight mismatch...
-      expect(uniSlippageCalculation).not.toEqual(expectedOutput.quotient.toString())
+      expect(actualOutput).not.toEqual(expectedOutput.quotient.toString())
     })
 
     it('Expect PASS: ExactIN swap: 0.5% Slippage', async () => {
       // calculate slippage EXACTLY as uni does
       // first we convert basis points slippage 50 (0.005) to Percent
       // then we add to Fraction(1) and INVERT
-      const slippage = basisPointsToPercent(50)
-      const expectedSlippage = new Fraction('1').add(slippage).invert()
+      const slippagePercent = basisPointsToPercent(50)
+      const expectedSlippage = new Fraction('1').add(slippagePercent).invert()
 
       // multiply our quoted amount by the expectedSlippage
       const expectedOutput = new Fraction(quote.amount).multiply(expectedSlippage)
       // Actual:
-      const uniSlippageCalculation = extendedTradeIn.minimumAmountOut(slippage).raw.toString()
+      const actualSlippage = extendedTradeIn.minimumAmountOut(slippagePercent).raw.toString()
 
-      expect(uniSlippageCalculation).toEqual(expectedOutput.quotient.toString())
+      expect(actualSlippage).toEqual(expectedOutput.quotient.toString())
     })
   })
 })

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -2,7 +2,6 @@ import { parseUnits } from '@ethersproject/units'
 import { getPriceQuote } from '@src/custom/utils/operator'
 import { basisPointsToPercent } from '@src/utils'
 import { ChainId, Fraction, JSBI, Pair, Route, Token, TokenAmount, Trade, TradeType, WETH } from '@uniswap/sdk'
-// import { BigNumber } from 'ethers'
 
 describe('Swap testing', () => {
   const WETH_MAINNET = new Token(ChainId.MAINNET, WETH[1].address, 18)

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -1,8 +1,16 @@
 import { parseUnits } from '@ethersproject/units'
 import { getCanonicalMarket } from '@src/custom/utils/misc'
-import { getPriceQuote } from '@src/custom/utils/operator'
+import { PriceQuoteParams } from '@src/custom/utils/operator'
 import { basisPointsToPercent } from '@src/utils'
 import { ChainId, Fraction, JSBI, Pair, Route, Token, TokenAmount, Trade, TradeType, WETH } from '@uniswap/sdk'
+
+async function mockGetPriceQuote(params: PriceQuoteParams & { mockedPriceOut: string }) {
+  const { quoteToken, mockedPriceOut } = params
+  return Promise.resolve({
+    amount: mockedPriceOut,
+    token: quoteToken
+  })
+}
 
 const WETH_MAINNET = new Token(ChainId.MAINNET, WETH[1].address, 18)
 const DAI_MAINNET = new Token(ChainId.MAINNET, '0x6b175474e89094c44da98b954eedeac495271d0f', 18)
@@ -20,6 +28,8 @@ describe('Swap PRICE Quote test', () => {
     const amountIn = parseUnits('1').toString()
     const currencyIn = new TokenAmount(WETH_MAINNET, amountIn)
 
+    const MOCKED_PRICE_OUT = parseUnits('4273', DAI_MAINNET.decimals).toString()
+
     beforeEach(async () => {
       // make a new Trade object
       inTrade = new Trade(new Route([PAIR_WETH_DAI], WETH_MAINNET), currencyIn, TradeType.EXACT_INPUT)
@@ -31,7 +41,10 @@ describe('Swap PRICE Quote test', () => {
       })
 
       // get the WETH/DAI quote
-      quote = await getPriceQuote({
+      // mock and return MOCKED_PRICE_OUT
+      quote = await mockGetPriceQuote({
+        // custom amount out we want as part of mock
+        mockedPriceOut: MOCKED_PRICE_OUT,
         chainId: 1,
         quoteToken,
         baseToken,
@@ -47,7 +60,7 @@ describe('Swap PRICE Quote test', () => {
       }
     })
 
-    it('Expect FAIL: ExactIN swap: 0.5% Slippage', async () => {
+    it('[Expect FAIL] ExactIN swap: 0.5% Slippage: <outputAmount * (1 - 0.005)>', async () => {
       // we expect a slippage of (1 - slippage) e.g 1 - 0.005 = 0.995
       const expectedSlippage = new Fraction('995', '1000')
       // let's check against the way Uni calculates it exactly using 0.5% slippage
@@ -78,19 +91,22 @@ describe('Swap PRICE Quote test', () => {
       expect(actualOutput).not.toEqual(expectedOutput.quotient.toString())
     })
 
-    it('Expect PASS: ExactIN swap: 0.5% Slippage', async () => {
+    it('[Expect PASS] ExactIN swap: 0.5% Slippage: <outputAmount * (1 / (1 + 0.005))>', async () => {
       // calculate slippage EXACTLY as uni does
       // first we convert basis points slippage 50 (0.005) to Percent
       // then we add to Fraction(1) and INVERT
       const slippagePercent = basisPointsToPercent(50)
+      // NOTE: the .invert() here, as Uni does it, doesn't return a clean
+      // amount as we might expect, hence the issue.
+      // it can be rewritten as: (1 / (1 + 0.005<slippage>)) = 0.9950248756218907
       const expectedSlippage = new Fraction('1').add(slippagePercent).invert()
 
       // multiply our quoted amount by the expectedSlippage
       const expectedOutput = new Fraction(quote.amount).multiply(expectedSlippage)
       // Actual:
-      const actualSlippage = extendedTradeIn.minimumAmountOut(slippagePercent).raw.toString()
+      const actualOutput = extendedTradeIn.minimumAmountOut(slippagePercent).raw.toString()
 
-      expect(actualSlippage).toEqual(expectedOutput.quotient.toString())
+      expect(actualOutput).toEqual(expectedOutput.quotient.toString())
     })
   })
 })

--- a/src/theme/styled.ts
+++ b/src/theme/styled.ts
@@ -1,5 +1,3 @@
-import { FlattenSimpleInterpolation, ThemedCssFunction } from 'styled-components'
-
 export type Color = string
 export interface Colors {
   // base


### PR DESCRIPTION
This attempts to show that the math is correct and it is the way Uni calculates the slippage minimium output amount on ExactIn trades that is showing the slight number mismatch.

To test: `yarn test` - it is the `trade.test.ts` file.

Basically (in the case of a 0.5% slippage) Uni does not use 0.995 (1 - 0.005) to multiply against the unadjusted output. It gets a slightly larger number like e.g 0.99523125123 (see in the test)