### PR TITLE
Disable WallEth wallet

### DIFF
--- a/src/custom/constants/index.ts
+++ b/src/custom/constants/index.ts
@@ -28,7 +28,13 @@ export const SUPPORTED_WALLETS = Object.keys(SUPPORTED_WALLETS_UNISWAP).reduce((
 }, {} as { [key: string]: WalletInfo })
 
 // Smart contract wallets are filtered out by default, no need to add them to this list
-export const UNSUPPORTED_WC_WALLETS = new Set(['DeFi Wallet', 'TokenPocket', '1inch Wallet', 'Pillar Wallet'])
+export const UNSUPPORTED_WC_WALLETS = new Set([
+  'DeFi Wallet',
+  'TokenPocket',
+  '1inch Wallet',
+  'Pillar Wallet',
+  'WallETH'
+])
 
 // TODO: When contracts are deployed, we can load this from the NPM package
 export const GP_SETTLEMENT_CONTRACT_ADDRESS: Partial<Record<ChainId, string>> = {


### PR DESCRIPTION
# Summary

Disabling Walleth for now.

It's one of the best wallets at displaying the data being signed:
![Screenshot_20210528-100344](https://user-images.githubusercontent.com/43217/120020912-3a139800-bf9f-11eb-9b23-63036feb9fa6.png)

But, the typed data signing creates and invalid signature:
![screenshot_2021-05-28_09-48-52](https://user-images.githubusercontent.com/43217/120020938-44ce2d00-bf9f-11eb-8fa3-a5837497eb0b.png)

Sometimes, it fails with different error messages. I'm not able to tell thus far what causes it to fail or not.

Every time it fails, though, a new signing prompt is displayed to the user, so it might be needed to repeat the process at least twice until we manage to get a signing method that works.

I managed to successfully sign once using `eth_sign`, but this data display is, well, interesting:
![Screenshot_20210528-100206](https://user-images.githubusercontent.com/43217/120021122-83fc7e00-bf9f-11eb-9ac0-a58a663cdef5.png)

