### PR TITLE
Wallet connect - unsupported wallets

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -27,6 +27,9 @@ export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((
   return acc
 }, {} as { [key: string]: WalletInfo })
 
+// Smart contract wallets are filtered out by default, no need to add them to this list
+export const UNSUPPORTED_WC_WALLETS = new Set(['DeFi Wallet', 'TokenPocket'])
+
 // TODO: When contracts are deployed, we can load this from the NPM package
 export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<ChainId, string>> = {
   [ChainId.MAINNET]: GPv2Settlement[ChainId.MAINNET].address,

--- a/src/custom/hooks/useWalletInfo.ts
+++ b/src/custom/hooks/useWalletInfo.ts
@@ -4,7 +4,7 @@ import { useWeb3React } from '@web3-react/core'
 import { Web3Provider } from '@ethersproject/providers'
 import useENSName from '@src/hooks/useENSName'
 import { useEffect, useState } from 'react'
-import { NetworkContextName } from 'constants/index'
+import { NetworkContextName, UNSUPPORTED_WC_WALLETS } from 'constants/index'
 import { getProviderType, WalletProvider } from 'connectors'
 import { useActiveWeb3Instance } from 'hooks/index'
 
@@ -32,6 +32,10 @@ async function checkIsSmartContractWallet(
   return code !== '0x'
 }
 
+function checkIsSupportedWallet(name: string | undefined, isSmartContractWallet: boolean): boolean {
+  return !isSmartContractWallet && !UNSUPPORTED_WC_WALLETS.has(name || '')
+}
+
 async function getWcPeerMetadata(connector: WalletConnectConnector): Promise<{ walletName?: string; icon?: string }> {
   const provider = (await connector.getProvider()) as WalletConnectProvider
   console.log('Meta: ', provider.walletMeta)
@@ -52,7 +56,6 @@ export function useWalletInfo(): ConnectedWalletInfo {
   const web3Instance = useActiveWeb3Instance()
   const [walletName, setWalletName] = useState<string>()
   const [icon, setIcon] = useState<string>()
-  // const [isSupportedWallet, setIsSupportedWallet] = useState(false)
   const [provider, setProvider] = useState<WalletProvider>()
   const [isSmartContractWallet, setIsSmartContractWallet] = useState(false)
   const contextNetwork = useWeb3React(NetworkContextName)
@@ -86,6 +89,6 @@ export function useWalletInfo(): ConnectedWalletInfo {
     walletName,
     icon,
     ensName: ENSName || undefined,
-    isSupportedWallet: true // TODO: We can do test of all wallets using WC, and see the ones we can support
+    isSupportedWallet: checkIsSupportedWallet(walletName, isSmartContractWallet)
   }
 }


### PR DESCRIPTION
# Summary

Part of and pipe into #597

Setting `isSupportedWallet` flag
![screenshot_2021-05-14_10-03-34](https://user-images.githubusercontent.com/43217/118304501-9654c300-b49b-11eb-8b7f-42a9ba62afda.png)

Adding two WC wallets to the list of unsupported wallets:
- Crypto.com Defi Wallet
- TokenPocket - dApp browser works, though

# Testing

1. Using WC, connect a smart contract wallet, like Argent or Gnosis Safe
- [ ]  Check the console logs for a message like the one above. It should have the flag `isSupportedWallet` set to `false`

2. Using WC, connect TokenPocket
- [ ]  Check the console logs for a message like the one above. It should have the flag `isSupportedWallet` set to `false`
3. Repeat `2` using Crypto.com Defi Wallet

4. Using WC, connect any other EOA wallet such as Metamask, TrustWallet, etc
- [ ]  Check the console logs for a message like the one above. It should have the flag `isSupportedWallet` set to `true`

5. Connect any other EOA wallet such as Metamask, or dApp browser wallets like Status
- [ ]  Check the console logs for a message like the one above. It should have the flag `isSupportedWallet` set to `true`
