### PR TITLE
Fix layout for expert mode.

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -365,7 +365,7 @@ export default function Swap({
       <SwapPoolTabs active={'swap'} />
       <AppBody className={className}>
         <SwapHeader />
-        <Wrapper id="swap-page">
+        <Wrapper id="swap-page" className={isExpertMode ? 'expertMode' : ''}>
           <ConfirmSwapModal
             isOpen={showConfirm}
             trade={trade}

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -7,7 +7,7 @@ import { Text } from 'rebass'
 import { ButtonSize, TYPE } from 'theme/index'
 
 import SwapMod from './SwapMod'
-import { RowBetween, RowFixed } from 'components/Row'
+import { AutoRow, RowBetween, RowFixed } from 'components/Row'
 import {
   BottomGrouping as BottomGroupingUni,
   Wrapper as WrapperUni,
@@ -47,6 +47,10 @@ const SwapModWrapper = styled(SwapMod)`
       grid-row-gap: 3px;
     }
 
+    .expertMode ${AutoColumn} {
+      grid-row-gap: 12px;
+    }
+
     ${Card} > ${AutoColumn} {
       margin: 6px auto 0;
     }
@@ -74,6 +78,13 @@ const SwapModWrapper = styled(SwapMod)`
       > svg {
         stroke: #000000b8;
       }
+    }
+
+    .expertMode ${ArrowWrapperUni} {
+      position: relative;
+    }
+    .expertMode ${AutoRow} {
+      padding: 0 1rem;
     }
   }
 `


### PR DESCRIPTION
Makes sure the layout is correct, when Expert Mode is enabled:
<img width="541" alt="Screen Shot 2021-05-17 at 13 32 21" src="https://user-images.githubusercontent.com/31534717/118481897-4f253700-b714-11eb-8e63-c9d5aca4a711.png">

Cherrypicked from #622 

Note:
- When you add the recipient field, then disable EXPERT MODE after, the recipient field stays in place (Needs to be addressed in a separate PR).
