### PR TITLE
Fix non-valid Price fetch amount, fix fee 2 times

### DIFF
--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -136,8 +136,7 @@ export default function Swap({
   // Is fee greater than input?
   const { isFeeGreater, fee } = useIsFeeGreaterThanInput({
     chainId,
-    address: INPUT.currencyId,
-    parsedAmount
+    address: INPUT.currencyId
   })
 
   const toggledVersion = useToggledVersion()

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -134,7 +134,11 @@ export default function Swap({
   const isNativeInSwap = isNativeIn && !isWrappedOut
 
   // Is fee greater than input?
-  const { isFeeGreater, fee } = useIsFeeGreaterThanInput({ chainId, address: INPUT.currencyId, parsedAmount })
+  const { isFeeGreater, fee } = useIsFeeGreaterThanInput({
+    chainId,
+    address: INPUT.currencyId,
+    parsedAmount
+  })
 
   const toggledVersion = useToggledVersion()
   const tradesByVersion = {

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -19,12 +19,12 @@ export interface FeeInformation {
 
 export interface PriceInformation {
   token: string
-  amount: string
+  amount: string | null
 }
 
 export interface QuoteInformationObject extends Omit<FeeQuoteParams, 'kind'> {
   fee: FeeInformation
-  price: PriceInformation | null
+  price: PriceInformation
   lastCheck: number
   feeExceedsPrice: boolean
 }

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -24,8 +24,9 @@ export interface PriceInformation {
 
 export interface QuoteInformationObject extends Omit<FeeQuoteParams, 'kind'> {
   fee: FeeInformation
-  price: PriceInformation
+  price: PriceInformation | null
   lastCheck: number
+  feeExceedsPrice: boolean
 }
 
 // Map token addresses to their last quote information

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -25,7 +25,7 @@ export type TradeWithFee = Trade & {
 type TradeExecutionPrice = CanonicalMarketParams<CurrencyAmount | undefined> & { price?: PriceInformation }
 
 export function _constructTradePrice({ sellToken, buyToken, kind, price }: TradeExecutionPrice): Price | undefined {
-  if (!sellToken || !buyToken || !price) return
+  if (!sellToken || !buyToken || !price?.amount) return
 
   let executionPrice: Price | undefined
   // get canonical market tokens
@@ -114,7 +114,7 @@ export function useTradeExactInWithFee({
 
   // make sure we have a typed in amount, a fee, and a price
   // else we can assume the trade will be null
-  if (!parsedInputAmount || !originalTrade || !outputCurrency || !quote?.fee || !quote?.price) return null
+  if (!parsedInputAmount || !originalTrade || !outputCurrency || !quote?.fee || !quote?.price.amount) return null
 
   const feeAsCurrency = stringToCurrency(quote.fee.amount, parsedInputAmount.currency)
   // Check that fee amount is not greater than the user's input amt
@@ -179,7 +179,7 @@ export function useTradeExactOutWithFee({
   // Original Uni trade hook
   const outTrade = useTradeExactOut(inputCurrency ?? undefined, parsedOutputAmount)
 
-  if (!outTrade || !parsedOutputAmount || !inputCurrency || !quote?.fee || !quote?.price) return null
+  if (!outTrade || !parsedOutputAmount || !inputCurrency || !quote?.fee || !quote?.price.amount) return null
 
   const feeAsCurrency = stringToCurrency(quote.fee.amount, inputCurrency)
   // set final fee object

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -263,17 +263,15 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
 
 export function useIsFeeGreaterThanInput({
   address,
-  parsedAmount,
   chainId
 }: {
   address?: string
-  parsedAmount?: CurrencyAmount
   chainId?: ChainId
 }): { isFeeGreater: boolean; fee: CurrencyAmount | null } {
   const quote = useQuote({ chainId, token: address })
   const feeToken = useCurrency(address)
 
-  if (!quote?.fee || !parsedAmount || !feeToken) return { isFeeGreater: false, fee: null }
+  if (!quote?.fee || !feeToken) return { isFeeGreater: false, fee: null }
 
   return {
     isFeeGreater: quote.feeExceedsPrice,

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -22,7 +22,6 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
 import { SwapState } from 'state/swap/reducer'
 import { ParsedQs } from 'qs'
-import { BigNumber } from 'ethers'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
 import { WrappedTokenInfo } from '../lists/hooks'
@@ -71,7 +70,7 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
   })
 
   useEffect(() => {
-    console.debug('[useDerivedSwapInfo] Price quote: ', quote?.price.amount)
+    console.debug('[useDerivedSwapInfo] Price quote: ', quote?.price?.amount)
     console.debug('[useDerivedSwapInfo] Fee quote: ', quote?.fee?.amount)
   }, [quote])
 
@@ -272,13 +271,12 @@ export function useIsFeeGreaterThanInput({
   chainId?: ChainId
 }): { isFeeGreater: boolean; fee: CurrencyAmount | null } {
   const quote = useQuote({ chainId, token: address })
+  const feeToken = useCurrency(address)
 
-  if (!quote || !quote.fee || !parsedAmount) return { isFeeGreater: false, fee: null }
-
-  const feeBigNumber = BigNumber.from(quote.fee.amount)
+  if (!quote?.fee || !parsedAmount || !feeToken) return { isFeeGreater: false, fee: null }
 
   return {
-    isFeeGreater: feeBigNumber.gte(parsedAmount.raw.toString()),
-    fee: stringToCurrency(feeBigNumber.toString(), parsedAmount.currency)
+    isFeeGreater: quote.feeExceedsPrice,
+    fee: stringToCurrency(quote.fee.amount, feeToken)
   }
 }

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -151,17 +151,19 @@ function toApiAddress(address: string, chainId: ChainId): string {
 
 async function _getJson(chainId: ChainId, url: string): Promise<any> {
   let response: Response | undefined
+  let json
   try {
     response = await _fetchGet(chainId, url)
+    json = await response.json()
   } finally {
-    if (!response) {
+    if (!response || !json) {
       throw new Error(`Error getting query @ ${url}`)
     } else if (!response.ok) {
       // is backend error handled at this point
-      const errorResponse: ApiError = await response.json()
+      const errorResponse: ApiError = json
       throw new OperatorError(errorResponse)
     } else {
-      return response.json()
+      return json
     }
   }
 }


### PR DESCRIPTION
Closes #547
Closes #637
May close #604, needs to be tested moar

This fixes several things:
1. more accurately show fee and fee exceed from amount in button when the user's input amount is indeed <= fee amount from API
2. price returned null if step 1 == true
3. if (fee.exists BUT !price) = feeExceedsPrice
4. dont use parsed amount as fee token, always use sellToken
5. dont query endpoint with negative amount, check before

To test:
1. WETH <> DAI
2. sell tiny amount
3. observe networks tab: no fetching if price <= fee amount
4. fee > input error correct in button 
5. fee shows correct amounts checkable against networks returned data for fee amount
6. fee token name correct (always sell)