### PR TITLE
Wallet connect - faq for unsupported wallets

### DIFF
--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -307,6 +307,21 @@ export default function Faq() {
             across different protocols. Since orders only incur a cost if traded, active market makers can observe the
             orderbook and place counter orders (creating a CoW) to prevent settling trades via external liquidity.
           </p>
+
+          <h3 id="wallet-not-supported">Why is my wallet not supported?</h3>
+
+          <p>CowSwap uses offline signatures to offer gas free orders.</p>
+          <p>
+            Currently, Smart Contract (SC) wallets such as Gnosis Safe, Argent or Pillar are not supported because it
+            would require an on chain transaction to place the order, making it no longer gas free. We are working to
+            make this a possibility though, and support will be added soon.
+          </p>
+
+          <p>
+            But, even if your wallet is not a SC wallet, it might be unsupported in some cases. Not all wallets
+            implement the necessary signing methods from EIP712 standard. If that is the case for you, reach out to your
+            wallet developers and ask for it.
+          </p>
         </Content>
       </Page>
 

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -313,7 +313,7 @@ export default function Faq() {
           <p>CowSwap uses offline signatures to offer gas free orders.</p>
           <p>
             Currently, Smart Contract (SC) wallets such as Gnosis Safe, Argent or Pillar are not supported because it
-            would require an on chain transaction to place the order, making it no longer gas free. We are working to
+            would require signing an on-chain transaction to place the order, making it no longer gas free. We are working to
             make this a possibility though, and support will be added soon.
           </p>
 

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -314,7 +314,7 @@ export default function Faq() {
           <p>
             Currently, Smart Contract (SC) wallets such as Gnosis Safe, Argent or Pillar are not supported because it
             would require signing an on-chain transaction to place the order, making it no longer gas free. We are working to
-            make this a possibility though, and support will be added soon.
+            make this a possibility and support will be added soon.
           </p>
 
           <p>

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -310,17 +310,17 @@ export default function Faq() {
 
           <h3 id="wallet-not-supported">Why is my wallet not supported?</h3>
 
-          <p>CowSwap uses offline signatures to offer gas free orders.</p>
+          <p>CowSwap uses offline signatures to offer gasless orders.</p>
           <p>
             Currently, Smart Contract (SC) wallets such as Gnosis Safe, Argent or Pillar are not supported because it
-            would require signing an on-chain transaction to place the order, making it no longer gas free. We are working to
-            make this a possibility and support will be added soon.
+            would require signing an on-chain transaction to place the order, making it no longer gasless. We are
+            working to make this a possibility and support will be added soon.
           </p>
 
           <p>
-            Nevertheless, even if your wallet is not an SC wallet, it might be unsupported in some cases. Not all wallets
-            implement the necessary signing methods from EIP712 standard. If that is the case for you, reach out to your
-            wallet developers and ask for it.
+            Nevertheless, even if your wallet is not an SC wallet, it might be unsupported in some cases. Not all
+            wallets implement the necessary signing methods from EIP712 standard. If that is the case for you, reach out
+            to your wallet developers and ask for it.
           </p>
         </Content>
       </Page>

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -318,7 +318,7 @@ export default function Faq() {
           </p>
 
           <p>
-            But, even if your wallet is not a SC wallet, it might be unsupported in some cases. Not all wallets
+            Nevertheless, even if your wallet is not an SC wallet, it might be unsupported in some cases. Not all wallets
             implement the necessary signing methods from EIP712 standard. If that is the case for you, reach out to your
             wallet developers and ask for it.
           </p>

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -58,6 +58,7 @@ import { isTradeBetter } from 'utils/trades'
 import FeeInformationTooltip from 'components/swap/FeeInformationTooltip'
 import { SwapProps } from '.'
 import { useWalletInfo } from 'hooks/useWalletInfo'
+import { HashLink } from 'react-router-hash-link'
 
 export default function Swap({
   history,
@@ -635,7 +636,12 @@ export default function Swap({
         <UnsupportedCurrencyFooter
           show={!isSupportedWallet}
           showDetailsText="Read more about unsupported wallets"
-          detailsText="CowSwap requires offline signatures, which is currently not supported by some wallets."
+          detailsText={
+            <>
+              CowSwap requires offline signatures, which is currently not supported by some wallets. Read more on the{' '}
+              <HashLink to="/faq#wallet-not-supported">FAQ</HashLink>.
+            </>
+          }
           detailsTitle="This wallet is not yet supported"
         />
       ) : !swapIsUnsupported ? (

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -638,8 +638,10 @@ export default function Swap({
           showDetailsText="Read more about unsupported wallets"
           detailsText={
             <>
-              CowSwap requires offline signatures, which is currently not supported by some wallets. Read more in the{' '}
-              <HashLink to="/faq#wallet-not-supported">FAQ</HashLink>.
+              <p>CowSwap requires offline signatures, which is currently not supported by some wallets.</p>
+              <p>
+                Read more in the <HashLink to="/faq#wallet-not-supported">FAQ</HashLink>.
+              </p>
             </>
           }
           detailsTitle="This wallet is not yet supported"

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -638,7 +638,7 @@ export default function Swap({
           showDetailsText="Read more about unsupported wallets"
           detailsText={
             <>
-              CowSwap requires offline signatures, which is currently not supported by some wallets. Read more on the{' '}
+              CowSwap requires offline signatures, which is currently not supported by some wallets. Read more in the{' '}
               <HashLink to="/faq#wallet-not-supported">FAQ</HashLink>.
             </>
           }


### PR DESCRIPTION
# Summary

Part of and pipe into #597

Added FAQ link
![screenshot_2021-05-18_14-03-21](https://user-images.githubusercontent.com/43217/118723209-fa4ff200-b7e1-11eb-8f8a-546fc8e63aa3.png)

And text (not final, please amend where needed)
![screenshot_2021-05-18_14-03-34](https://user-images.githubusercontent.com/43217/118723270-0dfb5880-b7e2-11eb-89f2-a3692e388729.png)

# Testing

1. Using WalletConnect, connect a wallet that's not supported (Gnosis Safe for example)
2. Click on "Read more about unsupported wallets"
![screenshot_2021-05-18_14-06-50](https://user-images.githubusercontent.com/43217/118723413-3f742400-b7e2-11eb-8cf8-c2928d7334e5.png)
- [ ] There should be an FAQ link
3. Click on the FAQ link
- [ ] It should lead to the question: `Why is my wallet not supported?`


