### PR TITLE
Fix unsupported tokens not getting flagged

### DIFF
--- a/src/custom/state/lists/reducer/reducerMod.ts
+++ b/src/custom/state/lists/reducer/reducerMod.ts
@@ -259,6 +259,10 @@ export default createReducer(initialState, builder =>
             return true
           })
         }
+
+        if (!state.gpUnsupportedTokens) {
+          state.gpUnsupportedTokens = {}
+        }
       }
     )
 )


### PR DESCRIPTION
Instantiate the unsupportedTokens object in state if it doesn't exist.

localStorage > redux

if localstorage.someProp doesn't exist in local it doesn't get set in redux