### PR TITLE
[🐯Release🐯] 0.12.0-RC.1

### DIFF
--- a/src/custom/components/SearchModal/CurrencyList/index.tsx
+++ b/src/custom/components/SearchModal/CurrencyList/index.tsx
@@ -1,22 +1,20 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Currency, CurrencyAmount } from '@uniswap/sdk'
-import { LONG_PRECISION } from 'constants/index'
+import { LONG_PRECISION, UNSUPPORTED_TOKENS_FAQ_URL } from 'constants/index'
 import CurrencyListMod, { StyledBalanceText, Tag as TagMod, TagContainer } from './CurrencyListMod'
 import { MouseoverTooltip } from 'components/Tooltip'
 import { TagInfo, WrappedTokenInfo } from 'state/lists/hooks'
-import { Link } from 'react-router-dom'
+import { HashLink } from 'react-router-hash-link'
 
 const UNSUPPORTED_TOKEN_TAG = [
   {
     name: 'Unsupported',
     description:
-      'This token is unsupported as it does not operate efficiently with Gnosis Protocol. Please refer to the FAQ for more information.',
+      'This token is unsupported as it does not operate optimally with Gnosis Protocol. Please refer to the FAQ for more information.',
     id: '0'
   }
 ]
-
-const FAQ_URL = '/faq#what-are-unsupported-tokens'
 
 const Tag = styled(TagMod)<{ bg?: string }>`
   background-color: ${({ bg, theme }) => bg || theme.bg3};
@@ -63,9 +61,9 @@ function TokenTags({ currency, isUnsupported }: { currency: Currency; isUnsuppor
     return (
       <TagDescriptor bg="#f3a1a1" tags={UNSUPPORTED_TOKEN_TAG}>
         <TagLink>
-          <Link to={FAQ_URL} target="_blank" onClick={e => e.stopPropagation()}>
+          <HashLink to={UNSUPPORTED_TOKENS_FAQ_URL} target="_blank" onClick={e => e.stopPropagation()}>
             FAQ
-          </Link>
+          </HashLink>
         </TagLink>
       </TagDescriptor>
     )

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import styled from 'styled-components'
 import { ExternalLink, TYPE } from 'theme'
 
-import { version as WEB } from '@src/../package.json'
-import { version as CONTRACTS } from '@gnosis.pm/gp-v2-contracts/package.json'
+import { version as WEB_VERSION } from '@src/../package.json'
+import { version as CONTRACTS_VERSION } from '@gnosis.pm/gp-v2-contracts/package.json'
 import { ChainId } from '@uniswap/sdk'
 import { getEtherscanLink } from 'utils'
 import { CODE_LINK, GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS, GP_SETTLEMENT_CONTRACT_ADDRESS } from 'constants/index'
@@ -29,26 +29,26 @@ const VERSIONS: Record<
   { version: string; href: (chainId: ChainId) => string | { github: string; etherscan: string } }
 > = {
   Web: {
-    version: 'v' + WEB,
+    version: 'v' + WEB_VERSION,
     href() {
       return CODE_LINK
     }
   },
   'Allowance manager contract': {
-    version: 'v' + CONTRACTS,
+    version: 'v' + CONTRACTS_VERSION,
     href(chainId: ChainId) {
       return {
         etherscan: _getContractsUrls(chainId, GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS),
-        github: 'https://github.com/gnosis/gp-v2-contracts/blob/main/src/contracts/GPv2AllowListAuthentication.sol'
+        github: `https://github.com/gnosis/gp-v2-contracts/blob/v${CONTRACTS_VERSION}/src/contracts/GPv2AllowListAuthentication.sol`
       }
     }
   },
   'Settlement contract': {
-    version: 'v' + CONTRACTS,
+    version: 'v' + CONTRACTS_VERSION,
     href(chainId: ChainId) {
       return {
         etherscan: _getContractsUrls(chainId, GP_SETTLEMENT_CONTRACT_ADDRESS),
-        github: 'https://github.com/gnosis/gp-v2-contracts/blob/main/src/contracts/GPv2Settlement.sol'
+        github: `https://github.com/gnosis/gp-v2-contracts/blob/v${CONTRACTS_VERSION}/src/contracts/GPv2Settlement.sol`
       }
     }
   }

--- a/src/custom/components/Version/index.tsx
+++ b/src/custom/components/Version/index.tsx
@@ -39,7 +39,7 @@ const VERSIONS: Record<
     href(chainId: ChainId) {
       return {
         etherscan: _getContractsUrls(chainId, GP_ALLOWANCE_MANAGER_CONTRACT_ADDRESS),
-        github: 'https://github.com/gnosis/gp-v2-contracts/blob/main/src/contracts/GPv2AllowanceManager.sol'
+        github: 'https://github.com/gnosis/gp-v2-contracts/blob/main/src/contracts/GPv2AllowListAuthentication.sol'
       }
     }
   },

--- a/src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
+++ b/src/custom/components/swap/UnsupportedCurrencyFooter/UnsupportedCurrencyFooterMod.tsx
@@ -9,9 +9,10 @@ import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { useActiveWeb3React } from 'hooks'
 import { getEtherscanLink } from 'utils'
-import { Currency, Token } from '@uniswap/sdk'
+import { Currency /* , Token */ } from '@uniswap/sdk'
 import { wrappedCurrency } from 'utils/wrappedCurrency'
-import { useUnsupportedTokens } from 'hooks/Tokens'
+// import { useUnsupportedTokens } from 'hooks/Tokens'
+import { useIsUnsupportedToken } from 'state/lists/hooks/hooksMod'
 
 export const DetailsFooter = styled.div<{ show: boolean }>`
   padding-top: calc(16px + 2rem);
@@ -67,7 +68,9 @@ UnsupportedCurrencyFooterParams) {
         })
       : []
 
-  const unsupportedTokens: { [address: string]: Token } = useUnsupportedTokens()
+  // const unsupportedTokens: { [address: string]: Token } = useUnsupportedTokens()
+
+  const isUnsupportedToken = useIsUnsupportedToken()
 
   return (
     <DetailsFooter show={show}>
@@ -83,9 +86,10 @@ UnsupportedCurrencyFooterParams) {
             {tokens.map(token => {
               return (
                 token &&
-                unsupportedTokens &&
-                Object.keys(unsupportedTokens).includes(token.address) && (
-                  <OutlineCard key={token.address?.concat('not-supported')}>
+                // unsupportedToken &&
+                // combinedUnsupportedList.includes(token.address) && (
+                isUnsupportedToken(token.address) && (
+                  <OutlineCard key={token.address.concat('not-supported')} padding="0 1.25rem">
                     <AutoColumn gap="10px">
                       <AutoRow gap="5px" align="center">
                         <CurrencyLogo currency={token} size={'24px'} />
@@ -113,7 +117,7 @@ UnsupportedCurrencyFooterParams) {
       </Modal>
       <ButtonEmpty padding={'0'} onClick={() => setShowDetails(true)}>
         {/* <TYPE.blue>Read more about unsupported assets</TYPE.blue> */}
-        <TYPE.blue>{showDetailsText}</TYPE.blue>
+        <TYPE.error error={!!showDetailsText}>{showDetailsText}</TYPE.error>
       </ButtonEmpty>
     </DetailsFooter>
   )

--- a/src/custom/components/swap/UnsupportedCurrencyFooter/index.tsx
+++ b/src/custom/components/swap/UnsupportedCurrencyFooter/index.tsx
@@ -1,10 +1,19 @@
 import React from 'react'
+import { HashLink } from 'react-router-hash-link'
 import UnsupportedCurrencyFooterMod, { UnsupportedCurrencyFooterParams } from './UnsupportedCurrencyFooterMod'
+import { UNSUPPORTED_TOKENS_FAQ_URL } from 'constants/index'
 
-const DEFAULT_DETAILS_TEXT =
-  'Some assets are not available through this interface because they may not work well with our smart contract or we are unable to allow trading for legal reasons.'
-const DEFAULT_DETAILS_TITLE = 'Unsupported Assets'
-const DEFAULT_SHOW_DETAILS_TEXT = 'Read more about unsupported assets'
+const DEFAULT_DETAILS_TEXT = (
+  <div>
+    CowSwap does not support all tokens. Some tokens implement similar, but logically different ERC20 contract methods
+    which do not operate optimally with Gnosis Protocol.
+    <p>
+      For more information, please refer to the <HashLink to={UNSUPPORTED_TOKENS_FAQ_URL}>FAQ</HashLink>.
+    </p>
+  </div>
+)
+const DEFAULT_DETAILS_TITLE = 'Unsupported Token'
+const DEFAULT_SHOW_DETAILS_TEXT = 'Read more about unsupported tokens'
 
 export default function UnsupportedCurrencyFooter({
   detailsText = DEFAULT_DETAILS_TEXT,

--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -82,3 +82,5 @@ export const GAS_FEE_ENDPOINTS = {
   // TODO: xdai? = main
   [ChainId.XDAI]: 'https://safe-relay.gnosis.io/api/v1/gas-station/'
 }
+
+export const UNSUPPORTED_TOKENS_FAQ_URL = '/faq#what-token-pairs-does-cowswap-allow-to-trade'

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -155,9 +155,9 @@ export default function Faq() {
           </h3>
 
           <p>
-            <a href="https://research.paradigm.xyz/MEV">Defined</a> by the Paradigm research team, Maximum Extractable
-            Value (MEV) is “a measure of the profit a miner (or validator, sequencer, etc.) can make through their
-            ability to arbitrarily include, exclude, or re-order transactions within the blocks they produce.”
+            Defined by Phil Daian in the <a href="https://arxiv.org/abs/1904.05234"> paper Flash Boys 2.0 </a>, MEV is a measure of the profit a miner
+            (or validator, sequencer, etc.) can make through their ability to arbitrarily include, exclude, or re-order
+            transactions within the blocks they produce.
           </p>
 
           <p>
@@ -253,6 +253,19 @@ export default function Faq() {
         <Content>
           <h2 id="protocol">Protocol</h2>
 
+          <h3 id="does-cowswap-have-a-token">Does CowSwap have a token?</h3>
+
+          <p>
+            There is currently no plan for a CowSwap specific token. At the moment the value is already captured by the
+            GNO token, as CowSwap is built on top of Gnosis Protocol. If you are curious about how the value is
+            captured, you can <a href="https://forum.gnosis.io/t/gpv2-fee-model/1266"> read this forum post</a>.
+          </p>
+
+          <p>
+            Be cautious, some people may create fake COW tokens, that are not affiliated with this project. Please note 
+            that any token listed in any AMM is  <strong>NOT</strong> associated with this project in any way, shape or form.
+          </p>
+
           <h3 id="what-is-cowswap-s-fee-model">What is CowSwap’s fee model?</h3>
 
           <p>
@@ -307,6 +320,26 @@ export default function Faq() {
             across different protocols. Since orders only incur a cost if traded, active market makers can observe the
             orderbook and place counter orders (creating a CoW) to prevent settling trades via external liquidity.
           </p>
+
+          <h3 id="what-are-gnosis-protocol-v2-solvers">What are Gnosis Protocol v2 Solvers?</h3>
+
+          <p>
+            In GPv2, instead of using a central operator or a constant function market maker to determine trade
+            settlements, solvers compete against each other to submit the most optimal batch settlement solution. Each
+            time a solver submits a successful batch settlement solution, the protocol rewards them with GNO. 
+            Anyone can become a solver, although, in order to become one, there are certain requirements:
+          </p>
+          <ol>
+            <li>To become a solver, an Ethereum address needs to deposit a bond of GNO tokens to GnosisDAO.</li>
+            <li>
+              Once the GNO tokens have been staked (locked up), GnosisDAO has to vote to approve or reject the
+              Ethereum address that will identify the solver.
+            </li>
+            <li>
+              Additionally, a solver must have the technical knowledge to create the appropriate batch settlement
+              solutions, or take the risk of being slashed by the GnosisDAO for wrongdoing.
+            </li>
+          </ol>
         </Content>
       </Page>
 
@@ -320,7 +353,21 @@ export default function Faq() {
 
           <h3 id="what-token-pairs-does-cowswap-allow-to-trade">What token pairs does CowSwap allow you to trade?</h3>
 
-          <p>Any valid ERC20 token pair for which there is some basic liquidity on a DEX (like Uniswap or Balancer).</p>
+          <p>
+            Any valid ERC20 token pair that does not apply transfer fees, and for which there is some basic liquidity on
+            a DEX (like Uniswap or Balancer).
+          </p>
+
+          <h3 id="what-token-pairs-does-cowswap-not-allow-to-trade">
+            What token pairs does CowSwap NOT allow you to trade?
+          </h3>
+
+          <p>
+            Unfortunately, CowSwap does not support some tokens. While these tokens implement the typical ERC20
+            interface, when calling the transfer and transferFrom methods, the actual amount the receiver will get will
+            be smaller than the specified sent amount. This causes problems with CowSwap&apos;s settlement logic which
+            expects the received amount (e.g. from a Uniswap interaction) to be fully transferable to the trader.
+          </p>
 
           <h3 id="why-is-cowswap-able-to-offer-gas-free-trades">Why is CowSwap able to offer gas-free trades?</h3>
 
@@ -415,6 +462,39 @@ export default function Faq() {
             allow you to wrap and unwrap ETH into WETH without needing to leave the dapp’s UI
           </p>
 
+          <h3 id="why-is-selling-eth-more-troublesome">
+            Why is selling ETH more troublesome?
+          </h3>
+
+          <p>
+            CowSwap only operates with ERC20 tokens. ETH is the native Ethereum currency, which is not an ERC20 token.
+          </p>
+          
+          <p>
+            In order to sell ETH, you need to wrap it first to make it ERC20 compatible. Wrapping is done by making an 
+            ETH deposit into the WETH contract. After doing so, you will get a balance of WETH in the amount of ETH 
+            previously deposited.
+          </p>
+          
+          <p>
+            You can withdraw your ETH from the WETH contract at any time, and this is called unwrapping WETH.
+          </p>
+          
+          <p>
+            Wrapping and unwrapping ETH are simple Ethereum transactions not related to CowSwap, meaning gas costs 
+            for executing the transactions are involved.
+          </p>
+
+          <p>
+            Although CowSwap doesn't allow you to sell ETH directly, it will assist you with the wrapping/unwrapping, 
+            so you can easily handle ETH/WETH, as needed.
+          </p>
+          
+          <p>
+            While ETH cannot be sold directly, it is possible to directly buy ETH. This is because CowSwap allows 
+            you to buy WETH and will directly unwrap it for you.
+          </p>
+          
           <hr />
 
           <p>

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -134,7 +134,10 @@ export default function Swap({
   const isNativeInSwap = isNativeIn && !isWrappedOut
 
   // Is fee greater than input?
-  const { isFeeGreater, fee } = useIsFeeGreaterThanInput({ chainId, address: INPUT.currencyId, parsedAmount })
+  const { isFeeGreater, fee } = useIsFeeGreaterThanInput({
+    chainId,
+    address: INPUT.currencyId
+  })
 
   const toggledVersion = useToggledVersion()
   const tradesByVersion = {

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -369,7 +369,7 @@ export default function Swap({
       <SwapPoolTabs active={'swap'} />
       <AppBody className={className}>
         <SwapHeader />
-        <Wrapper id="swap-page">
+        <Wrapper id="swap-page" className={isExpertMode ? 'expertMode' : ''}>
           <ConfirmSwapModal
             isOpen={showConfirm}
             trade={trade}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -552,7 +552,7 @@ export default function Swap({
                     'Approve ' + currencies[Field.INPUT]?.symbol
                   )}
                 </ButtonConfirmed>
-                {/* <ButtonError
+                <ButtonError
                   buttonSize={ButtonSize.BIG}
                   onClick={() => {
                     if (isExpertMode) {
@@ -570,16 +570,17 @@ export default function Swap({
                   width="48%"
                   id="swap-button"
                   disabled={
-                    !isValid || approval !== ApprovalState.APPROVED || (priceImpactSeverity > 3 && !isExpertMode)
+                    !isValid || approval !== ApprovalState.APPROVED // || (priceImpactSeverity > 3 && !isExpertMode)
                   }
-                  error={isValid && priceImpactSeverity > 2}
+                  // error={isValid && priceImpactSeverity > 2}
                 >
                   <Text fontSize={16} fontWeight={500}>
-                    {priceImpactSeverity > 3 && !isExpertMode
+                    {/* {priceImpactSeverity > 3 && !isExpertMode
                       ? `Price Impact High`
-                      : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`}
+                      : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`} */}
+                    Swap
                   </Text>
-                </ButtonError> */}
+                </ButtonError>
               </RowBetween>
             ) : (
               <ButtonError

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -513,7 +513,7 @@ export default function Swap({
           <BottomGrouping>
             {swapIsUnsupported ? (
               <ButtonPrimary buttonSize={ButtonSize.BIG} disabled={true}>
-                <TYPE.main mb="4px">Unsupported Asset</TYPE.main>
+                <TYPE.main mb="4px">Unsupported Token</TYPE.main>
               </ButtonPrimary>
             ) : !account ? (
               <ButtonLight buttonSize={ButtonSize.BIG} onClick={toggleWalletModal}>

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -7,7 +7,7 @@ import { Text } from 'rebass'
 import { ButtonSize, TYPE } from 'theme/index'
 
 import SwapMod from './SwapMod'
-import { RowBetween, RowFixed } from 'components/Row'
+import { AutoRow, RowBetween, RowFixed } from 'components/Row'
 import {
   BottomGrouping as BottomGroupingUni,
   Wrapper as WrapperUni,
@@ -47,6 +47,10 @@ const SwapModWrapper = styled(SwapMod)`
       grid-row-gap: 3px;
     }
 
+    .expertMode ${AutoColumn} {
+      grid-row-gap: 12px;
+    }
+
     ${Card} > ${AutoColumn} {
       margin: 6px auto 0;
     }
@@ -74,6 +78,13 @@ const SwapModWrapper = styled(SwapMod)`
       > svg {
         stroke: #000000b8;
       }
+    }
+
+    .expertMode ${ArrowWrapperUni} {
+      position: relative;
+    }
+    .expertMode ${AutoRow} {
+      padding: 0 1rem;
     }
   }
 `

--- a/src/custom/state/lists/hooks/hooksMod.ts
+++ b/src/custom/state/lists/hooks/hooksMod.ts
@@ -260,7 +260,7 @@ export function useIsUnsupportedToken() {
 
   return useCallback(
     (address?: string) => {
-      // Returns a predicate function determining a token's support by address against our Set
+      // Returns a predicate function determining a token's support by address against our hooks
       return Boolean(isUnsupportedTokenFromList(address) || isUnsupportedTokenGp(address))
     },
     [isUnsupportedTokenFromList, isUnsupportedTokenGp]

--- a/src/custom/state/price/reducer.ts
+++ b/src/custom/state/price/reducer.ts
@@ -19,13 +19,14 @@ export interface FeeInformation {
 
 export interface PriceInformation {
   token: string
-  amount: string
+  amount: string | null
 }
 
 export interface QuoteInformationObject extends Omit<FeeQuoteParams, 'kind'> {
   fee: FeeInformation
   price: PriceInformation
   lastCheck: number
+  feeExceedsPrice: boolean
 }
 
 // Map token addresses to their last quote information

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -213,7 +213,9 @@ export function useTradeExactOutWithFee({
     ...outTrade,
     // overriding inputAmount is a hack
     // to allow us to not have to change Uni's pages/swap/index and use different method names
-    inputAmount: inputAmountWithoutFee,
+    // in this case we need to show users the default inputAmount as the inputAmount adjusted for fee
+    // this is purely for display reasons and to keep it working with Uni's code.
+    inputAmount: inputAmountWithFee,
     inputAmountWithFee,
     minimumAmountOut(pct: Percent) {
       // this refers to trade object being constructed

--- a/src/custom/state/swap/extension.ts
+++ b/src/custom/state/swap/extension.ts
@@ -25,7 +25,7 @@ export type TradeWithFee = Trade & {
 type TradeExecutionPrice = CanonicalMarketParams<CurrencyAmount | undefined> & { price?: PriceInformation }
 
 export function _constructTradePrice({ sellToken, buyToken, kind, price }: TradeExecutionPrice): Price | undefined {
-  if (!sellToken || !buyToken || !price) return
+  if (!sellToken || !buyToken || !price?.amount) return
 
   let executionPrice: Price | undefined
   // get canonical market tokens
@@ -114,7 +114,7 @@ export function useTradeExactInWithFee({
 
   // make sure we have a typed in amount, a fee, and a price
   // else we can assume the trade will be null
-  if (!parsedInputAmount || !originalTrade || !outputCurrency || !quote?.fee || !quote?.price) return null
+  if (!parsedInputAmount || !originalTrade || !outputCurrency || !quote?.fee || !quote?.price.amount) return null
 
   const feeAsCurrency = stringToCurrency(quote.fee.amount, parsedInputAmount.currency)
   // Check that fee amount is not greater than the user's input amt
@@ -179,7 +179,7 @@ export function useTradeExactOutWithFee({
   // Original Uni trade hook
   const outTrade = useTradeExactOut(inputCurrency ?? undefined, parsedOutputAmount)
 
-  if (!outTrade || !parsedOutputAmount || !inputCurrency || !quote?.fee || !quote?.price) return null
+  if (!outTrade || !parsedOutputAmount || !inputCurrency || !quote?.fee || !quote?.price.amount) return null
 
   const feeAsCurrency = stringToCurrency(quote.fee.amount, inputCurrency)
   // set final fee object

--- a/src/custom/state/swap/hooks.ts
+++ b/src/custom/state/swap/hooks.ts
@@ -22,7 +22,6 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
 import { SwapState } from 'state/swap/reducer'
 import { ParsedQs } from 'qs'
-import { BigNumber } from 'ethers'
 import { DEFAULT_NETWORK_FOR_LISTS } from 'constants/lists'
 import { WETH_LOGO_URI, XDAI_LOGO_URI } from 'constants/index'
 import { WrappedTokenInfo } from '../lists/hooks'
@@ -71,7 +70,7 @@ export function useDerivedSwapInfo(): DerivedSwapInfo {
   })
 
   useEffect(() => {
-    console.debug('[useDerivedSwapInfo] Price quote: ', quote?.price.amount)
+    console.debug('[useDerivedSwapInfo] Price quote: ', quote?.price?.amount)
     console.debug('[useDerivedSwapInfo] Fee quote: ', quote?.fee?.amount)
   }, [quote])
 
@@ -264,21 +263,18 @@ export function useDetectNativeToken(input?: CurrencyWithAddress, output?: Curre
 
 export function useIsFeeGreaterThanInput({
   address,
-  parsedAmount,
   chainId
 }: {
   address?: string
-  parsedAmount?: CurrencyAmount
   chainId?: ChainId
 }): { isFeeGreater: boolean; fee: CurrencyAmount | null } {
   const quote = useQuote({ chainId, token: address })
+  const feeToken = useCurrency(address)
 
-  if (!quote || !quote.fee || !parsedAmount) return { isFeeGreater: false, fee: null }
-
-  const feeBigNumber = BigNumber.from(quote.fee.amount)
+  if (!quote?.fee || !feeToken) return { isFeeGreater: false, fee: null }
 
   return {
-    isFeeGreater: feeBigNumber.gte(parsedAmount.raw.toString()),
-    fee: stringToCurrency(feeBigNumber.toString(), parsedAmount.currency)
+    isFeeGreater: quote.feeExceedsPrice,
+    fee: stringToCurrency(quote.fee.amount, feeToken)
   }
 }

--- a/src/custom/state/swap/trade.test.ts
+++ b/src/custom/state/swap/trade.test.ts
@@ -57,15 +57,14 @@ describe('Swap PRICE Quote test', () => {
           price: { amount: MOCKED_PRICE_OUT.long, token: DAI_MAINNET.name || 'token' }
         })
 
-        console.debug('EXECUTION PRICE', executionPrice?.toSignificant(18))
-
         trade = {
           ...tradeSdk,
           executionPrice,
-          inputAmount: tradeSdk.inputAmount.subtract(feeAsCurrency),
+          // sell orders: we show user on UI inputAmount with no fee calculation
+          inputAmount: tradeSdk.inputAmount,
           inputAmountWithFee: tradeSdk.inputAmount.subtract(feeAsCurrency),
           inputAmountWithoutFee: tradeSdk.inputAmount,
-          outputAmount: new TokenAmount(DAI_MAINNET, MOCKED_PRICE_OUT.long),
+          outputAmount: currencyOut,
           maximumAmountIn(pct: Percent) {
             return _maximumAmountInExtension(pct, this)
           },
@@ -129,13 +128,13 @@ describe('Swap PRICE Quote test', () => {
           price: { amount: MOCKED_PRICE_IN.long, token: WETH_MAINNET.name || 'token' }
         })
 
-        console.debug('EXECUTION PRICE', executionPrice?.toSignificant(18))
-
         trade = {
           ...tradeSdk,
           executionPrice,
-          inputAmount: apiBuyPriceAsCurrency,
+          // fee is in selltoken so for buy orders we set inputAmount as inputAmountWithFee
+          inputAmount: apiBuyPriceAsCurrencyWithFee,
           inputAmountWithFee: apiBuyPriceAsCurrencyWithFee,
+          inputAmountWithoutFee: apiBuyPriceAsCurrency,
           maximumAmountIn(pct: Percent) {
             return _maximumAmountInExtension(pct, this)
           },

--- a/src/custom/utils/operator/index.ts
+++ b/src/custom/utils/operator/index.ts
@@ -151,17 +151,19 @@ function toApiAddress(address: string, chainId: ChainId): string {
 
 async function _getJson(chainId: ChainId, url: string): Promise<any> {
   let response: Response | undefined
+  let json
   try {
     response = await _fetchGet(chainId, url)
+    json = await response.json()
   } finally {
-    if (!response) {
+    if (!response || !json) {
       throw new Error(`Error getting query @ ${url}`)
     } else if (!response.ok) {
       // is backend error handled at this point
-      const errorResponse: ApiError = await response.json()
+      const errorResponse: ApiError = json
       throw new OperatorError(errorResponse)
     } else {
-      return response.json()
+      return json
     }
   }
 }


### PR DESCRIPTION
## Do not Squash 🥒, just normal merge

```
# To get commits used in the description (useful for next releases) 
git log master..HEAD --oneline --decorate=0
```

# 💪Work In Progress
🚨This version is not ready to be merged!!🚨 
Pending to incorporate some open PRs:
* ~Unsupported tokens #623, #628~ 
* ~Display price loaded from API: #611, #625~
* Fix issues:
- [x]  Flipping issue: invariants: If you start to swich tokens several times. Observed in #623
- [ ] Issue selling ETH for ETH (ben issue)
- [ ] When I first load the price, I see a price that is completely off. Then it corrects itself automatically. Observed in #623
- [x] Amounts issue when you flip: We need to review because it was modifying the amounts wswitchinghing tokens
- [x] Max amount issue: insufficient liqudity. Observed in #623
- [x] ~Button disappearing --> the actual SWAP button next to the APPROVE button~ #631 
- [x] Max amount issue -> Says insufficient balance when hitting the 'MAX' button. If you provide too low of an amount it will shows: "INSUFFICIENT LIQUIDITY". The only way it works is by inputting an amount somewhere in the middle (e.g. 50% of your SELL token balance) -> Happens on https://pr625--gpswapui.review.gnosisdev.com/#/swap
- [ ] UI broken / sender address -> Fixed in #622 
- [x] wrong From price in confirm modal for buy orders #638 
- [ ] FAQ #643 

# Release notes (QA instructions)
- [x] RC.0 Testing
 ### RC.0 Testing notes:
 ##### d91b6d3 Price Endpoint: Construct Trade object using external price information (#611)
a. The api now returns a price for the amount of tokens input by the user.  Here is a doc covering how to get to the correct amounts for different trades: https://docs.google.com/document/d/1zxY_9LH7yPKwXbpwQnN5cGkKWYh8j-Fnl9ovCCI4pKs/edit#
b. Note that the prices therefore amounts will change, and can be rapid, making testing difficult. One method for mitigating this and having deterministic numbers is to screenshot the screen on rinkeby (slower updates) and making the calulcations based on the screenshot.
c. Within the chrome console, you can filter using `[useDerivedSwapInfo]` to only show you the updating price/fee quote amounts, using that to get the correct amounts.
Note: I'll try and come up with an easier way for you to test this. If it helps, there is `trades.test.ts` which are js integration tests to test exactly this.
#### e008bfc2 [407 pt.1] Unsupported Tokens - Logic implementation (#623)
a. follow https://github.com/gnosis/gp-swap-ui/pull/619#issue-640320595 for testing information
#### adec417f Remove price impact (#614)
a. price impact has been removed for now, expected not to see it

@MareenG this just means we are freezing this version. On monday we will try to fix some bugs and create a Release Candidate in Staging so you can test. For now, it has too many bugs.


# Changelog
### v0.12.0-rc.1

740dd1ac [638] Buy order: show correct amount in modal (#642)
d00a0c88 Fix alloance manager contract source link (#647)
fe044fb0 Fix layout for expert mode. (#634)
0917e390 Fix missing swap button (#631)

--

### v0.12.0-rc.0

61243901 0.12.0-rc.0
d91b6d3e Price Endpoint: Construct Trade object using external price information (#611)
e008bfc2 [407 pt.1] Unsupported Tokens - Logic implementation (#623)
806d4760 Deduct fee from the quoted price (#620)
adec417f Remove price impact (#614)
e4e784b9 Streamline styles for the swap container. (#607)
c846edeb Remove route (#615)
f8bcf094 Added Cow background as SVG. (#613)
c93861a6 Improve appzi implementation (#605)
76f104a1 Improve popup contrast styles. (#603)
2758097a Use API price, and refetch logic (#600)
66703eba Make button colors consistent. (#540)
9efc7495 Main menu responsive improvements. (#588)
38574c41 style error button. (#580)
8b884c6e Change aria (#549)