### PR TITLE
662 - Dancing Numbers!

### DIFF
--- a/src/custom/hooks/useDebounceWithForceUpdate.ts
+++ b/src/custom/hooks/useDebounceWithForceUpdate.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+// modified from https://usehooks.com/useDebounce/
+export default function useDebounceWithForceUpdate<T>(
+  value: T,
+  delay: number,
+  forceUpdateRef?: string | number | boolean
+): T {
+  const [lastForceUpdateRef, setLastForceUpdateRef] = useState(forceUpdateRef)
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  // force update
+  useEffect(() => {
+    if (
+      (Boolean(value) && debouncedValue === undefined) ||
+      (Boolean(forceUpdateRef) && forceUpdateRef !== lastForceUpdateRef)
+    ) {
+      setDebouncedValue(value)
+      setLastForceUpdateRef(forceUpdateRef)
+    }
+  }, [debouncedValue, forceUpdateRef, lastForceUpdateRef, value])
+
+  // Update debounced value after delay
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    // Cancel the timeout if value changes (also on delay change or unmount)
+    // This is how we prevent debounced value from updating if value is changed ...
+    // .. within the delay period. Timeout gets cleared and restarted.
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay, debouncedValue])
+
+  return value
+}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -169,7 +169,7 @@ export default function Swap({
   )
   const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
   const { address: recipientAddress } = useENSAddress(recipient)
-  const trade = tradeLoading || showWrap ? undefined : tradeCurrentVersion
+  const trade = showWrap ? undefined : tradeCurrentVersion
   const defaultTrade = showWrap ? undefined : tradesByVersion[DEFAULT_VERSION]
 
   const betterTradeLinkV2: Version | undefined =

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -169,7 +169,7 @@ export default function Swap({
   )
   const showWrap: boolean = !isNativeInSwap && wrapType !== WrapType.NOT_APPLICABLE
   const { address: recipientAddress } = useENSAddress(recipient)
-  const trade = showWrap ? undefined : tradeCurrentVersion
+  const trade = tradeLoading || showWrap ? undefined : tradeCurrentVersion
   const defaultTrade = showWrap ? undefined : tradesByVersion[DEFAULT_VERSION]
 
   const betterTradeLinkV2: Version | undefined =

--- a/src/custom/state/price/updater.ts
+++ b/src/custom/state/price/updater.ts
@@ -4,12 +4,12 @@ import { useSwapState, tryParseAmount } from 'state/swap/hooks'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { Field } from 'state/swap/actions'
 import { useCurrency } from 'hooks/Tokens'
-import useDebounce from 'hooks/useDebounce'
 import { useAllQuotes, useLoadingQuote } from './hooks'
 import { useRefetchQuoteCallback } from 'hooks/useRefetchPriceCallback'
 import { FeeQuoteParams, UnsupportedToken } from 'utils/operator'
 import { QuoteInformationObject } from './reducer'
 import { useIsUnsupportedTokenGp } from 'state/lists/hooks/hooksMod'
+import useDebounceWithForceUpdate from 'hooks/useDebounceWithForceUpdate'
 
 const DEBOUNCE_TIME = 350
 const REFETCH_CHECK_INTERVAL = 10000 // Every 10s
@@ -106,9 +106,14 @@ export default function FeesUpdater(): null {
   } = useSwapState()
 
   const loadingQuote = useLoadingQuote()
+  // pass independent field as a reference to use against
+  // any changes to determine if user has switched input fields
+  // useful to force debounce value to refresh
+  const forceUpdateRef = independentField
+
   // Debounce the typed value to not refetch the fee too often
   // Fee API calculation/call
-  const typedValue = useDebounce(rawTypedValue, DEBOUNCE_TIME)
+  const typedValue = useDebounceWithForceUpdate(rawTypedValue, DEBOUNCE_TIME, forceUpdateRef)
 
   const sellCurrency = useCurrency(sellToken)
   const buyCurrency = useCurrency(buyToken)


### PR DESCRIPTION
Closes #662 - merges into #668 or should merge into develop after #668

Addresses dancing numbers which was a result of the `useDebounce` hook caching the last value. Why was this an issue? When switching trade types, e.g inputting something into the BUY input after initially inputtin sth in the SELL input would send a quote request using the last SELL input amt to the backend returning sometimes outlandish amounts for a few seconds, before recalculating the correct amounts.

The new hook, `useDebounceWithForceUpdate` (epic name) has a force arg that allows the last amount to be used and bypasses the debounce.

This also returns `null` on `quoteLoading` to reset the field