### PR TITLE
[0.13] Price Race Conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,9 +140,10 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@web3-react/walletconnect-connector": "^6.2.0",
     "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.18",
     "@uniswap/default-token-list": "^2.0.0",
+    "@web3-react/walletconnect-connector": "^6.2.0",
+    "awesome-only-resolves-last-promise": "^1.0.3",
     "react-appzi": "^1.0.4",
     "react-router-hash-link": "^2.4.0"
   }

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { useCallback } from 'react'
+import { onlyResolvesLast } from 'awesome-only-resolves-last-promise'
 import { useClearQuote, useUpdateQuote } from 'state/price/hooks'
 import { getCanonicalMarket, registerOnWindow } from 'utils/misc'
 import { FeeQuoteParams, getFeeQuote, getPriceQuote } from 'utils/operator'
@@ -25,7 +26,7 @@ type WithFeeExceedsPrice = {
 
 type PriceInformationWithFee = PriceInformation & WithFeeExceedsPrice
 
-async function getQuote({
+async function _getQuote({
   quoteParams,
   fetchFee,
   previousFee
@@ -70,6 +71,9 @@ async function getQuote({
 
   return Promise.all([pricePromise, feePromise])
 }
+
+// wrap _getQuote and only resolve once on several calls
+const getQuote = onlyResolvesLast(_getQuote)
 
 function _isValidOperatorError(error: any): error is OperatorError {
   return error instanceof OperatorError

--- a/yarn.lock
+++ b/yarn.lock
@@ -3738,6 +3738,18 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+awesome-imperative-promise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/awesome-imperative-promise/-/awesome-imperative-promise-1.0.1.tgz#be143d89615b9110ac310345457f37e9791ddac9"
+  integrity sha512-EmPr3FqbQGqlNh+WxMNcF9pO9uDQJnOC4/3rLBQNH9m4E9qI+8lbfHCmHpVAsmGqPJPKhCjJLHUQzQW/RBHRdQ==
+
+awesome-only-resolves-last-promise@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/awesome-only-resolves-last-promise/-/awesome-only-resolves-last-promise-1.0.3.tgz#f2dac3ff7df238e48b818b423483031750f13ef0"
+  integrity sha512-7q4WPsYiD8Omvi/yHL314DkvsD/lM//Z2/KcU1vWk0xJotiV0GMJTgHTpWl3n90HJqpXKg7qX+VVNs5YbQyPRQ==
+  dependencies:
+    awesome-imperative-promise "^1.0.1"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
Partly closes #709 (race condition from consecutive price fetches)

Uses the anxo recommended https://github.com/slorber/awesome-only-resolves-last-promise lib to wrap `getQuote` and only return the last call in a a subsequent series of calls.

Tested in console by logging fn and calling in succession:
![image](https://user-images.githubusercontent.com/21335563/120301646-fc777d80-c2c4-11eb-94fe-87c09d8b08d3.png)