### PR TITLE
Wallet connect - identify smart contract wallet

### DIFF
--- a/src/custom/hooks/index.tsx
+++ b/src/custom/hooks/index.tsx
@@ -1,0 +1,20 @@
+import { useMemo } from 'react'
+import { Web3Provider } from '@ethersproject/providers'
+import { useActiveWeb3React } from '@src/hooks/index'
+
+export * from '@src/hooks/index'
+
+/**
+ * Provides a Web3Provider instance for active web3 connection, if any
+ * Contrary to `getNetworkLibrary` that returns it for the default chainId
+ */
+export function useActiveWeb3Instance(): Web3Provider | undefined {
+  const { library } = useActiveWeb3React()
+
+  return useMemo(() => {
+    if (!library?.provider) {
+      return
+    }
+    return new Web3Provider(library.provider)
+  }, [library])
+}

--- a/src/custom/hooks/useWalletInfo.ts
+++ b/src/custom/hooks/useWalletInfo.ts
@@ -1,10 +1,12 @@
 import WalletConnectProvider from '@walletconnect/web3-provider'
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
 import { useWeb3React } from '@web3-react/core'
+import { Web3Provider } from '@ethersproject/providers'
 import useENSName from '@src/hooks/useENSName'
 import { useEffect, useState } from 'react'
 import { NetworkContextName } from 'constants/index'
 import { getProviderType, WalletProvider } from 'connectors'
+import { useActiveWeb3Instance } from 'hooks/index'
 
 export interface ConnectedWalletInfo {
   active: boolean
@@ -16,6 +18,18 @@ export interface ConnectedWalletInfo {
   ensName?: string
   icon?: string
   isSupportedWallet: boolean
+}
+
+async function checkIsSmartContractWallet(
+  address: string | undefined | null,
+  web3: Web3Provider | undefined
+): Promise<boolean> {
+  if (!address || !web3) {
+    return false
+  }
+
+  const code = await web3.getCode(address)
+  return code !== '0x'
 }
 
 async function getWcPeerMetadata(connector: WalletConnectConnector): Promise<{ walletName?: string; icon?: string }> {
@@ -35,10 +49,12 @@ async function getWcPeerMetadata(connector: WalletConnectConnector): Promise<{ w
 
 export function useWalletInfo(): ConnectedWalletInfo {
   const { active, account, connector } = useWeb3React()
+  const web3Instance = useActiveWeb3Instance()
   const [walletName, setWalletName] = useState<string>()
   const [icon, setIcon] = useState<string>()
   // const [isSupportedWallet, setIsSupportedWallet] = useState(false)
   const [provider, setProvider] = useState<WalletProvider>()
+  const [isSmartContractWallet, setIsSmartContractWallet] = useState(false)
   const contextNetwork = useWeb3React(NetworkContextName)
   const { ENSName } = useENSName(account ?? undefined)
 
@@ -55,12 +71,18 @@ export function useWalletInfo(): ConnectedWalletInfo {
     }
   }, [connector])
 
+  useEffect(() => {
+    if (account || web3Instance) {
+      checkIsSmartContractWallet(account, web3Instance).then(setIsSmartContractWallet)
+    }
+  }, [account, web3Instance])
+
   return {
     active,
     account,
     activeNetwork: contextNetwork.active,
     provider,
-    isSmartContractWallet: false, // TODO: Check if the connected address has some code associated
+    isSmartContractWallet,
     walletName,
     icon,
     ensName: ENSName || undefined,

--- a/src/custom/hooks/useWalletInfo.ts
+++ b/src/custom/hooks/useWalletInfo.ts
@@ -72,7 +72,7 @@ export function useWalletInfo(): ConnectedWalletInfo {
   }, [connector])
 
   useEffect(() => {
-    if (account || web3Instance) {
+    if (account && web3Instance) {
       checkIsSmartContractWallet(account, web3Instance).then(setIsSmartContractWallet)
     }
   }, [account, web3Instance])


### PR DESCRIPTION
# Summary

Wallet connect - identify smart contract wallet

Part of and pipe into https://github.com/gnosis/gp-swap-ui/pull/597

Now whenever a smart contract wallet is connected, the flag is properly set
![screenshot_2021-05-13_14-01-13](https://user-images.githubusercontent.com/43217/118187362-b03acb00-b3f3-11eb-8f3b-64234592ac30.png)

No functional changes in the UI so far, it'll come next.

# Testing

1. Using WC, connect a smart contract wallet, like Argent or Gnosis Safe
- [ ]  Check the console logs for a message like the one above. It should have the flag `isSmartContractWallet` set to `true`

1. Using WC, connect a EOA wallet, like TrustWallet, TokenPocket, etc
- [ ]  Check the console logs for a message like the one above. It should have the flag `isSmartContractWallet` set to `false`

1. Connect any other EOA wallet such as Metamask, or dApp browser wallets like Status
- [ ]  Check the console logs for a message like the one above. It should have the flag `isSmartContractWallet` set to `false`

