### PR TITLE
Unsupported Tokens - update FAQ links + modal content

### DIFF
--- a/src/custom/components/SearchModal/CurrencyList/index.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/index.tsx
@@ -1,22 +1,20 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Currency, CurrencyAmount } from '@uniswap/sdk'
-import { LONG_PRECISION } from 'constants/index'
+import { LONG_PRECISION, UNSUPPORTED_TOKENS_FAQ_URL } from 'constants/index'
 import CurrencyListMod, { StyledBalanceText, Tag as TagMod, TagContainer } from './CurrencyListMod'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { TagInfo, WrappedTokenInfo } from 'state/lists/hooks'
-import { Link } from 'react-router-dom'
+import { HashLink } from 'react-router-hash-link'
 
 const UNSUPPORTED_TOKEN_TAG = [
   {
     name: 'Unsupported',
     description:
-      'This token is unsupported as it does not operate efficiently with Gnosis Protocol. Please refer to the FAQ for more information.',
+      'This token is unsupported as it does not operate optimally with Gnosis Protocol. Please refer to the FAQ for more information.',
     id: '0'
   }
 ]
-
-const FAQ_URL = '/faq#what-are-unsupported-tokens'
 
 const Tag = styled(TagMod)<{ bg?: string }>`
   background-color: ${({ bg, theme }) => bg || theme.bg3};
@@ -63,9 +61,9 @@ function TokenTags({ currency, isUnsupported }: { currency: Currency; isUnsuppor
     return (
       <TagDescriptor bg="#f3a1a1" tags={UNSUPPORTED_TOKEN_TAG}>
         <TagLink>
-          <Link to={FAQ_URL} target="_blank" onClick={e => e.stopPropagation()}>
+          <HashLink to={UNSUPPORTED_TOKENS_FAQ_URL} target="_blank" onClick={e => e.stopPropagation()}>
             FAQ
-          </Link>
+          </HashLink>
         </TagLink>
       </TagDescriptor>
     )

--- a/src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
+++ b/src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
@@ -9,9 +9,10 @@ import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { useActiveWeb3React } from 'hooks'
 import { getEtherscanLink } from 'utils'
-import { Currency, Token } from '@uniswap/sdk'
+import { Currency /* , Token */ } from '@uniswap/sdk'
 import { wrappedCurrency } from 'utils/wrappedCurrency'
-import { useUnsupportedTokens } from 'hooks/Tokens'
+// import { useUnsupportedTokens } from 'hooks/Tokens'
+import { useIsUnsupportedToken } from 'state/lists/hooks/hooksMod'
 
 export const DetailsFooter = styled.div<{ show: boolean }>`
   padding-top: calc(16px + 2rem);
@@ -67,7 +68,9 @@ UnsupportedCurrencyFooterParams) {
         })
       : []
 
-  const unsupportedTokens: { [address: string]: Token } = useUnsupportedTokens()
+  // const unsupportedTokens: { [address: string]: Token } = useUnsupportedTokens()
+
+  const isUnsupportedToken = useIsUnsupportedToken()
 
   return (
     <DetailsFooter show={show}>
@@ -83,9 +86,10 @@ UnsupportedCurrencyFooterParams) {
             {tokens.map(token => {
               return (
                 token &&
-                unsupportedTokens &&
-                Object.keys(unsupportedTokens).includes(token.address) && (
-                  <OutlineCard key={token.address?.concat('not-supported')}>
+                // unsupportedToken &&
+                // combinedUnsupportedList.includes(token.address) && (
+                isUnsupportedToken(token.address) && (
+                  <OutlineCard key={token.address.concat('not-supported')} padding="0 1.25rem">
                     <AutoColumn gap="10px">
                       <AutoRow gap="5px" align="center">
                         <CurrencyLogo currency={token} size={'24px'} />

--- a/src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
+++ b/src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
@@ -117,7 +117,7 @@ UnsupportedCurrencyFooterParams) {
       </Modal>
       <ButtonEmpty padding={'0'} onClick={() => setShowDetails(true)}>
         {/* <TYPE.blue>Read more about unsupported assets</TYPE.blue> */}
-        <TYPE.blue>{showDetailsText}</TYPE.blue>
+        <TYPE.error error={!!showDetailsText}>{showDetailsText}</TYPE.error>
       </ButtonEmpty>
     </DetailsFooter>
   )

--- a/src/custom/components/swap/UnsupportedCurrencyFooter/index.tsx
+++ b/src/custom/components/swap/UnsupportedCurrencyFooter/index.tsx
@@ -1,10 +1,17 @@
 import React from 'react'
+import { HashLink } from 'react-router-hash-link'
 import UnsupportedCurrencyFooterMod, { UnsupportedCurrencyFooterParams } from './UnsupportedCurrencyFooterMod'
+import { UNSUPPORTED_TOKENS_FAQ_URL } from 'constants/index'
 
-const DEFAULT_DETAILS_TEXT =
-  'Some assets are not available through this interface because they may not work well with our smart contract or we are unable to allow trading for legal reasons.'
-const DEFAULT_DETAILS_TITLE = 'Unsupported Assets'
-const DEFAULT_SHOW_DETAILS_TEXT = 'Read more about unsupported assets'
+const DEFAULT_DETAILS_TEXT = (
+  <div>
+    CowSwap does not support all tokens. Some tokens implement similar, but logically different ERC20 contract methods
+    which do not operate optimally with Gnosis Protocol. For more information, please refer to the{' '}
+    <HashLink to={UNSUPPORTED_TOKENS_FAQ_URL}>FAQ</HashLink>.
+  </div>
+)
+const DEFAULT_DETAILS_TITLE = 'Unsupported Token'
+const DEFAULT_SHOW_DETAILS_TEXT = 'Read more about unsupported tokens'
 
 export default function UnsupportedCurrencyFooter({
   detailsText = DEFAULT_DETAILS_TEXT,

--- a/src/custom/components/swap/UnsupportedCurrencyFooter/index.tsx
+++ b/src/custom/components/swap/UnsupportedCurrencyFooter/index.tsx
@@ -6,8 +6,10 @@ import { UNSUPPORTED_TOKENS_FAQ_URL } from 'constants/index'
 const DEFAULT_DETAILS_TEXT = (
   <div>
     CowSwap does not support all tokens. Some tokens implement similar, but logically different ERC20 contract methods
-    which do not operate optimally with Gnosis Protocol. For more information, please refer to the{' '}
-    <HashLink to={UNSUPPORTED_TOKENS_FAQ_URL}>FAQ</HashLink>.
+    which do not operate optimally with Gnosis Protocol.
+    <p>
+      For more information, please refer to the <HashLink to={UNSUPPORTED_TOKENS_FAQ_URL}>FAQ</HashLink>.
+    </p>
   </div>
 )
 const DEFAULT_DETAILS_TITLE = 'Unsupported Token'

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -82,3 +82,5 @@ export const GAS_FEE_ENDPOINTS = {
   // TODO: xdai? = main
   [ChainId.XDAI]: 'https://safe-relay.gnosis.io/api/v1/gas-station/'
 }
+
+export const UNSUPPORTED_TOKENS_FAQ_URL = '/faq#what-token-pairs-does-cowswap-allow-to-trade'

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -510,7 +510,7 @@ export default function Swap({
           <BottomGrouping>
             {swapIsUnsupported ? (
               <ButtonPrimary buttonSize={ButtonSize.BIG} disabled={true}>
-                <TYPE.main mb="4px">Unsupported Asset</TYPE.main>
+                <TYPE.main mb="4px">Unsupported Token</TYPE.main>
               </ButtonPrimary>
             ) : !account ? (
               <ButtonLight buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>

--- a/src/custom/state/lists/hooks/hooksMod.ts
+++ b/src/custom/state/lists/hooks/hooksMod.ts
@@ -260,7 +260,7 @@ export function useIsUnsupportedToken() {
 
   return useCallback(
     (address?: string) => {
-      // Returns a predicate function determining a token's support by address against our Set
+      // Returns a predicate function determining a token's support by address against our hooks
       return Boolean(isUnsupportedTokenFromList(address) || isUnsupportedTokenGp(address))
     },
     [isUnsupportedTokenFromList, isUnsupportedTokenGp]


### PR DESCRIPTION
Properly links to FAQ section from currency list and swap modal when unuspported token detected.

in swap modal for unsupported tokens it shows the tokens and links to etherscan