### PR TITLE
Dancing numbers fix 2

### DIFF
--- a/src/custom/hooks/useDebounceWithForceUpdate.ts
+++ b/src/custom/hooks/useDebounceWithForceUpdate.ts
@@ -14,13 +14,13 @@ export default function useDebounceWithForceUpdate<T>(latestValue: T, delay: num
       setNeedToUpdate(false)
       setValue(latestValue)
     }
-  }, [needToUpdate, latestValue, value])
+  }, [needToUpdate, latestValue])
 
   // Debounce update
   const debouncedValue = useDebounce(latestValue, delay)
   useEffect(() => {
     setValue(debouncedValue)
-  }, [debouncedValue, value])
+  }, [debouncedValue])
 
   return value
 }

--- a/src/custom/hooks/useDebounceWithForceUpdate.ts
+++ b/src/custom/hooks/useDebounceWithForceUpdate.ts
@@ -2,11 +2,7 @@ import useDebounce from '@src/hooks/useDebounce'
 import { useEffect, useState } from 'react'
 
 // modified from https://usehooks.com/useDebounce/
-export default function useDebounceWithForceUpdate<T>(
-  latestValue: T,
-  delay: number,
-  forceUpdateRef?: string | number | boolean
-): T {
+export default function useDebounceWithForceUpdate<T>(latestValue: T, delay: number, forceUpdateRef?: any): T {
   // const value = useRef(latestValue)
   const [value, setValue] = useState(latestValue)
   const [needToUpdate, setNeedToUpdate] = useState(false)

--- a/src/custom/hooks/useDebounceWithForceUpdate.ts
+++ b/src/custom/hooks/useDebounceWithForceUpdate.ts
@@ -1,38 +1,30 @@
+import useDebounce from '@src/hooks/useDebounce'
 import { useEffect, useState } from 'react'
 
 // modified from https://usehooks.com/useDebounce/
 export default function useDebounceWithForceUpdate<T>(
-  value: T,
+  latestValue: T,
   delay: number,
   forceUpdateRef?: string | number | boolean
 ): T {
-  const [lastForceUpdateRef, setLastForceUpdateRef] = useState(forceUpdateRef)
-  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+  // const value = useRef(latestValue)
+  const [value, setValue] = useState(latestValue)
+  const [needToUpdate, setNeedToUpdate] = useState(false)
 
-  // force update
+  // Force update
+  useEffect(() => setNeedToUpdate(true), [forceUpdateRef])
   useEffect(() => {
-    if (
-      (Boolean(value) && debouncedValue === undefined) ||
-      (Boolean(forceUpdateRef) && forceUpdateRef !== lastForceUpdateRef)
-    ) {
-      setDebouncedValue(value)
-      setLastForceUpdateRef(forceUpdateRef)
+    if (needToUpdate) {
+      setNeedToUpdate(false)
+      setValue(latestValue)
     }
-  }, [debouncedValue, forceUpdateRef, lastForceUpdateRef, value])
+  }, [needToUpdate, latestValue, value])
 
-  // Update debounced value after delay
+  // Debounce update
+  const debouncedValue = useDebounce(latestValue, delay)
   useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value)
-    }, delay)
-
-    // Cancel the timeout if value changes (also on delay change or unmount)
-    // This is how we prevent debounced value from updating if value is changed ...
-    // .. within the delay period. Timeout gets cleared and restarted.
-    return () => {
-      clearTimeout(handler)
-    }
-  }, [value, delay, debouncedValue])
+    setValue(debouncedValue)
+  }, [debouncedValue, value])
 
   return value
 }


### PR DESCRIPTION
Proposal for the hook on #685 

Tries to simplify the implementation and address some issues.

Changes:
- Uses the original `useDebounce` to build the new hook removing the duplication of that logic
- Makes `forceUpdateRef` more genral, accepts any. There was also some issues with some `Boolean(forceUpdateRef)` logic  in the original
- Fixes issue that it was being eagerly triggered all the time
- Uses just one state for the value, and a flag for when we need to do an eager update