### PR TITLE
612/Incorrect mapping backend endpoint

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -13,7 +13,7 @@ REACT_APP_PORTIS_ID="c0e2bf01-4b08-4fd5-ac7b-8e26b58cd236"
 REACT_APP_FORTMATIC_KEY="pk_live_F937DF033A1666BF"
 
 # Domain
-REACT_APP_DOMAIN_REGEX_DEV="^(:?cowswap\.dev|localhost:\d{2,5}|pr\\d+--gpswapui\.review)"
+REACT_APP_DOMAIN_REGEX_DEV="^(:?cowswap\.dev|localhost:\d{2,5}|pr\d+--gpswapui\.review)"
 REACT_APP_DOMAIN_REGEX_STAGING="^cowswap\.staging"
 REACT_APP_DOMAIN_REGEX_PROD="^cowswap\.exchange$"
 REACT_APP_DOMAIN_REGEX_ENS="^cowswap\.eth"


### PR DESCRIPTION
# Summary

Closes #612 

Seems like the regex was over escaped

## Before
![screenshot_2021-05-26_13-22-01](https://user-images.githubusercontent.com/43217/119725856-4ecc2080-be25-11eb-870b-f19e78797127.png)

## Now
![screenshot_2021-05-26_13-20-54](https://user-images.githubusercontent.com/43217/119725751-2fcd8e80-be25-11eb-8051-0cb9bb0e508f.png)

# Testing

Check the fee/price requests go to the `.dev.gnosisdev.com` domain
