### PR TITLE
Fix missing swap button

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -551,7 +551,7 @@ export default function Swap({
                     'Approve ' + currencies[Field.INPUT]?.symbol
                   )}
                 </ButtonConfirmed>
-                {/* <ButtonError
+                <ButtonError
                   buttonSize={ButtonSize.BIG}
                   onClick={() => {
                     if (isExpertMode) {
@@ -569,16 +569,17 @@ export default function Swap({
                   width="48%"
                   id="swap-button"
                   disabled={
-                    !isValid || approval !== ApprovalState.APPROVED || (priceImpactSeverity > 3 && !isExpertMode)
+                    !isValid || approval !== ApprovalState.APPROVED // || (priceImpactSeverity > 3 && !isExpertMode)
                   }
-                  error={isValid && priceImpactSeverity > 2}
+                  // error={isValid && priceImpactSeverity > 2}
                 >
                   <Text fontSize={16} fontWeight={500}>
-                    {priceImpactSeverity > 3 && !isExpertMode
+                    {/* {priceImpactSeverity > 3 && !isExpertMode
                       ? `Price Impact High`
-                      : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`}
+                      : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`} */}
+                    Swap
                   </Text>
-                </ButtonError> */}
+                </ButtonError>
               </RowBetween>
             ) : (
               <ButtonError


### PR DESCRIPTION
Fixes an issue with the missing swap button.
It was happening always when you need to approve a token.

Before this PR:
<img width="714" alt="Screenshot at May 14 15-21-28" src="https://user-images.githubusercontent.com/2352112/118301495-6c26f380-b4e3-11eb-8ffe-79f45679103b.png">

After this PR:
<img width="672" alt="Screenshot at May 14 18-33-19" src="https://user-images.githubusercontent.com/2352112/118301522-7812b580-b4e3-11eb-9617-a5028c5c9dc8.png">


## Test
Make sure the Swap button shows in every condition.
Try to break the app so it doesn't show :) 

1. Select token pair, where the sell token hasn't been approved before
2. Observe the app, try to approve and swap