### PR TITLE
[638] Buy order: show correct amount in modal

### DIFF
--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -213,7 +213,9 @@ export function useTradeExactOutWithFee({
     ...outTrade,
     // overriding inputAmount is a hack
     // to allow us to not have to change Uni's pages/swap/index and use different method names
-    inputAmount: inputAmountWithoutFee,
+    // in this case we need to show users the default inputAmount as the inputAmount adjusted for fee
+    // this is purely for display reasons and to keep it working with Uni's code.
+    inputAmount: inputAmountWithFee,
     inputAmountWithFee,
     minimumAmountOut(pct: Percent) {
       // this refers to trade object being constructed

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -57,15 +57,14 @@ describe('Swap PRICE Quote test', () => {
           price: { amount: MOCKED_PRICE_OUT.long, token: DAI_MAINNET.name || 'token' }
         })
 
-        console.debug('EXECUTION PRICE', executionPrice?.toSignificant(18))
-
         trade = {
           ...tradeSdk,
           executionPrice,
-          inputAmount: tradeSdk.inputAmount.subtract(feeAsCurrency),
+          // sell orders: we show user on UI inputAmount with no fee calculation
+          inputAmount: tradeSdk.inputAmount,
           inputAmountWithFee: tradeSdk.inputAmount.subtract(feeAsCurrency),
           inputAmountWithoutFee: tradeSdk.inputAmount,
-          outputAmount: new TokenAmount(DAI_MAINNET, MOCKED_PRICE_OUT.long),
+          outputAmount: currencyOut,
           maximumAmountIn(pct: Percent) {
             return _maximumAmountInExtension(pct, this)
           },
@@ -129,13 +128,13 @@ describe('Swap PRICE Quote test', () => {
           price: { amount: MOCKED_PRICE_IN.long, token: WETH_MAINNET.name || 'token' }
         })
 
-        console.debug('EXECUTION PRICE', executionPrice?.toSignificant(18))
-
         trade = {
           ...tradeSdk,
           executionPrice,
-          inputAmount: apiBuyPriceAsCurrency,
+          // fee is in selltoken so for buy orders we set inputAmount as inputAmountWithFee
+          inputAmount: apiBuyPriceAsCurrencyWithFee,
           inputAmountWithFee: apiBuyPriceAsCurrencyWithFee,
+          inputAmountWithoutFee: apiBuyPriceAsCurrency,
           maximumAmountIn(pct: Percent) {
             return _maximumAmountInExtension(pct, this)
           },


### PR DESCRIPTION
Closes #638

Shows the correct _inputAmount_ in the confirmation modal when performing a _buy order_. Was previously showing the unadjusted inputAmount without the fee added on.\\@mareenG