### PR TITLE
Improve error messages

### DIFF
--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -24,7 +24,7 @@ const API_ERROR_CODE_DESCRIPTIONS = {
     'The order signature is invalid. Check whether your Wallet app supports off-chain signing.',
   [ApiErrorCodes.MissingOrderData]: 'The order has missing information',
   [ApiErrorCodes.InsufficientValidTo]:
-    'The order you are signing is already expired. This can happen if you set a short expiration in the settings and then you take some time for signing the transaction. Please try again',
+    'The order you are signing is already expired. This can happen if you set a short expiration in the settings and waited too long before signing the transaction. Please try again.',
   [ApiErrorCodes.InsufficientFunds]: "The account doesn't have enough funds",
   [ApiErrorCodes.UnsupportedToken]:
     'One of the tokens you are trading is unsupported. Please read the FAQ for more info.',

--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -17,13 +17,17 @@ export interface ApiError {
 }
 
 const API_ERROR_CODE_DESCRIPTIONS = {
-  [ApiErrorCodes.DuplicateOrder]: 'There was another identical order already submitted',
-  [ApiErrorCodes.InsufficientFee]: "The account doesn't have enough funds",
-  [ApiErrorCodes.InvalidSignature]: 'The order signature is invalid',
+  [ApiErrorCodes.DuplicateOrder]: 'There was another identical order already submitted. Please try again.',
+  [ApiErrorCodes.InsufficientFee]:
+    "The signed fee is insufficient. It's possible that is higher now for a change in gas prices, ether price, or the selling token price. Please try again so you get an updated fee quote.",
+  [ApiErrorCodes.InvalidSignature]:
+    'The order signature is invalid. Check with you support in your Wallet app the support for off-chain signing.',
   [ApiErrorCodes.MissingOrderData]: 'The order has missing information',
-  [ApiErrorCodes.InsufficientValidTo]: "The account doesn't have enough funds",
+  [ApiErrorCodes.InsufficientValidTo]:
+    'The order you are signing is already expired. This can happen if you set a short expiration in the settings and then you take some time for signing the transaction. Please try again',
   [ApiErrorCodes.InsufficientFunds]: "The account doesn't have enough funds",
-  [ApiErrorCodes.UnsupportedToken]: 'An unsupported token was detected',
+  [ApiErrorCodes.UnsupportedToken]:
+    'One of the tokens you are trading is unsupported. Please read the FAQ for more info.',
   [ApiErrorCodes.WrongOwner]: 'An invalid owner address was given',
   UNHANDLED_ERROR: 'The order was not accepted by the network'
 }

--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -19,7 +19,7 @@ export interface ApiError {
 const API_ERROR_CODE_DESCRIPTIONS = {
   [ApiErrorCodes.DuplicateOrder]: 'There was another identical order already submitted. Please try again.',
   [ApiErrorCodes.InsufficientFee]:
-    "The signed fee is insufficient. It's possible that is higher now for a change in gas prices, ether price, or the selling token price. Please try again so you get an updated fee quote.",
+    "The signed fee is insufficient. It's possible that is higher now due to a change in the gas price, ether price, or the sell token price. Please try again so you get an updated fee quote.",
   [ApiErrorCodes.InvalidSignature]:
     'The order signature is invalid. Check with you support in your Wallet app the support for off-chain signing.',
   [ApiErrorCodes.MissingOrderData]: 'The order has missing information',

--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -19,7 +19,7 @@ export interface ApiError {
 const API_ERROR_CODE_DESCRIPTIONS = {
   [ApiErrorCodes.DuplicateOrder]: 'There was another identical order already submitted. Please try again.',
   [ApiErrorCodes.InsufficientFee]:
-    "The signed fee is insufficient. It's possible that is higher now due to a change in the gas price, ether price, or the sell token price. Please try again so you get an updated fee quote.",
+    "The signed fee is insufficient. It's possible that is higher now due to a change in the gas price, ether price, or the sell token price. Please try again to get an updated fee quote.",
   [ApiErrorCodes.InvalidSignature]:
     'The order signature is invalid. Check whether your Wallet app supports off-chain signing.',
   [ApiErrorCodes.MissingOrderData]: 'The order has missing information',

--- a/src/custom/utils/operator/error.ts
+++ b/src/custom/utils/operator/error.ts
@@ -21,7 +21,7 @@ const API_ERROR_CODE_DESCRIPTIONS = {
   [ApiErrorCodes.InsufficientFee]:
     "The signed fee is insufficient. It's possible that is higher now due to a change in the gas price, ether price, or the sell token price. Please try again so you get an updated fee quote.",
   [ApiErrorCodes.InvalidSignature]:
-    'The order signature is invalid. Check with you support in your Wallet app the support for off-chain signing.',
+    'The order signature is invalid. Check whether your Wallet app supports off-chain signing.',
   [ApiErrorCodes.MissingOrderData]: 'The order has missing information',
   [ApiErrorCodes.InsufficientValidTo]:
     'The order you are signing is already expired. This can happen if you set a short expiration in the settings and then you take some time for signing the transaction. Please try again',


### PR DESCRIPTION
Fixes an issue with some error in the message description

![image](https://user-images.githubusercontent.com/2352112/119113922-e3014680-ba25-11eb-8ded-252ef3fdba5d.png)

Steps:
1. Set time to 1 min
2. Swap, etc
3. Don't sign yet. Hold it for a few minutes
4. Sign order
Will fail with the message above


New message:
![image](https://user-images.githubusercontent.com/2352112/119119233-4cd01f00-ba2b-11eb-92a6-3249a0fdc6a3.png)


