### PR TITLE
Approve buttons fix v3

### DIFF
--- a/src/components/ProgressSteps/index.tsx
+++ b/src/components/ProgressSteps/index.tsx
@@ -10,7 +10,7 @@ const Grouping = styled(RowBetween)`
   width: 50%;
 `
 
-const Circle = styled.div<{ confirmed?: boolean; disabled?: boolean }>`
+export const Circle = styled.div<{ confirmed?: boolean; disabled?: boolean }>`
   min-width: 20px;
   min-height: 20px;
   background-color: ${({ theme, confirmed, disabled }) =>

--- a/src/custom/components/ProgressSteps/ProgressStepsMod.tsx
+++ b/src/custom/components/ProgressSteps/ProgressStepsMod.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import styled from 'styled-components'
+import { RowBetween } from 'components/Row'
+import { AutoColumn } from 'components/Column'
+import { transparentize } from 'polished'
+
+const Wrapper = styled(AutoColumn)``
+
+const Grouping = styled(RowBetween)`
+  width: 50%;
+`
+
+export const Circle = styled.div<{ confirmed?: boolean; disabled?: boolean }>`
+  min-width: 20px;
+  min-height: 20px;
+  background-color: ${({ theme, confirmed, disabled }) =>
+    disabled ? theme.bg4 : confirmed ? theme.green1 : theme.primary1};
+  border-radius: 50%;
+  color: ${({ theme }) => theme.white};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 8px;
+  font-size: 12px;
+`
+
+const CircleRow = styled.div`
+  width: calc(100% - 20px);
+  display: flex;
+  align-items: center;
+`
+
+const Connector = styled.div<{ prevConfirmed?: boolean; disabled?: boolean }>`
+  width: 100%;
+  height: 2px;
+  background-color: ;
+  background: linear-gradient(
+    90deg,
+    ${({ theme, prevConfirmed, disabled }) =>
+        disabled ? theme.bg4 : transparentize(0.5, prevConfirmed ? theme.green1 : theme.primary1)}
+      0%,
+    ${({ theme, prevConfirmed, disabled }) => (disabled ? theme.bg4 : prevConfirmed ? theme.primary1 : theme.bg4)} 80%
+  );
+  opacity: 0.6;
+`
+
+export interface ProgressCirclesProps {
+  steps: boolean[]
+  disabled?: boolean
+  CircleComponent: typeof Circle
+}
+
+/**
+ * Based on array of steps, create a step counter of circles.
+ * A circle can be enabled, disabled, or confirmed. States are derived
+ * from previous step.
+ *
+ * An extra circle is added to represent the ability to swap, add, or remove.
+ * This step will never be marked as complete (because no 'txn done' state in body ui).
+ *
+ * @param steps  array of booleans where true means step is complete
+ */
+export default function ProgressCircles({ steps, disabled = false, CircleComponent, ...rest }: ProgressCirclesProps) {
+  return (
+    <Wrapper justify={'center'} {...rest}>
+      <Grouping>
+        {steps.map((step, i) => {
+          return (
+            <CircleRow key={i}>
+              <CircleComponent confirmed={step} disabled={disabled || (!steps[i - 1] && i !== 0)}>
+                {step ? '✓' : i + 1}
+              </CircleComponent>
+              <Connector prevConfirmed={step} disabled={disabled} />
+            </CircleRow>
+          )
+        })}
+        <CircleComponent disabled={disabled || !steps[steps.length - 1]}>{steps.length + 1}</CircleComponent>
+      </Grouping>
+    </Wrapper>
+  )
+}

--- a/src/custom/components/ProgressSteps/index.tsx
+++ b/src/custom/components/ProgressSteps/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import ProgressCirclesUni, { Circle as CircleUni, ProgressCirclesProps } from './ProgressStepsMod'
+
+export const Circle = styled(CircleUni)`
+  color: ${({ theme, confirmed, disabled }) => (disabled ? theme.text1 : confirmed ? theme.white : theme.text1)};
+`
+
+export default function ProgressCircles(props: Omit<ProgressCirclesProps, 'CircleComponent'>) {
+  return <ProgressCirclesUni {...props} CircleComponent={Circle} />
+}

--- a/src/custom/pages/Swap/SwapMod.tsx
+++ b/src/custom/pages/Swap/SwapMod.tsx
@@ -556,7 +556,10 @@ export default function Swap({
                 >
                   {approval === ApprovalState.PENDING ? (
                     <AutoRow gap="6px" justify="center">
-                      Approving <Loader stroke="white" />
+                      Approving{' '}
+                      <Loader
+                      // stroke="white"
+                      />
                     </AutoRow>
                   ) : approvalSubmitted && approval === ApprovalState.APPROVED ? (
                     'Approved'
@@ -586,7 +589,10 @@ export default function Swap({
                   }
                   // error={isValid && priceImpactSeverity > 2}
                 >
-                  <Text fontSize={16} fontWeight={500}>
+                  <Text
+                    // fontSize={16}
+                    fontWeight={500}
+                  >
                     {/* {priceImpactSeverity > 3 && !isExpertMode
                       ? `Price Impact High`
                       : `Swap${priceImpactSeverity > 2 ? ' Anyway' : ''}`} */}
@@ -614,7 +620,10 @@ export default function Swap({
                 disabled={!isValid /*|| (priceImpactSeverity > 3 && !isExpertMode) */ || !!swapCallbackError}
                 // error={isValid && priceImpactSeverity > 2 && !swapCallbackError}
               >
-                <Text fontSize={20} fontWeight={500}>
+                <Text
+                  // fontSize={20}
+                  fontWeight={500}
+                >
                   {swapInputError ? swapInputError : 'Swap'
                   // : priceImpactSeverity > 3 && !isExpertMode
                   // ? `Price Impact Too High`

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -23,7 +23,6 @@ import QuestionHelper from 'components/QuestionHelper'
 import { ButtonError, ButtonPrimary } from 'components/Button'
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
 import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
-import { Circle } from 'components/ProgressSteps'
 
 interface FeeGreaterMessageProp {
   fee: CurrencyAmount
@@ -116,10 +115,6 @@ const SwapModWrapper = styled(SwapMod)`
 
     .expertMode ${AutoRow} {
       padding: 0 1rem;
-    }
-
-    ${Circle} {
-      color: ${({ theme, confirmed, disabled }) => (disabled ? theme.text1 : confirmed ? theme.white : theme.text1)};
     }
 
     ${AutoRow} svg > path {

--- a/src/custom/pages/Swap/index.tsx
+++ b/src/custom/pages/Swap/index.tsx
@@ -23,6 +23,8 @@ import QuestionHelper from 'components/QuestionHelper'
 import { ButtonError, ButtonPrimary } from 'components/Button'
 import EthWethWrap, { Props as EthWethWrapProps } from 'components/swap/EthWethWrap'
 import { useReplaceSwapState, useSwapState } from 'state/swap/hooks'
+import { Circle } from 'components/ProgressSteps'
+
 interface FeeGreaterMessageProp {
   fee: CurrencyAmount
 }
@@ -114,6 +116,14 @@ const SwapModWrapper = styled(SwapMod)`
 
     .expertMode ${AutoRow} {
       padding: 0 1rem;
+    }
+
+    ${Circle} {
+      color: ${({ theme, confirmed, disabled }) => (disabled ? theme.text1 : confirmed ? theme.white : theme.text1)};
+    }
+
+    ${AutoRow} svg > path {
+      stroke: ${({ theme }) => theme.text1};
     }
   }
 `


### PR DESCRIPTION
Supersedes https://github.com/gnosis/gp-swap-ui/pull/660

- Pointing to `develop` instead of `master`
- Modding `ProgressSteps` component

Modding is needed because (AFAIK) access to a [styled component's inner props inside another component](https://github.com/gnosis/gp-swap-ui/pull/660/files#diff-e1d5a26ef1f0d5d518088887aa8e77620e509679ab3a6138b94360dc722102ccR92) will not work:
```css
    ${Circle} {
      color: ${({ theme, confirmed, disabled }) => (disabled ? theme.text1 : confirmed ? theme.white : theme.text1)};
    }
```

So I'm injecting the wrapped `Circle` component into the parent.