### PR TITLE
Add cancelable promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.18",
     "@uniswap/default-token-list": "^2.0.0",
     "@web3-react/walletconnect-connector": "^6.2.0",
-    "awesome-only-resolves-last-promise": "^1.0.3",
     "react-appzi": "^1.0.4",
     "react-router-hash-link": "^2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -140,9 +140,10 @@
   },
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "@web3-react/walletconnect-connector": "^6.2.0",
     "@gnosis.pm/gp-v2-contracts": "^0.0.1-alpha.18",
     "@uniswap/default-token-list": "^2.0.0",
+    "@web3-react/walletconnect-connector": "^6.2.0",
+    "awesome-only-resolves-last-promise": "^1.0.3",
     "react-appzi": "^1.0.4",
     "react-router-hash-link": "^2.4.0"
   }

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { useCallback } from 'react'
-// import { onlyResolvesLast } from 'awesome-only-resolves-last-promise'
 import { useClearQuote, useUpdateQuote } from 'state/price/hooks'
 import { getCanonicalMarket, registerOnWindow } from 'utils/misc'
 import { FeeQuoteParams, getFeeQuote, getPriceQuote } from 'utils/operator'

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { useCallback } from 'react'
+import { onlyResolvesLast } from 'awesome-only-resolves-last-promise'
 import { useClearQuote, useUpdateQuote } from 'state/price/hooks'
 import { getCanonicalMarket, registerOnWindow } from 'utils/misc'
 import { FeeQuoteParams, getFeeQuote, getPriceQuote } from 'utils/operator'
@@ -25,7 +26,7 @@ type WithFeeExceedsPrice = {
 
 type PriceInformationWithFee = PriceInformation & WithFeeExceedsPrice
 
-async function getQuote({
+async function _getQuote({
   quoteParams,
   fetchFee,
   previousFee
@@ -70,6 +71,9 @@ async function getQuote({
 
   return Promise.all([pricePromise, feePromise])
 }
+
+// wrap _getQuote and only resolve once on several calls
+const getQuote = onlyResolvesLast(_getQuote)
 
 function _isValidOperatorError(error: any): error is OperatorError {
   return error instanceof OperatorError

--- a/src/custom/hooks/useRefetchPriceCallback.ts
+++ b/src/custom/hooks/useRefetchPriceCallback.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { useCallback } from 'react'
-import { onlyResolvesLast } from 'awesome-only-resolves-last-promise'
+// import { onlyResolvesLast } from 'awesome-only-resolves-last-promise'
 import { useClearQuote, useUpdateQuote } from 'state/price/hooks'
 import { getCanonicalMarket, registerOnWindow } from 'utils/misc'
 import { FeeQuoteParams, getFeeQuote, getPriceQuote } from 'utils/operator'
@@ -13,6 +13,7 @@ import { FeeInformation, PriceInformation } from 'state/price/reducer'
 import { AddGpUnsupportedTokenParams } from 'state/lists/actions'
 import { ChainId } from '@uniswap/sdk'
 import OperatorError, { ApiErrorCodes } from 'utils/operator/error'
+import { onlyResolvesLast } from 'utils/async'
 
 export interface RefetchQuoteCallbackParmams {
   quoteParams: FeeQuoteParams
@@ -26,11 +27,9 @@ type WithFeeExceedsPrice = {
 
 type PriceInformationWithFee = PriceInformation & WithFeeExceedsPrice
 
-async function _getQuote({
-  quoteParams,
-  fetchFee,
-  previousFee
-}: RefetchQuoteCallbackParmams): Promise<[PriceInformationWithFee, FeeInformation]> {
+type QuoteResult = [PriceInformationWithFee, FeeInformation]
+
+async function _getQuote({ quoteParams, fetchFee, previousFee }: RefetchQuoteCallbackParmams): Promise<QuoteResult> {
   const { sellToken, buyToken, amount, kind, chainId } = quoteParams
   const { baseToken, quoteToken } = getCanonicalMarket({ sellToken, buyToken, kind })
 
@@ -73,7 +72,7 @@ async function _getQuote({
 }
 
 // wrap _getQuote and only resolve once on several calls
-const getQuote = onlyResolvesLast(_getQuote)
+const getQuote = onlyResolvesLast<QuoteResult>(_getQuote)
 
 function _isValidOperatorError(error: any): error is OperatorError {
   return error instanceof OperatorError
@@ -130,7 +129,12 @@ export function useRefetchQuoteCallback() {
       try {
         // Get the quote
         // price can be null if fee > price
-        const [price, fee] = await getQuote(params)
+        const { cancelled, data } = await getQuote(params)
+        if (cancelled) {
+          console.debug('[useRefetchPriceCallback] Canceled get quote price for', params)
+          return
+        }
+        const [price, fee] = data as QuoteResult
 
         const previouslyUnsupportedToken = isUnsupportedTokenGp(sellToken) || isUnsupportedTokenGp(buyToken)
         // can be a previously unsupported token which is now valid

--- a/src/custom/utils/async.ts
+++ b/src/custom/utils/async.ts
@@ -1,0 +1,90 @@
+// // TODO: If this work our, I will move it to my own library
+// This logic is a modified version of:
+//    https://github.com/slorber/awesome-only-resolves-last-promise
+//    https://github.com/slorber/awesome-imperative-promise
+// Main difference, is that cancel resolves the promise with a cancelled flag to true
+
+export type ResolveCallback<T> = (value: CancelableResult<T>) => void
+export type RejectCallback = (reason?: any) => void
+export type CancelCallback = () => void
+
+export type ImperativePromise<T> = {
+  promise: Promise<CancelableResult<T>>
+  resolve: ResolveCallback<T>
+  reject: RejectCallback
+  cancel: CancelCallback
+}
+
+export type CancelableResult<T> = CancelledResult | SuccessResult<T>
+
+export type CancelledResult = {
+  cancelled: true
+  data: undefined
+}
+
+export type SuccessResult<T> = {
+  cancelled: false
+  data: T
+}
+
+export function createImperativePromise<T>(promiseArg?: Promise<T> | null | undefined): ImperativePromise<T> {
+  let resolve: ResolveCallback<T> | null = null
+  let reject: RejectCallback | null = null
+
+  const wrappedPromise = new Promise<CancelableResult<T>>((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+
+  promiseArg &&
+    promiseArg.then(
+      data => {
+        resolve &&
+          resolve({
+            cancelled: false,
+            data
+          })
+      },
+      error => {
+        reject && reject(error)
+      }
+    )
+
+  return {
+    promise: wrappedPromise,
+    resolve: ({ cancelled, data }) => {
+      if (resolve) {
+        if (cancelled) {
+          resolve({ cancelled, data: undefined })
+        } else {
+          resolve({ cancelled, data: data as T })
+        }
+      }
+    },
+    reject: (reason?: any) => {
+      reject && reject(reason)
+    },
+    cancel: () => {
+      resolve && resolve({ cancelled: true, data: undefined })
+    }
+  }
+}
+
+type ArgumentsType<T> = T extends (...args: infer A) => any ? A : never
+type AsyncFunction<T> = (...args: any[]) => Promise<T>
+type AnyFunctionCancelable<T> = (...args: any[]) => Promise<CancelableResult<T>>
+
+// see https://stackoverflow.com/a/54825370/82609
+export function onlyResolvesLast<R>(asyncFunction: AsyncFunction<R>): AnyFunctionCancelable<R> {
+  let cancelPrevious: CancelCallback | null = null
+
+  const wrappedFunction = (...args: ArgumentsType<AsyncFunction<R>>) => {
+    cancelPrevious && cancelPrevious()
+    const initialPromise = asyncFunction(...args)
+    const { promise, cancel } = createImperativePromise(initialPromise)
+    cancelPrevious = cancel
+    return promise
+  }
+
+  return wrappedFunction as any // TODO fix TS
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3738,18 +3738,6 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
-awesome-imperative-promise@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/awesome-imperative-promise/-/awesome-imperative-promise-1.0.1.tgz#be143d89615b9110ac310345457f37e9791ddac9"
-  integrity sha512-EmPr3FqbQGqlNh+WxMNcF9pO9uDQJnOC4/3rLBQNH9m4E9qI+8lbfHCmHpVAsmGqPJPKhCjJLHUQzQW/RBHRdQ==
-
-awesome-only-resolves-last-promise@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/awesome-only-resolves-last-promise/-/awesome-only-resolves-last-promise-1.0.3.tgz#f2dac3ff7df238e48b818b423483031750f13ef0"
-  integrity sha512-7q4WPsYiD8Omvi/yHL314DkvsD/lM//Z2/KcU1vWk0xJotiV0GMJTgHTpWl3n90HJqpXKg7qX+VVNs5YbQyPRQ==
-  dependencies:
-    awesome-imperative-promise "^1.0.1"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3738,6 +3738,18 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+awesome-imperative-promise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/awesome-imperative-promise/-/awesome-imperative-promise-1.0.1.tgz#be143d89615b9110ac310345457f37e9791ddac9"
+  integrity sha512-EmPr3FqbQGqlNh+WxMNcF9pO9uDQJnOC4/3rLBQNH9m4E9qI+8lbfHCmHpVAsmGqPJPKhCjJLHUQzQW/RBHRdQ==
+
+awesome-only-resolves-last-promise@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/awesome-only-resolves-last-promise/-/awesome-only-resolves-last-promise-1.0.3.tgz#f2dac3ff7df238e48b818b423483031750f13ef0"
+  integrity sha512-7q4WPsYiD8Omvi/yHL314DkvsD/lM//Z2/KcU1vWk0xJotiV0GMJTgHTpWl3n90HJqpXKg7qX+VVNs5YbQyPRQ==
+  dependencies:
+    awesome-imperative-promise "^1.0.1"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
This PR tries to address the comment https://github.com/gnosis/gp-swap-ui/pull/721#pullrequestreview-672889816 (also asked in the original library https://github.com/slorber/awesome-imperative-promise/issues/1)

Main change, is that now the cancelable promises RESOLVES always. Now if promises are canceled, they are resolved with a flag `canceled = true`

This way, the new query quote logic can be:
![image](https://user-images.githubusercontent.com/2352112/120315683-e70e4d80-c2dc-11eb-9b0d-945496192ba8.png)


**NOTE:** By looking at the log, I see is super hard to create parallel promises that are canceled. I managed to create a few, but probably the debounce functionality is making this harder anyways.

**NOTE 2:** The TS part is improvable, probably there's way to infer better the types instead of needing to specify the return type of the promise. Also, we should fork the library if it can create memory leaks.