### PR TITLE
Approve button style fixes.

### DIFF
--- a/src/components/ProgressSteps/index.tsx
+++ b/src/components/ProgressSteps/index.tsx
@@ -10,7 +10,7 @@ const Grouping = styled(RowBetween)`
   width: 50%;
 `
 
-const Circle = styled.div<{ confirmed?: boolean; disabled?: boolean }>`
+export const Circle = styled.div<{ confirmed?: boolean; disabled?: boolean }>`
   min-width: 20px;
   min-height: 20px;
   background-color: ${({ theme, confirmed, disabled }) =>

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -547,7 +547,10 @@ export default function Swap({
                 >
                   {approval === ApprovalState.PENDING ? (
                     <AutoRow gap="6px" justify="center">
-                      Approving <Loader stroke="white" />
+                      Approving{' '}
+                      <Loader
+                      // stroke="white"
+                      />
                     </AutoRow>
                   ) : approvalSubmitted && approval === ApprovalState.APPROVED ? (
                     'Approved'
@@ -577,7 +580,10 @@ export default function Swap({
                   }
                   // error={isValid && priceImpactSeverity > 2}
                 >
-                  <Text fontSize={16} fontWeight={500}>
+                  <Text
+                    // fontSize={16}
+                    fontWeight={500}
+                  >
                     {/* {priceImpactSeverity > 3 && !isExpertMode
                       ? `Price Impact High`
                       : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`} */}
@@ -605,7 +611,10 @@ export default function Swap({
                 disabled={!isValid /*|| (priceImpactSeverity > 3 && !isExpertMode) */ || !!swapCallbackError}
                 // error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
               >
-                <Text fontSize={20} fontWeight={500}>
+                <Text
+                  // fontSize={20}
+                  fontWeight={500}
+                >
                   {swapInputError ? swapInputError : 'Swap'
                   // : priceImpactSeverity > 3 && !isExpertMode
                   // ? `Price Impact Too High`

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -19,6 +19,7 @@ import QuestionHelper from 'components/QuestionHelper'
 import { ButtonError, ButtonPrimary } from 'components/Button'
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
 import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
+import { Circle } from '@src/components/ProgressSteps'
 
 interface FeeGreaterMessageProp {
   fee: CurrencyAmount
@@ -85,6 +86,14 @@ const SwapModWrapper = styled(SwapMod)`
     }
     .expertMode ${AutoRow} {
       padding: 0 1rem;
+    }
+
+    ${Circle} {
+      color: ${({ theme, confirmed, disabled }) => (disabled ? theme.text1 : confirmed ? theme.white : theme.text1)};
+    }
+
+    ${AutoRow} svg > path {
+      stroke: ${({ theme }) => theme.text1};
     }
   }
 `


### PR DESCRIPTION
- Fixes styles for the PENDING state of the Approve button.
- Make sure button font-sizes are equal
- Makes the circle steps visible by applying a proper text color.

<img width="350" alt="Screen Shot 2021-05-20 at 15 03 32" src="https://user-images.githubusercontent.com/31534717/118983535-d5dc4d00-b97c-11eb-9233-d73c5b0af4de.png"><img width="350" alt="Screen Shot 2021-05-20 at 15 04 02" src="https://user-images.githubusercontent.com/31534717/118983526-d4128980-b97c-11eb-92d9-3ecc1a57d71d.png">

Tried to override the steps when the first check is `confirmed` to have a white color (on the green circle). For some reason I can't override it (yet..).
<img width="350" alt="Screen Shot 2021-05-20 at 15 04 15" src="https://user-images.githubusercontent.com/31534717/118983520-d2e15c80-b97c-11eb-90a4-0565372b2f87.png">
