### PR TITLE
Wallet connect - block unsupported

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,9 +8,7 @@
       "jsx": true
     }
   },
-  "ignorePatterns": [
-    "node_modules/**/*"
-  ],
+  "ignorePatterns": ["node_modules/**/*"],
   "settings": {
     "react": {
       "version": "detect"
@@ -21,7 +19,8 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:react-hooks/recommended",
     "prettier/@typescript-eslint",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:jsx-a11y/recommended"
   ],
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -62,7 +62,7 @@ export function getStatusIcon(connector?: AbstractConnector, walletInfo?: Connec
   if (walletInfo && !walletInfo.isSupportedWallet) {
     /* eslint-disable jsx-a11y/accessible-emoji */
     return (
-      <MouseoverTooltip text="Wallet not currently supported">
+      <MouseoverTooltip text="This wallet is not yet supported">
         <IconWrapper role="img" aria-label="Warning sign. Wallet not supported">
           ⚠️
         </IconWrapper>

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -43,14 +43,18 @@ import { MouseoverTooltip } from 'components/Tooltip/TooltipMod'
 
 type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'>['connector']
 
-export function formatConnectorName(connector?: AbstractConnector) {
+export function formatConnectorName(connector?: AbstractConnector, walletInfo?: ConnectedWalletInfo) {
   const { ethereum } = window
+  const { walletName } = walletInfo || {}
   const isMetaMask = !!(ethereum && ethereum.isMetaMask)
-  const name = Object.keys(SUPPORTED_WALLETS)
-    .filter(
-      k => SUPPORTED_WALLETS[k].connector === connector && (connector !== injected || isMetaMask === (k === 'METAMASK'))
-    )
-    .map(k => SUPPORTED_WALLETS[k].name)[0]
+  const name =
+    walletName ||
+    Object.keys(SUPPORTED_WALLETS)
+      .filter(
+        k =>
+          SUPPORTED_WALLETS[k].connector === connector && (connector !== injected || isMetaMask === (k === 'METAMASK'))
+      )
+      .map(k => SUPPORTED_WALLETS[k].name)[0]
   return <WalletName>Connected with {name}</WalletName>
 }
 
@@ -147,7 +151,7 @@ export default function AccountDetails({
           <YourAccount>
             <InfoCard>
               <AccountGroupingRow>
-                {formatConnectorName(connector)}
+                {formatConnectorName(connector, walletInfo)}
                 <div>
                   {connector !== injected && connector !== walletlink && (
                     <WalletAction

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -38,6 +38,8 @@ import {
   IconWrapper,
   renderTransactions
 } from './AccountDetailsMod'
+import { ConnectedWalletInfo, useWalletInfo } from 'hooks/useWalletInfo'
+import { MouseoverTooltip } from 'components/Tooltip/TooltipMod'
 
 type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'>['connector']
 
@@ -52,8 +54,18 @@ export function formatConnectorName(connector?: AbstractConnector) {
   return <WalletName>Connected with {name}</WalletName>
 }
 
-export function getStatusIcon(connector?: AbstractConnector) {
-  if (connector === injected) {
+export function getStatusIcon(connector?: AbstractConnector, walletInfo?: ConnectedWalletInfo) {
+  if (walletInfo && !walletInfo.isSupportedWallet) {
+    /* eslint-disable jsx-a11y/accessible-emoji */
+    return (
+      <MouseoverTooltip text="Wallet not currently supported">
+        <IconWrapper role="img" aria-label="Warning sign. Wallet not supported">
+          ⚠️
+        </IconWrapper>
+      </MouseoverTooltip>
+    )
+    /* eslint-enable jsx-a11y/accessible-emoji */
+  } else if (connector === injected) {
     return (
       <IconWrapper size={16}>
         <Identicon />
@@ -104,6 +116,7 @@ export default function AccountDetails({
   openOptions
 }: AccountDetailsProps) {
   const { chainId, account, connector } = useActiveWeb3React()
+  const walletInfo = useWalletInfo()
   const theme = useContext(ThemeContext)
   const dispatch = useDispatch<AppDispatch>()
 
@@ -155,14 +168,14 @@ export default function AccountDetails({
                   {ENSName ? (
                     <>
                       <div>
-                        {getStatusIcon()}
+                        {getStatusIcon(connector, walletInfo)}
                         <p> {ENSName}</p>
                       </div>
                     </>
                   ) : (
                     <>
                       <div>
-                        {getStatusIcon()}
+                        {getStatusIcon(connector, walletInfo)}
                         <p> {account && shortenAddress(account)}</p>
                       </div>
                     </>

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -45,10 +45,9 @@ type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'
 
 export function formatConnectorName(connector?: AbstractConnector, walletInfo?: ConnectedWalletInfo) {
   const { ethereum } = window
-  const { walletName } = walletInfo || {}
   const isMetaMask = !!(ethereum && ethereum.isMetaMask)
   const name =
-    walletName ||
+    walletInfo?.walletName ||
     Object.keys(SUPPORTED_WALLETS)
       .filter(
         k =>

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -43,17 +43,19 @@ import { MouseoverTooltip } from 'components/Tooltip/TooltipMod'
 
 type AbstractConnector = Pick<ReturnType<typeof useActiveWeb3React>, 'connector'>['connector']
 
-export function formatConnectorName(connector?: AbstractConnector, walletInfo?: ConnectedWalletInfo) {
+function getWalletName(connector?: AbstractConnector): string {
   const { ethereum } = window
   const isMetaMask = !!(ethereum && ethereum.isMetaMask)
-  const name =
-    walletInfo?.walletName ||
-    Object.keys(SUPPORTED_WALLETS)
-      .filter(
-        k =>
-          SUPPORTED_WALLETS[k].connector === connector && (connector !== injected || isMetaMask === (k === 'METAMASK'))
-      )
-      .map(k => SUPPORTED_WALLETS[k].name)[0]
+
+  const walletTuple = Object.entries(SUPPORTED_WALLETS).filter(
+    ([walletType, { connector: walletConnector }]) =>
+      walletConnector === connector && (connector !== injected || isMetaMask === (walletType === 'METAMASK'))
+  )
+  return walletTuple[0]?.[1]?.name || 'Unknown wallet'
+}
+
+export function formatConnectorName(connector?: AbstractConnector, walletInfo?: ConnectedWalletInfo) {
+  const name = walletInfo?.walletName || getWalletName(connector)
   return <WalletName>Connected with {name}</WalletName>
 }
 

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -65,6 +65,12 @@ export function getStatusIcon(connector?: AbstractConnector, walletInfo?: Connec
       </MouseoverTooltip>
     )
     /* eslint-enable jsx-a11y/accessible-emoji */
+  } else if (walletInfo?.icon) {
+    return (
+      <IconWrapper size={16}>
+        <img src={walletInfo.icon} alt={`${walletInfo?.walletName || 'wallet'} logo`} />
+      </IconWrapper>
+    )
   } else if (connector === injected) {
     return (
       <IconWrapper size={16}>

--- a/src/custom/components/AccountDetails/index.tsx
+++ b/src/custom/components/AccountDetails/index.tsx
@@ -10,7 +10,7 @@ import Copy from 'components/AccountDetails/Copy'
 
 import { SUPPORTED_WALLETS } from 'constants/index'
 import { getEtherscanLink } from 'utils'
-import { injected, walletconnect, walletlink, fortmatic, portis } from 'connectors'
+import { injected, walletconnect, walletlink, fortmatic, portis, WalletProvider } from 'connectors'
 import CoinbaseWalletIcon from 'assets/images/coinbaseWalletIcon.svg'
 import WalletConnectIcon from 'assets/images/walletConnectIcon.svg'
 import FortmaticIcon from 'assets/images/fortmaticIcon.png'
@@ -56,7 +56,18 @@ function getWalletName(connector?: AbstractConnector): string {
 
 export function formatConnectorName(connector?: AbstractConnector, walletInfo?: ConnectedWalletInfo) {
   const name = walletInfo?.walletName || getWalletName(connector)
-  return <WalletName>Connected with {name}</WalletName>
+  // In case the wallet is connected via WalletConnect and has wallet name set, add the suffix to be clear
+  // This to avoid confusion for instance when using Metamask mobile
+  // When name is not set, it defaults to WalletConnect already
+  const walletConnectSuffix =
+    walletInfo?.provider === WalletProvider.WALLET_CONNECT && walletInfo?.walletName ? ' (via WalletConnect)' : ''
+
+  return (
+    <WalletName>
+      Connected with {name}
+      {walletConnectSuffix}
+    </WalletName>
+  )
 }
 
 export function getStatusIcon(connector?: AbstractConnector, walletInfo?: ConnectedWalletInfo) {

--- a/src/custom/components/Web3Status/Web3StatusMod.tsx
+++ b/src/custom/components/Web3Status/Web3StatusMod.tsx
@@ -1,39 +1,39 @@
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core'
 import { darken, lighten } from 'polished'
-import React, { useMemo } from 'react'
+import React /*{, useMemo }*/ from 'react'
 import { Activity } from 'react-feather'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
-import CoinbaseWalletIcon from 'assets/images/coinbaseWalletIcon.svg'
-import FortmaticIcon from 'assets/images/fortmaticIcon.png'
-import PortisIcon from 'assets/images/portisIcon.png'
-import WalletConnectIcon from 'assets/images/walletConnectIcon.svg'
-import { fortmatic, injected, portis, walletconnect, walletlink } from 'connectors'
-import { NetworkContextName } from 'constants/index'
+// import CoinbaseWalletIcon from 'assets/images/coinbaseWalletIcon.svg'
+// import FortmaticIcon from 'assets/images/fortmaticIcon.png'
+// import PortisIcon from 'assets/images/portisIcon.png'
+// import WalletConnectIcon from 'assets/images/walletConnectIcon.svg'
+// import { fortmatic, injected, portis, walletconnect, walletlink } from 'connectors'
+// import { NetworkContextName } from 'constants/index'
 import useENSName from 'hooks/useENSName'
 import { useHasSocks } from 'hooks/useSocksBalance'
 import { useWalletModalToggle } from 'state/application/hooks'
-import { isTransactionRecent, useAllTransactions } from 'state/transactions/hooks'
+// import { isTransactionRecent, useAllTransactions } from 'state/transactions/hooks'
 import { TransactionDetails } from 'state/transactions/reducer'
 import { shortenAddress } from 'utils'
 import { ButtonSecondary } from 'components/Button'
 
-import Identicon from 'components/Identicon'
+// import Identicon from 'components/Identicon'
 import Loader from 'components/Loader'
 
 import { RowBetween } from 'components/Row'
-import WalletModal from 'components/WalletModal'
+// import WalletModal from 'components/WalletModal'
 
-const IconWrapper = styled.div<{ size?: number }>`
-  ${({ theme }) => theme.flexColumnNoWrap};
-  align-items: center;
-  justify-content: center;
-  & > * {
-    height: ${({ size }) => (size ? size + 'px' : '32px')};
-    width: ${({ size }) => (size ? size + 'px' : '32px')};
-  }
-`
+// const IconWrapper = styled.div<{ size?: number }>`
+//   ${({ theme }) => theme.flexColumnNoWrap};
+//   align-items: center;
+//   justify-content: center;
+//   & > * {
+//     height: ${({ size }) => (size ? size + 'px' : '32px')};
+//     width: ${({ size }) => (size ? size + 'px' : '32px')};
+//   }
+// `
 
 const Web3StatusGeneric = styled(ButtonSecondary)`
   ${({ theme }) => theme.flexRowNoWrap}
@@ -130,38 +130,44 @@ const SOCK = (
 )
 
 // eslint-disable-next-line react/prop-types
-function StatusIcon({ connector }: { connector: AbstractConnector }) {
-  if (connector === injected) {
-    return <Identicon />
-  } else if (connector === walletconnect) {
-    return (
-      <IconWrapper size={16}>
-        <img src={WalletConnectIcon} alt={''} />
-      </IconWrapper>
-    )
-  } else if (connector === walletlink) {
-    return (
-      <IconWrapper size={16}>
-        <img src={CoinbaseWalletIcon} alt={''} />
-      </IconWrapper>
-    )
-  } else if (connector === fortmatic) {
-    return (
-      <IconWrapper size={16}>
-        <img src={FortmaticIcon} alt={''} />
-      </IconWrapper>
-    )
-  } else if (connector === portis) {
-    return (
-      <IconWrapper size={16}>
-        <img src={PortisIcon} alt={''} />
-      </IconWrapper>
-    )
-  }
-  return null
-}
+// function StatusIcon({ connector }: { connector: AbstractConnector }) {
+//   if (connector === injected) {
+//     return <Identicon />
+//   } else if (connector === walletconnect) {
+//     return (
+//       <IconWrapper size={16}>
+//         <img src={WalletConnectIcon} alt={''} />
+//       </IconWrapper>
+//     )
+//   } else if (connector === walletlink) {
+//     return (
+//       <IconWrapper size={16}>
+//         <img src={CoinbaseWalletIcon} alt={''} />
+//       </IconWrapper>
+//     )
+//   } else if (connector === fortmatic) {
+//     return (
+//       <IconWrapper size={16}>
+//         <img src={FortmaticIcon} alt={''} />
+//       </IconWrapper>
+//     )
+//   } else if (connector === portis) {
+//     return (
+//       <IconWrapper size={16}>
+//         <img src={PortisIcon} alt={''} />
+//       </IconWrapper>
+//     )
+//   }
+//   return null
+// }
 
-export function Web3StatusInner({ pendingCount }: { pendingCount?: number }) {
+export function Web3StatusInner({
+  pendingCount,
+  StatusIconComponent
+}: {
+  pendingCount?: number
+  StatusIconComponent: (props: { connector: AbstractConnector }) => JSX.Element | null
+}) {
   const { t } = useTranslation()
   const { account, connector, error } = useWeb3React()
 
@@ -193,7 +199,7 @@ export function Web3StatusInner({ pendingCount }: { pendingCount?: number }) {
             <Text>{ENSName || shortenAddress(account)}</Text>
           </>
         )}
-        {!hasPendingTransactions && connector && <StatusIcon connector={connector} />}
+        {!hasPendingTransactions && connector && <StatusIconComponent connector={connector} />}
       </Web3StatusConnected>
     )
   } else if (error) {
@@ -212,30 +218,30 @@ export function Web3StatusInner({ pendingCount }: { pendingCount?: number }) {
   }
 }
 
-export default function Web3Status() {
-  const { active, account } = useWeb3React()
-  const contextNetwork = useWeb3React(NetworkContextName)
+// export default function Web3Status() {
+//   const { active, account } = useWeb3React()
+//   const contextNetwork = useWeb3React(NetworkContextName)
 
-  const { ENSName } = useENSName(account ?? undefined)
+//   const { ENSName } = useENSName(account ?? undefined)
 
-  const allTransactions = useAllTransactions()
+//   const allTransactions = useAllTransactions()
 
-  const sortedRecentTransactions = useMemo(() => {
-    const txs = Object.values(allTransactions)
-    return txs.filter(isTransactionRecent).sort(newTransactionsFirst)
-  }, [allTransactions])
+//   const sortedRecentTransactions = useMemo(() => {
+//     const txs = Object.values(allTransactions)
+//     return txs.filter(isTransactionRecent).sort(newTransactionsFirst)
+//   }, [allTransactions])
 
-  const pending = sortedRecentTransactions.filter(tx => !tx.receipt).map(tx => tx.hash)
-  const confirmed = sortedRecentTransactions.filter(tx => tx.receipt).map(tx => tx.hash)
+//   const pending = sortedRecentTransactions.filter(tx => !tx.receipt).map(tx => tx.hash)
+//   const confirmed = sortedRecentTransactions.filter(tx => tx.receipt).map(tx => tx.hash)
 
-  if (!contextNetwork.active && !active) {
-    return null
-  }
+//   if (!contextNetwork.active && !active) {
+//     return null
+//   }
 
-  return (
-    <>
-      <Web3StatusInner />
-      <WalletModal ENSName={ENSName ?? undefined} pendingTransactions={pending} confirmedTransactions={confirmed} />
-    </>
-  )
-}
+//   return (
+//     <>
+//       <Web3StatusInner />
+//       <WalletModal ENSName={ENSName ?? undefined} pendingTransactions={pending} confirmedTransactions={confirmed} />
+//     </>
+//   )
+// }

--- a/src/custom/components/Web3Status/index.tsx
+++ b/src/custom/components/Web3Status/index.tsx
@@ -1,14 +1,24 @@
 import React, { useMemo } from 'react'
+import { AbstractConnector } from '@web3-react/abstract-connector'
 
 import WalletModal from 'components/WalletModal'
-import { Web3StatusInner } from './Web3StatusMod'
+import { getStatusIcon } from 'components/AccountDetails'
+
 import useRecentActivity, { TransactionAndOrder } from 'hooks/useRecentActivity'
+import { useWalletInfo } from 'hooks/useWalletInfo'
+
 import { OrderStatus } from 'state/orders/actions'
-import { useWalletInfo } from '@src/custom/hooks/useWalletInfo'
+
+import { Web3StatusInner } from './Web3StatusMod'
 
 const isPending = (data: TransactionAndOrder) => data.status === OrderStatus.PENDING
 const isConfirmedOrExpired = (data: TransactionAndOrder) =>
   data.status === OrderStatus.FULFILLED || data.status === OrderStatus.EXPIRED
+
+function StatusIcon({ connector }: { connector: AbstractConnector }): JSX.Element | null {
+  const walletInfo = useWalletInfo()
+  return getStatusIcon(connector, walletInfo)
+}
 
 export default function Web3Status() {
   const walletInfo = useWalletInfo()
@@ -35,7 +45,7 @@ export default function Web3Status() {
 
   return (
     <>
-      <Web3StatusInner pendingCount={pendingActivity.length} />
+      <Web3StatusInner pendingCount={pendingActivity.length} StatusIconComponent={StatusIcon} />
       <WalletModal
         ENSName={ensName}
         pendingTransactions={pendingActivity}

--- a/src/custom/components/swap/UnsupportedCurrencyFooter/index.tsx
+++ b/src/custom/components/swap/UnsupportedCurrencyFooter/index.tsx
@@ -6,18 +6,24 @@ const DEFAULT_DETAILS_TEXT =
 const DEFAULT_DETAILS_TITLE = 'Unsupported Assets'
 const DEFAULT_SHOW_DETAILS_TEXT = 'Read more about unsupported assets'
 
+type Props = Omit<UnsupportedCurrencyFooterParams, 'currencies'> & {
+  currencies?: UnsupportedCurrencyFooterParams['currencies']
+}
+
 export default function UnsupportedCurrencyFooter({
   detailsText = DEFAULT_DETAILS_TEXT,
   detailsTitle = DEFAULT_DETAILS_TITLE,
   showDetailsText = DEFAULT_SHOW_DETAILS_TEXT,
+  currencies = [],
   ...props
-}: UnsupportedCurrencyFooterParams) {
+}: Props) {
   return (
     <UnsupportedCurrencyFooterMod
       {...props}
       detailsText={detailsText}
       detailsTitle={detailsTitle}
       showDetailsText={showDetailsText}
+      currencies={currencies}
     />
   )
 }

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -57,6 +57,7 @@ import UnsupportedCurrencyFooter from 'components/swap/UnsupportedCurrencyFooter
 import { isTradeBetter } from 'utils/trades'
 import FeeInformationTooltip from 'components/swap/FeeInformationTooltip'
 import { SwapProps } from '.'
+import { useWalletInfo } from 'hooks/useWalletInfo'
 
 export default function Swap({
   history,
@@ -94,6 +95,7 @@ export default function Swap({
     })
 
   const { account, chainId } = useActiveWeb3React()
+  const { isSupportedWallet } = useWalletInfo()
   const theme = useContext(ThemeContext)
 
   // toggle wallet when disconnected
@@ -515,6 +517,12 @@ export default function Swap({
               <ButtonLight buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>
                 Connect Wallet
               </ButtonLight>
+            ) : !isSupportedWallet ? (
+              <ButtonError buttonSize={ButtonSize.BIG} id="swap-button" disabled={!isSupportedWallet}>
+                <Text fontSize={20} fontWeight={500}>
+                  Wallet not supported
+                </Text>
+              </ButtonError>
             ) : showWrap ? (
               <ButtonPrimary buttonSize={ButtonSize.BIG} disabled={Boolean(wrapInputError)} onClick={onWrap}>
                 {wrapInputError ??
@@ -623,7 +631,14 @@ export default function Swap({
           </BottomGrouping>
         </Wrapper>
       </AppBody>
-      {!swapIsUnsupported ? (
+      {!isSupportedWallet ? (
+        <UnsupportedCurrencyFooter
+          show={!isSupportedWallet}
+          showDetailsText="Read more about unsupported wallets"
+          detailsText="CowSwap requires offline signatures, which is currently not supported by some wallets."
+          detailsTitle="Wallet not supported"
+        />
+      ) : !swapIsUnsupported ? (
         <AdvancedSwapDetailsDropdown trade={trade} />
       ) : (
         <UnsupportedCurrencyFooter show={swapIsUnsupported} currencies={[currencies.INPUT, currencies.OUTPUT]} />

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -636,7 +636,7 @@ export default function Swap({
           show={!isSupportedWallet}
           showDetailsText="Read more about unsupported wallets"
           detailsText="CowSwap requires offline signatures, which is currently not supported by some wallets."
-          detailsTitle="Wallet not supported"
+          detailsTitle="This wallet is not yet supported"
         />
       ) : !swapIsUnsupported ? (
         <AdvancedSwapDetailsDropdown trade={trade} />


### PR DESCRIPTION
# Summary

Part of and pipe into #597

Wallet connect - block unsupported wallets

![screenshot_2021-05-17_13-15-06](https://user-images.githubusercontent.com/43217/118550849-12584080-b712-11eb-98e4-8f2f57d7e724.png)
![screenshot_2021-05-17_13-14-22](https://user-images.githubusercontent.com/43217/118550852-12f0d700-b712-11eb-8b01-f9b3ba5321b7.png)
![screenshot_2021-05-17_13-13-21](https://user-images.githubusercontent.com/43217/118550855-12f0d700-b712-11eb-9959-71ffd40f26ac.png)


Those include:
- Any SmartContract wallet
- Crypto.com Defi Wallet
- TokenPocket

Regarding TokenPocket, they are working on a fix https://github.com/TP-Lab/tp-android/issues/16. 
We might be able to remove this block soon.

**Bonus**:
![screenshot_2021-05-17_13-16-18](https://user-images.githubusercontent.com/43217/118550813-03718e00-b712-11eb-8e80-c405aad64680.png)
![screenshot_2021-05-17_13-16-10](https://user-images.githubusercontent.com/43217/118550823-066c7e80-b712-11eb-8ec1-cd71bf46925b.png)

- Added wallet images to details modal (it was disabled)
- Show connected wallet name, if available
- Show connected wallet icon, if available

# Testing

1. Connect an EOA (Metamask, Nifty) or injected (dApp browser such as imToken, TokenPocket) wallet
- [ ] Swap button should be enabled

1. Using WalletConnect, connect a SmartContract wallet (like Gnosis Safe, Argent, Pillar)
- [ ] Swap button should be disabled
- [ ] The icon next to the account address should be a :warning: and show a tooltip on hover
- [ ] On account details, the icon next to the account address should be a :warning: and show a tooltip on hover


----

## Note

This PR is already too big.
Will add an FAQ entry in a follow up.