### PR TITLE
Improve styling+markup for policy pages.

### DIFF
--- a/src/custom/components/Page/index.tsx
+++ b/src/custom/components/Page/index.tsx
@@ -84,6 +84,11 @@ export const Content = styled.div`
     }
   }
 
+  li > em {
+    background: ${({ theme }) => theme.redShade};
+    color: ${({ theme }) => theme.white};
+  }
+
   a {
     color: ${({ theme }) => theme.text1};
     transition: color 0.2s ease-in-out;

--- a/src/custom/components/Page/index.tsx
+++ b/src/custom/components/Page/index.tsx
@@ -59,6 +59,31 @@ export const Content = styled.div`
     margin: 24px auto;
   }
 
+  > p em {
+    color: ${({ theme }) => theme.white};
+    position: relative;
+    width: 100%;
+    display: flex;
+    z-index: 0;
+    padding: 12px;
+    font-style: normal;
+    font-size: 14px;
+    line-height: 1.8;
+    text-transform: uppercase;
+
+    &::before {
+      content: '';
+      background: ${({ theme }) => theme.redShade};
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      z-index: -1;
+      border-radius: 3px;
+      top: 0;
+      left: 0;
+    }
+  }
+
   a {
     color: ${({ theme }) => theme.text1};
     transition: color 0.2s ease-in-out;
@@ -83,6 +108,14 @@ export const GdocsListStyle = css`
       /* Match 1st level list styles from G Docs */
       margin: 0 0 10px;
       list-style: decimal;
+
+      a {
+        color: ${({ theme }) => theme.text2};
+
+        &:hover {
+          color: ${({ theme }) => theme.primary1};
+        }
+      }
 
       > ul,
       > ol {

--- a/src/custom/pages/App/index.tsx
+++ b/src/custom/pages/App/index.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components'
 import { RedirectPathToSwapOnly, RedirectToSwap } from 'pages/Swap/redirects'
 import { Route, Switch } from 'react-router-dom'
 import Swap from 'pages/Swap'
-// import PrivacyPolicy from 'pages/PrivacyPolicy'
-// import CookiePolicy from 'pages/CookiePolicy'
+import PrivacyPolicy from 'pages/PrivacyPolicy'
+import CookiePolicy from 'pages/CookiePolicy'
 import TermsAndConditions from 'pages/TermsAndConditions'
 import About from 'pages/About'
 import Faq from 'pages/Faq'
@@ -21,8 +21,8 @@ export default function App() {
         <Route exact strict path="/send" component={RedirectPathToSwapOnly} />
         <Route exact strict path="/about" component={About} />
         <Route exact strict path="/faq" component={Faq} />
-        {/* <Route exact strict path="/privacy-policy" component={PrivacyPolicy} />
-        <Route exact strict path="/cookie-policy" component={CookiePolicy} /> */}
+        <Route exact strict path="/privacy-policy" component={PrivacyPolicy} />
+        <Route exact strict path="/cookie-policy" component={CookiePolicy} />
         <Route exact strict path="/terms-and-conditions" component={TermsAndConditions} />
         <Route component={RedirectPathToSwapOnly} />
       </Switch>

--- a/src/custom/pages/Faq/index.tsx
+++ b/src/custom/pages/Faq/index.tsx
@@ -220,7 +220,7 @@ export default function Faq() {
           <p>
             CowSwap leverages batch auctions with uniform clearing prices for all trades in the same batch. Because of
             the uniform clearing price, there is no need for ordering the transactions within a single batch. Because
-            everyone receives the same price across assets it’s not possible for <em>any</em> value to be extracted by
+            everyone receives the same price across assets it’s not possible for <b>any</b> value to be extracted by
             placing transactions in a certain order. This prevents the primary strategy used in MEV.
           </p>
 

--- a/src/custom/pages/PrivacyPolicy/PrivacyPolicy.md
+++ b/src/custom/pages/PrivacyPolicy/PrivacyPolicy.md
@@ -1,7 +1,7 @@
 # Privacy Policy
+
 ### (updated March 2021)
 
- 
 We are delighted that you have chosen to use our App and/or visit our website. We take our data protection responsibilities with the utmost seriousness and we have designed our website so that you may navigate and use it without having to provide Personal Data.
 
 This Policy sets out what Personal Data we collect, how we process it and how long we retain it. This Policy applies to all of our processing activities where we act as a data controller.
@@ -13,8 +13,9 @@ In this Policy, “personal data” means any information relating to you as an 
 In this Policy, “processing” means any operation or set of operations which is performed on personal data (as defined in this Privacy Policy) or on sets of personal data, whether or not by automated means, such as collection, recording, organisation, structuring, storage, adaptation or alteration, retrieval, consultation, use, disclosure by transmission, dissemination or otherwise making available, alignment or combination, restriction, erasure or destruction.
 
 ## Navigating this Policy
+
 If you are viewing this policy online, you can click on the below links to jump to the relevant section:
-    
+
 1. [Your information and the Blockchain](#1--your-information-and-the-blockchain)
 2. [How We Use Personal Data](#2--how-we-use-personal-data)
 3. [Use of Third Party Applications](#3--use-of-third-party-applications)
@@ -27,81 +28,74 @@ If you are viewing this policy online, you can click on the below links to jump 
 10. [Changes to this Privacy Policy](#10--changes-to-this-privacy-policy)
 11. [Our details](#11--our-details)
 
-### 1. Your information and the Blockchain ###
+### 1. Your information and the Blockchain
+
 Blockchain technology, also known as distributed ledger technology (or simply ‘DLT’), is at the core of our business. Blockchains are decentralized and made up of digitally recorded data in a chain of packages called ‘blocks’. The manner in which these blocks are linked is chronological, meaning that the data is very difficult to alter once recorded. Since the ledger may be distributed all over the world (across several ‘nodes’ which usually replicate the ledger) this means there is no single person making decisions or otherwise administering the system (such as an operator of a cloud computing system), and that there is no centralized place where it is located either.
 Accordingly, by design, a blockchains records cannot be changed or deleted and are said to be ‘immutable’. This may affect your ability to exercise your rights such as your right to erasure (‘right to be forgotten’), or your rights to object or restrict processing of your personal data. Data on the blockchain cannot be erased and cannot be changed. Although smart contracts may be used to revoke certain access rights, and some content may be made invisible to others, it is not deleted.
 In certain circumstances, in order to comply with our contractual obligations to you (such as delivery of tokens) it will be necessary to write certain personal data, such as your Ethereum or other cryptocurrency wallet address, onto the blockchain; this is done through a smart contract and requires you to execute such transactions using your wallet’s private key.
 
-<span style="color: red;">IF YOU WANT TO ENSURE YOUR PRIVACY RIGHTS ARE NOT AFFECTED IN ANY WAY, YOU SHOULD NOT TRANSACT ON BLOCKCHAINS AS CERTAIN RIGHTS MAY NOT BE FULLY AVAILABLE OR EXERCISABLE BY YOU OR US DUE TO THE TECHNOLOGICAL INFRASTRUCTURE OF THE BLOCKCHAIN. IN PARTICULAR THE BLOCKCHAIN IS AVAILABLE TO THE PUBLIC AND ANY PERSONAL DATA SHARED ON THE BLOCKCHAIN WILL BECOME PUBLICLY AVAILABLE</span>
+<em>IF YOU WANT TO ENSURE YOUR PRIVACY RIGHTS ARE NOT AFFECTED IN ANY WAY, YOU SHOULD NOT TRANSACT ON BLOCKCHAINS AS CERTAIN RIGHTS MAY NOT BE FULLY AVAILABLE OR EXERCISABLE BY YOU OR US DUE TO THE TECHNOLOGICAL INFRASTRUCTURE OF THE BLOCKCHAIN. IN PARTICULAR THE BLOCKCHAIN IS AVAILABLE TO THE PUBLIC AND ANY PERSONAL DATA SHARED ON THE BLOCKCHAIN WILL BECOME PUBLICLY AVAILABLE</em>
 
 ### 2. How We Use Personal Data
-	
+
 #### When visiting our website
 
-* We may collect and process Personal Data about your use of our website. This data may include:
-	1. the browser types and versions used;
-	2. the operating system used by the accessing system;
-	3. the website from which an accessing system reaches our website (so-called referrers);
-	4. behaviour: subpage, duration, and revisit
-	5. the date and time of access to our website,
-	6. the Internet protocol address (“IP address”);
-	7. the Internet service provider of the accessing system; and
-	8. any other similar data and information that may be used in the event of attacks on our information technology systems.
+- We may collect and process Personal Data about your use of our website. This data may include: 1. the browser types and versions used; 2. the operating system used by the accessing system; 3. the website from which an accessing system reaches our website (so-called referrers); 4. behaviour: subpage, duration, and revisit 5. the date and time of access to our website, 6. the Internet protocol address (“IP address”); 7. the Internet service provider of the accessing system; and 8. any other similar data and information that may be used in the event of attacks on our information technology systems.
 
-* This data may be processed in order to deliver the content of our website correctly, to optimize the content of our website to ensure the long-term viability of our information technology systems and website technology, and to provide law enforcement authorities with the information necessary for criminal prosecution in case of a cyber-attack.
-* The legal basis for this processing is our legitimate business interests, namely monitoring and improving our website and the proper protection of our business against risks and your consent when agreeing to accept cookies
+- This data may be processed in order to deliver the content of our website correctly, to optimize the content of our website to ensure the long-term viability of our information technology systems and website technology, and to provide law enforcement authorities with the information necessary for criminal prosecution in case of a cyber-attack.
+- The legal basis for this processing is our legitimate business interests, namely monitoring and improving our website and the proper protection of our business against risks and your consent when agreeing to accept cookies
 
-	#### When interacting with GP Swap
-	
-* When interacting with GP Swap, Personal Data may be collected and processed. The data  will be stored on the Ethereum blockchain, where the  following data will be stored:
-	1. your wallet address; and
-	2. a record of your interactions.
-* <span style="color: red;">Given the technological design of the blockchain, as explained in section 2, this data will become public and it will not likely be possible to delete or change the data at any given time.</span>
-* This data may be processed in order to deliver the functionality of the product. 
-* The legal basis for this processing is your consent, provided by the active wallet connection through MetaMask or WalletConnect during the login process, but also our legitimate business interests, namely monitoring and improving our service.
+#### When interacting with GP Swap
 
-	#### Other uses of your Personal Data
+- When interacting with GP Swap, Personal Data may be collected and processed. The data will be stored on the Ethereum blockchain, where the following data will be stored: 1. your wallet address; and 2. a record of your interactions.
+- <em>Given the technological design of the blockchain, as explained in section 2, this data will become public and it will not likely be possible to delete or change the data at any given time.</em>
+- This data may be processed in order to deliver the functionality of the product.
+- The legal basis for this processing is your consent, provided by the active wallet connection through MetaMask or WalletConnect during the login process, but also our legitimate business interests, namely monitoring and improving our service.
 
-* We may process any of your Personal Data where it is necessary to establish, exercise, or defend legal claims. The legal basis for this processing is our legitimate interests, namely the protection and assertion of our legal rights, your legal rights and the legal rights of others.
-* Further, we may process your Personal data where such processing is necessary in order for us to comply with a legal obligation to which we are subject. The legal basis for this processing is our legitimate interests, namely the protection and assertion of our legal rights.
+#### Other uses of your Personal Data
+
+- We may process any of your Personal Data where it is necessary to establish, exercise, or defend legal claims. The legal basis for this processing is our legitimate interests, namely the protection and assertion of our legal rights, your legal rights and the legal rights of others.
+- Further, we may process your Personal data where such processing is necessary in order for us to comply with a legal obligation to which we are subject. The legal basis for this processing is our legitimate interests, namely the protection and assertion of our legal rights.
 
 ### 3. Use of Third Party Applications
 
-* #### Ethereum Blockchain
+- #### Ethereum Blockchain
 
-	1. When using the GP Swap with your wallet address, the transactions made with the account will be stored on the Ethereum blockchain. Please see section 2 of this Policy.
-	2. <span style="color: red;">The information will be displayed permanently and publicly; this is part of the nature of the blockchain. If you are new to this field, we highly recommend informing yourself about blockchain technology before using our services.</span>
+1. When using the GP Swap with your wallet address, the transactions made with the account will be stored on the Ethereum blockchain. Please see section 2 of this Policy.
+2. <em>The information will be displayed permanently and publicly; this is part of the nature of the blockchain. If you are new to this field, we highly recommend informing yourself about blockchain technology before using our services.</em>
 
-* #### The Graph
+- #### The Graph
 
-	1. We use The Graph to index data uploaded by registered users from underlying blockchains and storage networks, making the data available via their Services.
-	2. We use the Graph to index the following data 
-		1. Your wallet address
-		2. a record of your interactions
-		3. For further information and the applicable data protection provisions of the Graph please visit [https://thegraph.com/privacy/](https://thegraph.com/privacy/)
+1. We use The Graph to index data uploaded by registered users from underlying blockchains and storage networks, making the data available via their Services.
+2. We use the Graph to index the following data
+   1. Your wallet address
+   2. a record of your interactions
+   3. For further information and the applicable data protection provisions of the Graph please visit [https://thegraph.com/privacy/](https://thegraph.com/privacy/)
 
-* #### MetaMask
+- #### MetaMask
 
-	In order to interact with GP Swap, you will have to connect your wallet through the web3 wallet provider MetaMask. When connecting with MetaMask, they may collect Personal Data. This may include:
-	* Network information regarding transactions; 
-	* first wallet address created through the MetaMask plugin;
-	* highest browser permissions could lead to procurements of more personal information
-	* interaction with the site is also documented via a MetaMask Google Analytics account, and that information is processed by Google.
-	* For further information and the applicable data protection provisions of MetaMask please visit [https://metamask.io/privacy.html](https://metamask.io/privacy.html).
-	
+In order to interact with GP Swap, you will have to connect your wallet through the web3 wallet provider MetaMask. When connecting with MetaMask, they may collect Personal Data. This may include:
+
+- Network information regarding transactions;
+- first wallet address created through the MetaMask plugin;
+- highest browser permissions could lead to procurements of more personal information
+- interaction with the site is also documented via a MetaMask Google Analytics account, and that information is processed by Google.
+- For further information and the applicable data protection provisions of MetaMask please visit [https://metamask.io/privacy.html](https://metamask.io/privacy.html).
+
 * #### Google Analytics
 
-	In order to measure the traffic of the GP Swap, we use Google Analytics. Through this tool we will be collecting the following data:
-	1. IP address
-	2. Session Times
-	3. Referrer
-	4. Page Views
-	5. User Platform
-	
-	For further information and the applicable data protection provisions of Google Analytics, please visit [https://policies.google.com/privacy?hl=en_GB](https://policies.google.com/privacy?hl=en_GB)
+In order to measure the traffic of the GP Swap, we use Google Analytics. Through this tool we will be collecting the following data:
 
+1. IP address
+2. Session Times
+3. Referrer
+4. Page Views
+5. User Platform
+
+For further information and the applicable data protection provisions of Google Analytics, please visit [https://policies.google.com/privacy?hl=en_GB](https://policies.google.com/privacy?hl=en_GB)
 
 ### 4. Sharing Your Personal Data
+
 We may pass your information to our Business Partners, administration centres, third party service providers, agents, subcontractors and other associated organisations for the purposes of completing tasks and providing our services to you.
 
 In addition, when we use any other third-party service providers, we will disclose only the personal information that is necessary to deliver the service required and we will ensure that they keep your information secure and not to use it for their own direct marketing purposes.
@@ -109,21 +103,25 @@ In addition, when we use any other third-party service providers, we will disclo
 In addition, we may transfer your personal information to a third party as part of a sale of some, or all, of our business and assets or as part of any business restructuring or reorganisation, or if we are under a duty to disclose or share your personal data in order to comply with any legal obligation. However, we will take steps to ensure that your privacy rights continue to be protected.
 
 ### 5. Transferring Your data outside of the EU
-Google, as a US based company, may share your personal data within the Google Group or with external third parties. This may involve transferring your data outside the EEA. Whenever they transfer your personal data outside the EEA, they ensure a similar degree of protection is afforded to it. 
+
+Google, as a US based company, may share your personal data within the Google Group or with external third parties. This may involve transferring your data outside the EEA. Whenever they transfer your personal data outside the EEA, they ensure a similar degree of protection is afforded to it.
 
 [https://policies.google.com/privacy?hl=en_GB#enforcement](https://policies.google.com/privacy?hl=en_GB#enforcement)
 
-<span style="color: red;">When interacting with the blockchain, as explained above in this Policy, the blockchain is a global decentralized public network and accordingly any personal data written onto the blockchain may be transferred and stored across the globe.</span>
+<em>When interacting with the blockchain, as explained above in this Policy, the blockchain is a global decentralized public network and accordingly any personal data written onto the blockchain may be transferred and stored across the globe.</em>
 
 ### 6. Existence of Automated Decision-making
+
 We do not use automatic decision-making or profiling when processing Personal Data.
 
 ### 7. Data Security
+
 We have put in place appropriate security measures to prevent your personal data from being accidentally lost, used or accessed in an unauthorised way, altered or disclosed. In addition, we limit access to your personal data to those employees, agents, contractors and other third parties who have a business need to know. They will only process your personal data on our instructions and they are subject to a duty of confidentiality.
 
 We have put in place procedures to deal with any suspected personal data breach and will notify you and any applicable regulator of a breach where we are legally required to do so.
 
 ### 8. Your Rights as a Data Subject
+
 You have certain rights under applicable legislation, and in particular under Regulation EU 2016/679 (General Data Protection Regulation or ‘GDPR’). We explain these below. You can find out more about the GDPR and your rights by accessing the [European Commission’s website](https://ec.europa.eu/info/law/law-topic/data-protection_en).
 
 #### Right Information and access
@@ -132,50 +130,35 @@ You have a right to be informed about the processing of your personal data (and 
 
 #### Right to rectification
 
-* You have the right to have any inaccurate personal information about you rectified and to have any incomplete personal information about you completed. You may also request that we restrict the processing of that information.
-* The accuracy of your information is important to us. If you do not want us to use your Personal Information in the manner set out in this Privacy Policy, or need to advise us of any changes to your personal information, or would like any more information about the way in which we collect and use your Personal Information, please contact us at the above details.
+- You have the right to have any inaccurate personal information about you rectified and to have any incomplete personal information about you completed. You may also request that we restrict the processing of that information.
+- The accuracy of your information is important to us. If you do not want us to use your Personal Information in the manner set out in this Privacy Policy, or need to advise us of any changes to your personal information, or would like any more information about the way in which we collect and use your Personal Information, please contact us at the above details.
 
-	#### Right to erasure (right to be ‘forgotten’)
+#### Right to erasure (right to be ‘forgotten’)
 
-* You have the general right to request the erasure of your personal information in the following circumstances:
-	1. the personal information is no longer necessary for the purpose for which it was collected;
-	2. you withdraw your consent to consent based processing and no other legal justification for processing applies;
-	3. you object to processing for direct marketing purposes;
-	4. we unlawfully processed your personal information; and
-	5. erasure is required to comply with a legal obligation that applies to us.
-* <span style="color: red;">However, when interacting with the blockchain we may not be able to ensure that your personal data is deleted. This is because the blockchain is a public decentralized network and blockchain technology does not generally allow for data to be deleted and your right to erasure may not be able to be fully enforced. In these circumstances we will only be able to ensure that all personal data that is held by us is permanently deleted.</span>
-* We will proceed to comply with an erasure request without delay unless continued retention is necessary for:
-	1. Exercising the right of freedom of expression and information;
-	2. Complying with a legal obligation under EU or other applicable law;
-	3. The performance of a task carried out in the public interest;
-	4. Archiving purposes in the public interest, scientific or historical research purposes, or statistical purposes, under certain circumstances; and/or
-	5. The establishment, exercise, or defence of legal claims.
+- You have the general right to request the erasure of your personal information in the following circumstances: 1. the personal information is no longer necessary for the purpose for which it was collected; 2. you withdraw your consent to consent based processing and no other legal justification for processing applies; 3. you object to processing for direct marketing purposes; 4. we unlawfully processed your personal information; and 5. erasure is required to comply with a legal obligation that applies to us.
+- <em>However, when interacting with the blockchain we may not be able to ensure that your personal data is deleted. This is because the blockchain is a public decentralized network and blockchain technology does not generally allow for data to be deleted and your right to erasure may not be able to be fully enforced. In these circumstances we will only be able to ensure that all personal data that is held by us is permanently deleted.</em>
+- We will proceed to comply with an erasure request without delay unless continued retention is necessary for: 1. Exercising the right of freedom of expression and information; 2. Complying with a legal obligation under EU or other applicable law; 3. The performance of a task carried out in the public interest; 4. Archiving purposes in the public interest, scientific or historical research purposes, or statistical purposes, under certain circumstances; and/or 5. The establishment, exercise, or defence of legal claims.
 
-	#### Right to restrict processing and right to object to processing
+#### Right to restrict processing and right to object to processing
 
-* You have a right to restrict processing of your personal information, such as where:
-	1. you contest the accuracy of the personal information;
-	2. where processing is unlawful you may request, instead of requesting erasure, that we restrict the use of the unlawfully processed personal information;
-	3. we no longer need to process your personal information but need to retain your information for the establishment, exercise, or defence of legal claims. 
-* You also have the right to object to processing of your personal information under certain circumstances, such as where the processing is based on your consent and you withdraw that consent. This may impact the services we can provide and we will explain this to you if you decide to exercise this right.
-* <span style="color: red;">However, when interacting with the blockchain, as it is a public decentralized network, we will likely not be able to prevent external parties from processing any personal data which has been written onto the blockchain. In these circumstances we will use our reasonable endeavours to ensure that all processing of personal data held by us is restricted, notwithstanding this, your right to restrict to processing may not be able to be fully enforced.</span>
+- You have a right to restrict processing of your personal information, such as where: 1. you contest the accuracy of the personal information; 2. where processing is unlawful you may request, instead of requesting erasure, that we restrict the use of the unlawfully processed personal information; 3. we no longer need to process your personal information but need to retain your information for the establishment, exercise, or defence of legal claims.
+- You also have the right to object to processing of your personal information under certain circumstances, such as where the processing is based on your consent and you withdraw that consent. This may impact the services we can provide and we will explain this to you if you decide to exercise this right.
+- <em>However, when interacting with the blockchain, as it is a public decentralized network, we will likely not be able to prevent external parties from processing any personal data which has been written onto the blockchain. In these circumstances we will use our reasonable endeavours to ensure that all processing of personal data held by us is restricted, notwithstanding this, your right to restrict to processing may not be able to be fully enforced.</em>
 
 #### Right to data portability
 
 Where the legal basis for our processing is your consent or the processing is necessary for the performance of a contract to which you are party or in order to take steps at your request prior to entering into a contract, you have a right to receive the personal information you provided to us in a structured, commonly used and machine-readable format, or ask us to send it to another person.
 
 #### Right to freedom from automated decision-making
-	
+
 As explained above, we do not use automated decision-making, but where any automated decision-making takes place, you have the right in this case to express your point of view and to contest the decision, as well as request that decisions based on automated processing concerning you or significantly affecting you and based on your personal data are made by natural persons, not only by computers.
 
 #### Right to object to direct marketing (‘opting out’)
 
-* You have a choice about whether or not you wish to receive information from us.
-* We will not contact you for marketing purposes unless:
-	1. you have a business relationship with us, and we rely on our legitimate interests as the lawful basis for processing (as described above)
-	2. you have otherwise given your prior consent (such as when you download one of our guides)
-* You can change your marketing preferences at any time by contacting us on the above details. On each and every marketing communication, we will always provide the option for you to exercise your right to object to the processing of your personal data for marketing purposes (known as ‘opting-out’) by clicking on the ‘unsubscribe’ button on our marketing emails or choosing a similar opt-out option on any forms we use to collect your data. You may also opt-out at any time by contacting us on the below details.
-* Please note that any administrative or service-related communications (to offer our services, or notify you of an update to this Privacy Policy or applicable terms of business, etc.) will solely be directed at our clients or business partners, and such communications generally do not offer an option to unsubscribe as they are necessary to provide the services requested. Therefore, please be aware that your ability to opt-out from receiving marketing and promotional materials does not change our right to contact you regarding your use of our website or as part of a contractual relationship we may have with you.
+- You have a choice about whether or not you wish to receive information from us.
+- We will not contact you for marketing purposes unless: 1. you have a business relationship with us, and we rely on our legitimate interests as the lawful basis for processing (as described above) 2. you have otherwise given your prior consent (such as when you download one of our guides)
+- You can change your marketing preferences at any time by contacting us on the above details. On each and every marketing communication, we will always provide the option for you to exercise your right to object to the processing of your personal data for marketing purposes (known as ‘opting-out’) by clicking on the ‘unsubscribe’ button on our marketing emails or choosing a similar opt-out option on any forms we use to collect your data. You may also opt-out at any time by contacting us on the below details.
+- Please note that any administrative or service-related communications (to offer our services, or notify you of an update to this Privacy Policy or applicable terms of business, etc.) will solely be directed at our clients or business partners, and such communications generally do not offer an option to unsubscribe as they are necessary to provide the services requested. Therefore, please be aware that your ability to opt-out from receiving marketing and promotional materials does not change our right to contact you regarding your use of our website or as part of a contractual relationship we may have with you.
 
 #### Right to request access
 
@@ -186,40 +169,42 @@ You also have a right to access information we hold about you. We are happy to p
 Where the legal basis for processing your personal information is your consent, you have the right to withdraw that consent at any time by contacting us on the above details.
 
 #### Raising a complaint about how we have handled your personal data
-	
+
 If you wish to raise a complaint on how we have handled your personal data, you can contact us as set out above and we will then investigate the matter.
 
 #### Right to lodge a complaint with a relevant supervisory authority
 
-* If we have not responded to you within a reasonable time or if you feel that your complaint has not been resolved to your satisfaction, you are entitled to make a complaint to the Data Protection Commissioner under the Data Protection Act, which is presently the Gibraltar Regulatory Authority (GRA). You may contact the GRA on the below details:
- 
-		Gibraltar Data Protection Commissioner
-		Gibraltar Regulatory Authority
-		2nd Floor, Eurotowers 4
-		1 Europort Road
-		Gibraltar
-		Email: info@gra.gi
-		Phone: (+350) 200 74636
-		Fax: (+350) 200 72166
+- If we have not responded to you within a reasonable time or if you feel that your complaint has not been resolved to your satisfaction, you are entitled to make a complaint to the Data Protection Commissioner under the Data Protection Act, which is presently the Gibraltar Regulatory Authority (GRA). You may contact the GRA on the below details:
 
-* You also have the right to lodge a complaint with the supervisory authority in the country of your habitual residence, place of work, or the place where you allege an infringement of one or more of our rights has taken place, if that is based in the EEA.
+      	Gibraltar Data Protection Commissioner
+      	Gibraltar Regulatory Authority
+      	2nd Floor, Eurotowers 4
+      	1 Europort Road
+      	Gibraltar
+      	Email: info@gra.gi
+      	Phone: (+350) 200 74636
+      	Fax: (+350) 200 72166
+
+- You also have the right to lodge a complaint with the supervisory authority in the country of your habitual residence, place of work, or the place where you allege an infringement of one or more of our rights has taken place, if that is based in the EEA.
 
 ### 9. Storing Personal Data
+
 We retain your information only for as long as is necessary for the purposes for which we process the information as set out in this policy.
 However, we may retain your Personal Data for a longer period of time where such retention is necessary for compliance with a legal obligation to which we are subject, or in order to protect your vital interests or the vital interests of another natural person.
 
 ### 10. Changes to this Privacy Policy
+
 We may make changes to this Policy from time to time. Where we do so, we will notify those who have a business relationship with us or who are subscribed to our emailing lists directly of the changes, and change the ‘Last updated’ date above. We encourage you to review the Policy whenever you access or use our website to stay informed about our information practices and the choices available to you. If you do not agree to the revised Policy, you should discontinue your use of this website.
 
 ### 11. Our details
+
 This website is owned and operated by Gnosis Limited.
 We are registered in Gibraltar under registration number 115571, and our registered office is located at:
-        	
 You can contact us via:
- 
-        	Gnosis Limited
-        	World Trade Center
-        	6 Bayside Rd,
-        	GX111AA Gibraltar
-        	
+
+    Gnosis Limited
+    World Trade Center
+    6 Bayside Rd,
+    GX111AA Gibraltar
+
 If you have any queries concerning your rights under this Privacy Policy, please contact us at dataprotection@gnosis.pm .

--- a/src/custom/theme/baseTheme.tsx
+++ b/src/custom/theme/baseTheme.tsx
@@ -55,7 +55,7 @@ export function colors(darkMode: boolean): Colors {
     blueShade2: '#011e34',
     border: darkMode ? '#3a3b5a' : 'rgb(58 59 90 / 10%)',
     disabled: darkMode ? '#31323e' : 'rgb(237, 238, 242)',
-    redShade: darkMode ? '#AE2C00' : '#AE2C00',
+    redShade: darkMode ? '#842100' : '#AE2C00',
     textLink: darkMode ? '#ffffff' : '#AE2C00'
   }
 }


### PR DESCRIPTION
- Improves the RED emphasized text for both light/dark mode. Making use of the native `<em>` element for this specific use case.
- Improve markup on the Markdown page.

Partly adresses #681

<img width="350" alt="Screen Shot 2021-05-28 at 13 41 14" src="https://user-images.githubusercontent.com/31534717/119979304-0ba3b600-bfbb-11eb-832f-67b7e058f839.png">
<img width="350" alt="Screen Shot 2021-05-28 at 13 41 07" src="https://user-images.githubusercontent.com/31534717/119979313-0f373d00-bfbb-11eb-8e58-092b75b20796.png">


To consider for future PR's:
- Add plugin support for our Markdown parser, to allow us passing attributes to links. This so we can define `target=_blank` without having to use default HTML => `[Link](https://example.org/ "title" target="_blank")`
